### PR TITLE
Fix for the type1 reader

### DIFF
--- a/PDFWriter/Type1Input.cpp
+++ b/PDFWriter/Type1Input.cpp
@@ -251,6 +251,11 @@ EStatusCode Type1Input::ReadFontInfoDictionary()
 	EStatusCode status = PDFHummus::eSuccess;
 	BoolAndString token;
 
+  // initialize some values to defaults
+  mFontInfoDictionary.ItalicAngle = 0.0;
+  mFontInfoDictionary.UnderlinePosition = 0.0;
+  mFontInfoDictionary.UnderlineThickness = 0.0;
+  
 	while(mPFBDecoder.NotEnded() && PDFHummus::eSuccess == status)
 	{
 		token = mPFBDecoder.GetNextToken();


### PR DESCRIPTION
I have some Type1 font which do not contain the UnderlineThickness key in the FontInfo dictionary. This results in uninitialized members in the mFontInfoDictionary structure. It is better to explicitly initialized double fields to default values.
