### PR TITLE
compatibility issues with libtiff 4.0.x

### DIFF
--- a/PDFWriter/TIFFImageHandler.cpp
+++ b/PDFWriter/TIFFImageHandler.cpp
@@ -2865,6 +2865,7 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 					break;
 				}
 				bufferoffset+=read;
+				stripsize = (stripsize > mT2p->tiff_datasize - bufferoffset) ? mT2p->tiff_datasize - bufferoffset : stripsize;
 			}
 			if(status != PDFHummus::eSuccess)
 				break;
@@ -2979,6 +2980,7 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 					break;
 				}
 				bufferoffset+=read;
+				stripsize = (stripsize > mT2p->tiff_datasize - bufferoffset) ? mT2p->tiff_datasize - bufferoffset : stripsize;
 			}
 			if(status != PDFHummus::eSuccess)
 				break;

--- a/PDFWriter/TIFFImageHandler.h
+++ b/PDFWriter/TIFFImageHandler.h
@@ -112,8 +112,29 @@ typedef std::pair<double,double> DoubleAndDoublePair;
 typedef	unsigned short uint16;	/* sizeof (uint16) must == 2 */
 typedef	unsigned int uint32;	/* sizeof (uint32) must == 4 */
 typedef	int int32;
+#ifdef _INCLUDE_TIFF_HEADER
+/*
+Since libtiff 4.0.0 tsize_t is changed from int32 to machine dependant.
+'tiffconf.h' which contains the declarations for it is generated for platform.
+Altough we might be able to guess tsize_t size depending on architecture,
+it's not guaranteed that it will match the actual tiff headers...
+*/
+
+#include <tiffio.h>
+
+#else
+/*
+	if you still don't want to include tiff headers, but it's not int32,
+	you can set the required definition with this macro.
+*/
+#ifndef _USE_TIFF_TSIZE_AS_FOLLOWS
 typedef int32 tsize_t;          /* i/o size in bytes */
+#else
+typedef _USE_TIFF_TSIZE_AS_FOLLOWS tsize_t;          /* i/o size in bytes */
+#endif // #ifndef _USE_TIFF_TSIZE_AS_FOLLOWS
 typedef void* tdata_t;          /* image data ref */
+
+#endif // #ifdef _INCLUDE_TIFF_HEADER
 
 typedef	tsize_t (*ImageSizeProc)(T2P* inT2p);
 


### PR DESCRIPTION
This code should allow both 3.9.5 and 4.0.x branch of tiff to be used.
Macro definitions to override default behavior on custom compile.

Tests TIFFImageTest fail with tiff 4.0.6, because of heap overflow when a tiff's strips have different sizes (ycbcr-cat.tif).
