### PR TITLE
Hummus dll

### DIFF
--- a/PDFWriter/DocumentContext.h
+++ b/PDFWriter/DocumentContext.h
@@ -199,15 +199,15 @@ namespace PDFHummus
 		// TIFF
 #ifndef PDFHUMMUS_NO_TIFF
 		PDFFormXObject* CreateFormXObjectFromTIFFFile(	const std::string& inTIFFFilePath,
-														const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+														const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 		PDFFormXObject* CreateFormXObjectFromTIFFStream(IByteReaderWithPosition* inTIFFStream,
-														const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+														const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 		PDFFormXObject* CreateFormXObjectFromTIFFFile(	const std::string& inTIFFFilePath,
 														ObjectIDType inFormXObjectID,
-														const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+														const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 		PDFFormXObject* CreateFormXObjectFromTIFFStream(	IByteReaderWithPosition* inTIFFStream,
 														ObjectIDType inFormXObjectID,
-														const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+														const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 #endif
 		// PDF
 		// CreateFormXObjectsFromPDF is for using input PDF pages as objects in one page or more. you can used the returned IDs to place the 
@@ -271,9 +271,9 @@ namespace PDFHummus
         PDFDocumentCopyingContext* CreatePDFCopyingContext(PDFParser* inPDFParser);
 
 		// some public image info services, for users of hummus
-		DoubleAndDoublePair GetImageDimensions(const std::string& inImageFile,unsigned long inImageIndex = 0, const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+		DoubleAndDoublePair GetImageDimensions(const std::string& inImageFile,unsigned long inImageIndex = 0, const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 		EHummusImageType GetImageType(const std::string& inImageFile,unsigned long inImageIndex);
-		unsigned long GetImagePagesCount(const std::string& inImageFile, const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+		unsigned long GetImagePagesCount(const std::string& inImageFile, const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 
 		// Font [Text] (font index is for multi-font files. for single file fonts, pass 0)
@@ -333,7 +333,7 @@ namespace PDFHummus
 			const std::string& inImagePath,
 			unsigned long inImageIndex,
 			ObjectIDType inObjectID,
-			const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions
+			const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions()
 		);
 		ObjectIDTypeAndBool RegisterImageForDrawing(const std::string& inImageFile,unsigned long inImageIndex);
 

--- a/PDFWriter/EncryptionOptions.cpp
+++ b/PDFWriter/EncryptionOptions.cpp
@@ -20,4 +20,8 @@ limitations under the License.
 */
 #include "EncryptionOptions.h"
 
-const EncryptionOptions EncryptionOptions::DefaultEncryptionOptions(false,"",0,"");
+const EncryptionOptions& EncryptionOptions::DefaultEncryptionOptions()
+{
+	static const EncryptionOptions default_encrypt_options(false, "", 0, "");
+	return default_encrypt_options;
+}

--- a/PDFWriter/EncryptionOptions.h
+++ b/PDFWriter/EncryptionOptions.h
@@ -50,5 +50,5 @@ struct EncryptionOptions
 		OwnerPassword = inOwnerPassword;
 	}
 
-	static const EncryptionOptions DefaultEncryptionOptions;
+	static const EncryptionOptions& DefaultEncryptionOptions();
 };

--- a/PDFWriter/PDFDocumentHandler.cpp
+++ b/PDFWriter/PDFDocumentHandler.cpp
@@ -437,7 +437,7 @@ EStatusCode PDFDocumentHandler::WritePageContentToSingleStream(IByteWriter* inTa
 	}
 	else
 	{
-		TRACE_LOG1("PDFDocumentHandler::WritePageContentToSingleStream, error copying page content, expected either array or stream, getting %s",PDFObject::scPDFObjectTypeLabel[pageContent->GetType()]);
+		TRACE_LOG1("PDFDocumentHandler::WritePageContentToSingleStream, error copying page content, expected either array or stream, getting %s",PDFObject::scPDFObjectTypeLabel(pageContent->GetType()));
 		status = PDFHummus::eFailure;
 	}
 	
@@ -860,7 +860,7 @@ EStatusCode PDFDocumentHandler::CopyPageContentToTargetPagePassthrough(PDFPage* 
 	}
 	else
 	{
-		TRACE_LOG1("PDFDocumentHandler::CopyPageContentToTargetPagePassthrough, error copying page content, expected either array or stream, getting %s", PDFObject::scPDFObjectTypeLabel[pageContent->GetType()]);
+		TRACE_LOG1("PDFDocumentHandler::CopyPageContentToTargetPagePassthrough, error copying page content, expected either array or stream, getting %s", PDFObject::scPDFObjectTypeLabel(pageContent->GetType()));
 		status = PDFHummus::eFailure;
 	}
 
@@ -907,7 +907,7 @@ EStatusCode PDFDocumentHandler::CopyPageContentToTargetPageRecoded(PDFPage* inPa
 	}
 	else
 	{
-		TRACE_LOG1("PDFDocumentHandler::CopyPageContentToTargetPageRecoded, error copying page content, expected either array or stream, getting %s",PDFObject::scPDFObjectTypeLabel[pageContent->GetType()]);
+		TRACE_LOG1("PDFDocumentHandler::CopyPageContentToTargetPageRecoded, error copying page content, expected either array or stream, getting %s",PDFObject::scPDFObjectTypeLabel(pageContent->GetType()));
 		status = PDFHummus::eFailure;
 	}
 	
@@ -1594,7 +1594,7 @@ EStatusCode PDFDocumentHandler::MergePageContentToTargetPage(PDFPage* inTargetPa
 	}
 	else
 	{
-		TRACE_LOG1("PDFDocumentHandler::MergePageContentToTargetPage, error copying page content, expected either array or stream, getting %s",PDFObject::scPDFObjectTypeLabel[pageContent->GetType()]);
+		TRACE_LOG1("PDFDocumentHandler::MergePageContentToTargetPage, error copying page content, expected either array or stream, getting %s",PDFObject::scPDFObjectTypeLabel(pageContent->GetType()));
 		status = PDFHummus::eFailure;
 	}
 
@@ -2384,7 +2384,7 @@ EStatusCode PDFDocumentHandler::MergePageContentToTargetXObject(PDFFormXObject* 
 	}
 	else
 	{
-		TRACE_LOG1("PDFDocumentHandler::MergePageContentToTargetXObject, error copying page content, expected either array or stream, getting %s",PDFObject::scPDFObjectTypeLabel[pageContent->GetType()]);
+		TRACE_LOG1("PDFDocumentHandler::MergePageContentToTargetXObject, error copying page content, expected either array or stream, getting %s",PDFObject::scPDFObjectTypeLabel(pageContent->GetType()));
 		status = PDFHummus::eFailure;
 	}
 

--- a/PDFWriter/PDFObject.cpp
+++ b/PDFWriter/PDFObject.cpp
@@ -20,20 +20,24 @@
 */
 #include "PDFObject.h"
 
-const char* PDFObject::scPDFObjectTypeLabel[] = 
+const char* PDFObject::scPDFObjectTypeLabel(int index) 
 {
-	"Boolean",
-	"LiteralString",
-	"HexString",
-	"Null",
-	"Name",
-	"Integer",
-	"Real",
-	"Array",
-	"Dictionary",
-	"IndirectObjectReference",
-	"Stream",
-	"Symbol"
+	static const char* labels[] =
+	{
+		"Boolean",
+		"LiteralString",
+		"HexString",
+		"Null",
+		"Name",
+		"Integer",
+		"Real",
+		"Array",
+		"Dictionary",
+		"IndirectObjectReference",
+		"Stream",
+		"Symbol"
+	};
+	return labels[index];
 };
 
 PDFObject::PDFObject(EPDFObjectType inType)

--- a/PDFWriter/PDFObject.h
+++ b/PDFWriter/PDFObject.h
@@ -53,7 +53,7 @@ public:
 
 	EPDFObjectType GetType();
     
-    static const char* scPDFObjectTypeLabel[];
+    static const char* scPDFObjectTypeLabel(int index);
 
 	/*
 		metadata will automatically be deleted when object is released

--- a/PDFWriter/PDFParser.cpp
+++ b/PDFWriter/PDFParser.cpp
@@ -890,7 +890,7 @@ EStatusCode PDFParser::ParsePagesIDs(PDFDictionary* inPageNode,ObjectIDType inNo
 			{
 				if(it.GetItem()->GetType() != PDFObject::ePDFObjectIndirectObjectReference)
 				{
-					TRACE_LOG1("PDFParser::ParsePagesIDs, unexpected type for a Kids array object, type = %s",PDFObject::scPDFObjectTypeLabel[it.GetItem()->GetType()]);
+					TRACE_LOG1("PDFParser::ParsePagesIDs, unexpected type for a Kids array object, type = %s",PDFObject::scPDFObjectTypeLabel(it.GetItem()->GetType()));
 					status = PDFHummus::eFailure;
 					break;
 				}

--- a/PDFWriter/PDFParser.h
+++ b/PDFWriter/PDFParser.h
@@ -81,7 +81,7 @@ public:
 	// sets the stream to parse, then parses for enough information to be able
 	// to parse objects later
 	PDFHummus::EStatusCode StartPDFParsing(IByteReaderWithPosition* inSourceStream, 
-											const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+											const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 	// get a parser that can parse objects
 	PDFObjectParser& GetObjectParser();

--- a/PDFWriter/PDFParsingOptions.cpp
+++ b/PDFWriter/PDFParsingOptions.cpp
@@ -20,4 +20,7 @@ limitations under the License.
 */
 #include "PDFParsingOptions.h"
 
-const PDFParsingOptions PDFParsingOptions::DefaultPDFParsingOptions("");
+const PDFParsingOptions& PDFParsingOptions::DefaultPDFParsingOptions(){
+	static PDFParsingOptions pdf_parsing_options("");
+	return pdf_parsing_options;
+}

--- a/PDFWriter/PDFParsingOptions.h
+++ b/PDFWriter/PDFParsingOptions.h
@@ -29,5 +29,5 @@ struct PDFParsingOptions
 	PDFParsingOptions() {}
 	PDFParsingOptions(std::string inPassword) { Password = inPassword; }
 
-	static const PDFParsingOptions DefaultPDFParsingOptions;
+	static const PDFParsingOptions& DefaultPDFParsingOptions();
 };

--- a/PDFWriter/PDFWriter.cpp
+++ b/PDFWriter/PDFWriter.cpp
@@ -38,7 +38,10 @@
 
 using namespace PDFHummus;
 
-const LogConfiguration LogConfiguration::DefaultLogConfiguration(false,false,"PDFWriterLog.txt");
+const LogConfiguration& LogConfiguration::DefaultLogConfiguration(){
+	static LogConfiguration default_log_configuration(false, false, "PDFWriterLog.txt");
+	return default_log_configuration;
+}
 
 PDFWriter::PDFWriter(void)
 {
@@ -159,9 +162,9 @@ EStatusCode PDFWriter::WritePageAndRelease(PDFPage* inPage)
 void PDFWriter::SetupLog(const LogConfiguration& inLogConfiguration)
 {
 	if(inLogConfiguration.LogStream)
-		Trace::DefaultTrace.SetLogSettings(inLogConfiguration.LogStream,inLogConfiguration.ShouldLog);
+		Trace::DefaultTrace().SetLogSettings(inLogConfiguration.LogStream,inLogConfiguration.ShouldLog);
 	else
-		Trace::DefaultTrace.SetLogSettings(inLogConfiguration.LogFileLocation,inLogConfiguration.ShouldLog,inLogConfiguration.StartWithBOM);
+		Trace::DefaultTrace().SetLogSettings(inLogConfiguration.LogFileLocation,inLogConfiguration.ShouldLog,inLogConfiguration.StartWithBOM);
 }
 
 void PDFWriter::SetupCreationSettings(const PDFCreationSettings& inPDFCreationSettings)

--- a/PDFWriter/PDFWriter.h
+++ b/PDFWriter/PDFWriter.h
@@ -51,7 +51,7 @@ struct LogConfiguration
 																							LogFileLocation=inLogFileLocation;LogStream = NULL;}
 	LogConfiguration(bool inShouldLog,IByteWriter* inLogStream){ShouldLog = inShouldLog;LogStream = inLogStream;StartWithBOM = false;}
 
-	static const LogConfiguration DefaultLogConfiguration;
+	static const LogConfiguration& DefaultLogConfiguration();
 };
 
 struct PDFCreationSettings
@@ -60,7 +60,7 @@ struct PDFCreationSettings
 	bool EmbedFonts;
 	EncryptionOptions DocumentEncryptionOptions;
 
-	PDFCreationSettings(bool inCompressStreams, bool inEmbedFonts,EncryptionOptions inDocumentEncryptionOptions = EncryptionOptions::DefaultEncryptionOptions):DocumentEncryptionOptions(inDocumentEncryptionOptions){ 
+	PDFCreationSettings(bool inCompressStreams, bool inEmbedFonts,EncryptionOptions inDocumentEncryptionOptions = EncryptionOptions::DefaultEncryptionOptions()):DocumentEncryptionOptions(inDocumentEncryptionOptions){ 
 		CompressStreams = inCompressStreams; 
 		EmbedFonts = inEmbedFonts;
 	}
@@ -83,7 +83,7 @@ public:
 	// output to file
 	PDFHummus::EStatusCode StartPDF(const std::string& inOutputFilePath,
 							EPDFVersion inPDFVersion,
-							const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration,
+							const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration(),
 							const PDFCreationSettings& inPDFCreationSettings = PDFCreationSettings(true,true));
 
 	PDFHummus::EStatusCode EndPDF();
@@ -91,7 +91,7 @@ public:
 	// output to stream
 	PDFHummus::EStatusCode StartPDFForStream(IByteWriterWithPosition* inOutputStream,
 								  EPDFVersion inPDFVersion,
-								  const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration,
+								  const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration(),
 								  const PDFCreationSettings& inPDFCreationSettings = PDFCreationSettings(true,true));
 	PDFHummus::EStatusCode EndPDFForStream();
 
@@ -103,14 +103,14 @@ public:
     PDFHummus::EStatusCode ModifyPDF(const std::string& inModifiedFile,
                                      EPDFVersion inPDFVersion,
                                      const std::string& inOptionalAlternativeOutputFile,
-                                     const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration,
+                                     const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration(),
                                      const PDFCreationSettings& inPDFCreationSettings = PDFCreationSettings(true,true));                                 
     PDFHummus::EStatusCode ModifyPDFForStream(
                                     IByteReaderWithPosition* inModifiedSourceStream,
                                     IByteWriterWithPosition* inModifiedDestinationStream,
                                     bool inAppendOnly,
                                     EPDFVersion inPDFVersion,
-                                    const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration,
+                                    const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration(),
                                     const PDFCreationSettings& inPDFCreationSettings = PDFCreationSettings(true,true)                                 
                                     );
     
@@ -119,12 +119,12 @@ public:
 	PDFHummus::EStatusCode ContinuePDF(const std::string& inOutputFilePath,
 							const std::string& inStateFilePath,
                             const std::string& inOptionalModifiedFile = "",
-							const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration);
+							const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration());
 	// Continue PDF in output stream workflow (optional input stream is for modification scenarios)
 	PDFHummus::EStatusCode ContinuePDFForStream(IByteWriterWithPosition* inOutputStream,
 									 const std::string& inStateFilePath,
                                      IByteReaderWithPosition* inModifiedSourceStream = NULL,
-				 					 const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration);
+				 					 const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration());
 
 	// Page context, for drwaing page content
 	PageContentContext* StartPageContentContext(PDFPage* inPage);
@@ -172,15 +172,15 @@ public:
 	// tiff
 #ifndef PDFHUMMUS_NO_TIFF
 	PDFFormXObject* CreateFormXObjectFromTIFFFile(	const std::string& inTIFFFilePath,
-													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 	PDFFormXObject* CreateFormXObjectFromTIFFStream(IByteReaderWithPosition* inTIFFStream,
-													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 	PDFFormXObject* CreateFormXObjectFromTIFFFile(	const std::string& inTIFFFilePath,
 													ObjectIDType inFormXObjectID,
-													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 	PDFFormXObject* CreateFormXObjectFromTIFFStream(	IByteReaderWithPosition* inTIFFStream,
 													ObjectIDType inFormXObjectID,
-													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 #endif
 	// PDF 
 
@@ -191,14 +191,14 @@ public:
 															 EPDFPageBox inPageBoxToUseAsFormBox,
 															 const double* inTransformationMatrix = NULL,
 															 const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
-															 const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+															 const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 	EStatusCodeAndObjectIDTypeList CreateFormXObjectsFromPDF(IByteReaderWithPosition* inPDFStream,
 															 const PDFPageRange& inPageRange,
 															 EPDFPageBox inPageBoxToUseAsFormBox,
 															 const double* inTransformationMatrix = NULL,
 															 const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
-															 const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+															 const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 	
 	// CreateFormXObjectsFromPDF is an override to allow you to determine a custom crop for the page embed
 	EStatusCodeAndObjectIDTypeList CreateFormXObjectsFromPDF(const std::string& inPDFFilePath,
@@ -206,25 +206,25 @@ public:
 															 const PDFRectangle& inCropBox,
 															 const double* inTransformationMatrix = NULL,
 															 const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
-															 const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+															 const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 	EStatusCodeAndObjectIDTypeList CreateFormXObjectsFromPDF(IByteReaderWithPosition* inPDFStream,
 															 const PDFPageRange& inPageRange,
 															 const PDFRectangle& inCropBox,
 															 const double* inTransformationMatrix = NULL,
 															 const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
-															 const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+															 const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 	// AppendPDFPagesFromPDF is for simple appending of the input PDF pages
 	EStatusCodeAndObjectIDTypeList AppendPDFPagesFromPDF(const std::string& inPDFFilePath,
 														const PDFPageRange& inPageRange,
 														const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
-														const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+														const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 	
 	EStatusCodeAndObjectIDTypeList AppendPDFPagesFromPDF(IByteReaderWithPosition* inPDFStream,
 														const PDFPageRange& inPageRange,
 														const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
-														const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+														const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 	// MergePDFPagesToPage, merge PDF pages content to an input page. good for single-placement of a page content, cheaper than creating
 	// and XObject and later placing, when the intention is to use this graphic just once.
@@ -232,30 +232,30 @@ public:
 									const std::string& inPDFFilePath,
 									const PDFPageRange& inPageRange,
 									const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
-									const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+									const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 	PDFHummus::EStatusCode MergePDFPagesToPage(PDFPage* inPage,
 									IByteReaderWithPosition* inPDFStream,
 									const PDFPageRange& inPageRange,
 									const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
-									const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+									const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 
 	// Copying context, allowing for a continous flow of copying from multiple sources PDFs (create one per source) to target PDF
 	PDFDocumentCopyingContext* CreatePDFCopyingContext(
 		const std::string& inPDFFilePath, 
-		const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+		const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 	PDFDocumentCopyingContext* CreatePDFCopyingContext(
 		IByteReaderWithPosition* inPDFStream, 
-		const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+		const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
     
     // for modified file path, create a copying context for the modified file
     PDFDocumentCopyingContext* CreatePDFCopyingContextForModifiedFile();
 
 	// some public image info services, for users of hummus
-	DoubleAndDoublePair GetImageDimensions(const std::string& inImageFile,unsigned long inImageIndex = 0, const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+	DoubleAndDoublePair GetImageDimensions(const std::string& inImageFile,unsigned long inImageIndex = 0, const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 	EHummusImageType GetImageType(const std::string& inImageFile,unsigned long inImageIndex);
-	unsigned long GetImagePagesCount(const std::string& inImageFile, const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions);
+	unsigned long GetImagePagesCount(const std::string& inImageFile, const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 
 	// fonts [text], font index is provided for multi-font file packages (such as dfont and ttc), 0 the default is

--- a/PDFWriter/ParsedPrimitiveHelper.cpp
+++ b/PDFWriter/ParsedPrimitiveHelper.cpp
@@ -112,7 +112,7 @@ std::string ParsedPrimitiveHelper::ToString()
             result = ((PDFBoolean*)mWrappedObject)->GetValue() ? "true":"false";
             break;
         default:
-            result = PDFObject::scPDFObjectTypeLabel[mWrappedObject->GetType()];
+            result = PDFObject::scPDFObjectTypeLabel(mWrappedObject->GetType());
     }
     return result;
 }

--- a/PDFWriter/TIFFImageHandler.cpp
+++ b/PDFWriter/TIFFImageHandler.cpp
@@ -363,7 +363,7 @@ void ReportWarning(const char* inModel, const char* inFormat, va_list inParamete
 
 	SAFE_VSPRINTF(buffer,5001,formatter.str().c_str(),inParametersList);
 
-    Trace::DefaultTrace.TraceToLog(buffer);
+    Trace::DefaultTrace().TraceToLog(buffer);
 }
 
 void ReportError(const char* inModel, const char* inFormat, va_list inParametersList)
@@ -374,10 +374,10 @@ void ReportError(const char* inModel, const char* inFormat, va_list inParameters
 
 	SAFE_VSPRINTF(buffer,5001,formatter.str().c_str(),inParametersList);
 
-	Trace::DefaultTrace.TraceToLog(buffer);
+	Trace::DefaultTrace().TraceToLog(buffer);
 }
 
-TIFFImageHandler::TIFFImageHandler():mUserParameters(TIFFUsageParameters::DefaultTIFFUsageParameters)
+TIFFImageHandler::TIFFImageHandler():mUserParameters(TIFFUsageParameters::DefaultTIFFUsageParameters())
 {
 	mT2p = NULL;
 	mExtender = NULL;

--- a/PDFWriter/TIFFImageHandler.cpp
+++ b/PDFWriter/TIFFImageHandler.cpp
@@ -2865,6 +2865,7 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 					break;
 				}
 				bufferoffset+=read;
+				stripsize = (stripsize > mT2p->tiff_datasize - bufferoffset) ? mT2p->tiff_datasize - bufferoffset : stripsize;
 			}
 			if(status != PDFHummus::eSuccess)
 				break;
@@ -2979,6 +2980,7 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 					break;
 				}
 				bufferoffset+=read;
+				stripsize = (stripsize > mT2p->tiff_datasize - bufferoffset) ? mT2p->tiff_datasize - bufferoffset : stripsize;
 			}
 			if(status != PDFHummus::eSuccess)
 				break;

--- a/PDFWriter/TIFFImageHandler.h
+++ b/PDFWriter/TIFFImageHandler.h
@@ -152,15 +152,15 @@ public:
 
 	// create a form XObject from an image (using form for 1. tiled images 2. to setup matrix, set color space...and leave you with just placing the image object
 	PDFFormXObject* CreateFormXObjectFromTIFFFile(	const std::string& inTIFFFilePath,
-													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 	PDFFormXObject* CreateFormXObjectFromTIFFStream(IByteReaderWithPosition* inTIFFStream,
-													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 	PDFFormXObject* CreateFormXObjectFromTIFFFile(	const std::string& inTIFFFilePath,
 													ObjectIDType inFormXObjectID,
-													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 	PDFFormXObject* CreateFormXObjectFromTIFFStream(IByteReaderWithPosition* inTIFFStream,
 													ObjectIDType inFormXObjectID,
-													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters);
+													const TIFFUsageParameters& inTIFFUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters());
 
 
 	void SetOperationsContexts(PDFHummus::DocumentContext* inContainerDocumentContext,ObjectsContext* inObjectsContext);

--- a/PDFWriter/TIFFImageHandler.h
+++ b/PDFWriter/TIFFImageHandler.h
@@ -112,8 +112,29 @@ typedef std::pair<double,double> DoubleAndDoublePair;
 typedef	unsigned short uint16;	/* sizeof (uint16) must == 2 */
 typedef	unsigned int uint32;	/* sizeof (uint32) must == 4 */
 typedef	int int32;
+#ifdef _INCLUDE_TIFF_HEADER
+/*
+Since libtiff 4.0.0 tsize_t is changed from int32 to machine dependant.
+'tiffconf.h' which contains the declarations for it is generated for platform.
+Altough we might be able to guess tsize_t size depending on architecture,
+it's not guaranteed that it will match the actual tiff headers...
+*/
+
+#include <tiffio.h>
+
+#else
+/*
+	if you still don't want to include tiff headers, but it's not int32,
+	you can set the required definition with this macro.
+*/
+#ifndef _USE_TIFF_TSIZE_AS_FOLLOWS
 typedef int32 tsize_t;          /* i/o size in bytes */
+#else
+typedef _USE_TIFF_TSIZE_AS_FOLLOWS tsize_t;          /* i/o size in bytes */
+#endif // #ifndef _USE_TIFF_TSIZE_AS_FOLLOWS
 typedef void* tdata_t;          /* image data ref */
+
+#endif // #ifdef _INCLUDE_TIFF_HEADER
 
 typedef	tsize_t (*ImageSizeProc)(T2P* inT2p);
 

--- a/PDFWriter/TiffUsageParameters.cpp
+++ b/PDFWriter/TiffUsageParameters.cpp
@@ -20,10 +20,23 @@
 */
 #include "TiffUsageParameters.h"
 
-const TIFFBiLevelBWColorTreatment TIFFBiLevelBWColorTreatment::DefaultTIFFBiLevelBWColorTreatment(false,CMYKRGBColor::CMYKBlack);
+const TIFFBiLevelBWColorTreatment& TIFFBiLevelBWColorTreatment::DefaultTIFFBiLevelBWColorTreatment()
+{
+	static TIFFBiLevelBWColorTreatment default_tiff_bilevel_bwcolor_treatment(false, CMYKRGBColor::CMYKBlack);
+	return default_tiff_bilevel_bwcolor_treatment;
+}
 
-const TIFFBiLevelGrayscaleColorTreatment TIFFBiLevelGrayscaleColorTreatment::DefaultTIFFBiLevelGrayscaleColorTreatment(false,CMYKRGBColor::CMYKBlack,CMYKRGBColor::CMYKWhite);
+const TIFFBiLevelGrayscaleColorTreatment& TIFFBiLevelGrayscaleColorTreatment::DefaultTIFFBiLevelGrayscaleColorTreatment()
+{
+	static TIFFBiLevelGrayscaleColorTreatment default_tiff_bilevel_grayscale_treatment(false, CMYKRGBColor::CMYKBlack, CMYKRGBColor::CMYKWhite);
+	return default_tiff_bilevel_grayscale_treatment;
 
-const TIFFUsageParameters TIFFUsageParameters::DefaultTIFFUsageParameters(	0,
-																			TIFFBiLevelBWColorTreatment::DefaultTIFFBiLevelBWColorTreatment,				
-																			TIFFBiLevelGrayscaleColorTreatment::DefaultTIFFBiLevelGrayscaleColorTreatment);
+}
+
+const TIFFUsageParameters& TIFFUsageParameters::DefaultTIFFUsageParameters()
+{
+	static TIFFUsageParameters default_tiff_usage_parameters(0,
+		TIFFBiLevelBWColorTreatment::DefaultTIFFBiLevelBWColorTreatment(),
+		TIFFBiLevelGrayscaleColorTreatment::DefaultTIFFBiLevelGrayscaleColorTreatment());
+	return default_tiff_usage_parameters;
+}

--- a/PDFWriter/TiffUsageParameters.h
+++ b/PDFWriter/TiffUsageParameters.h
@@ -42,7 +42,7 @@ struct TIFFBiLevelBWColorTreatment
 																					OneColor=inOneColor;}
 
 	// default treatment is AsImageMask = false
-	static const TIFFBiLevelBWColorTreatment DefaultTIFFBiLevelBWColorTreatment;
+	static const TIFFBiLevelBWColorTreatment& DefaultTIFFBiLevelBWColorTreatment();
 };
 
 struct TIFFBiLevelGrayscaleColorTreatment
@@ -64,7 +64,7 @@ struct TIFFBiLevelGrayscaleColorTreatment
 																					ZeroColor=inZeroColor;}
 
 	// default treatment is AsColorMap = false
-	static const TIFFBiLevelGrayscaleColorTreatment DefaultTIFFBiLevelGrayscaleColorTreatment;
+	static const TIFFBiLevelGrayscaleColorTreatment& DefaultTIFFBiLevelGrayscaleColorTreatment();
 };
 
 
@@ -80,7 +80,7 @@ struct TIFFUsageParameters
 	// Grayscale options
 	TIFFBiLevelGrayscaleColorTreatment GrayscaleTreatment;
 
-	TIFFUsageParameters():BWTreatment(TIFFBiLevelBWColorTreatment::DefaultTIFFBiLevelBWColorTreatment),GrayscaleTreatment(TIFFBiLevelGrayscaleColorTreatment::DefaultTIFFBiLevelGrayscaleColorTreatment)
+	TIFFUsageParameters():BWTreatment(TIFFBiLevelBWColorTreatment::DefaultTIFFBiLevelBWColorTreatment()),GrayscaleTreatment(TIFFBiLevelGrayscaleColorTreatment::DefaultTIFFBiLevelGrayscaleColorTreatment())
 						{PageIndex = 0;}
 
 	TIFFUsageParameters(unsigned int inPageIndex,
@@ -89,6 +89,6 @@ struct TIFFUsageParameters
 						{PageIndex = inPageIndex;}
 
 	// default treatment is 0 page index, and defaults for black & white and Grayscale
-	static const TIFFUsageParameters DefaultTIFFUsageParameters;
+	static const TIFFUsageParameters& DefaultTIFFUsageParameters();
 
 };

--- a/PDFWriter/Trace.cpp
+++ b/PDFWriter/Trace.cpp
@@ -25,7 +25,10 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-Trace Trace::DefaultTrace;
+Trace& Trace::DefaultTrace(){
+	static Trace default_trace;
+	return default_trace;
+}
 
 Trace::Trace(void)
 {

--- a/PDFWriter/Trace.h
+++ b/PDFWriter/Trace.h
@@ -45,7 +45,7 @@ public:
 	void TraceToLog(const char* inFormat,...);
 	void TraceToLog(const char* inFormat,va_list inList);
 
-    static Trace DefaultTrace;
+    static Trace& DefaultTrace();
 
 private:
 	char mBuffer[5001];
@@ -62,12 +62,12 @@ private:
 
 
 // short cuts for logging formats strings
-#define TRACE_LOG(FORMAT) Trace::DefaultTrace.TraceToLog(FORMAT)
-#define TRACE_LOG1(FORMAT,ARG1) Trace::DefaultTrace.TraceToLog(FORMAT,ARG1)
-#define TRACE_LOG2(FORMAT,ARG1,ARG2) Trace::DefaultTrace.TraceToLog(FORMAT,ARG1,ARG2)
-#define TRACE_LOG3(FORMAT,ARG1,ARG2,ARG3) Trace::DefaultTrace.TraceToLog(FORMAT,ARG1,ARG2,ARG3)
-#define TRACE_LOG4(FORMAT,ARG1,ARG2,ARG3,ARG4) Trace::DefaultTrace.TraceToLog(FORMAT,ARG1,ARG2,ARG3,ARG4)
-#define TRACE_LOG5(FORMAT,ARG1,ARG2,ARG3,ARG4,ARG5) Trace::DefaultTrace.TraceToLog(FORMAT,ARG1,ARG2,ARG3,ARG4,ARG5)
+#define TRACE_LOG(FORMAT) Trace::DefaultTrace().TraceToLog(FORMAT)
+#define TRACE_LOG1(FORMAT,ARG1) Trace::DefaultTrace().TraceToLog(FORMAT,ARG1)
+#define TRACE_LOG2(FORMAT,ARG1,ARG2) Trace::DefaultTrace().TraceToLog(FORMAT,ARG1,ARG2)
+#define TRACE_LOG3(FORMAT,ARG1,ARG2,ARG3) Trace::DefaultTrace().TraceToLog(FORMAT,ARG1,ARG2,ARG3)
+#define TRACE_LOG4(FORMAT,ARG1,ARG2,ARG3,ARG4) Trace::DefaultTrace().TraceToLog(FORMAT,ARG1,ARG2,ARG3,ARG4)
+#define TRACE_LOG5(FORMAT,ARG1,ARG2,ARG3,ARG4,ARG5) Trace::DefaultTrace().TraceToLog(FORMAT,ARG1,ARG2,ARG3,ARG4,ARG5)
 
 
 

--- a/PDFWriterTestPlayground/PDFParserTest.cpp
+++ b/PDFWriterTestPlayground/PDFParserTest.cpp
@@ -146,7 +146,7 @@ EStatusCode PDFParserTest::IterateObjectTypes(PDFObject* inObject,PDFParser& inP
 	}
 	else if(inObject->GetType() == PDFObject::ePDFObjectArray)
 	{
-		primitivesWriter.WriteKeyword(PDFObject::scPDFObjectTypeLabel[inObject->GetType()]);
+		primitivesWriter.WriteKeyword(PDFObject::scPDFObjectTypeLabel(inObject->GetType()));
 		++mTabLevel;
 		PDFObjectCastPtr<PDFArray> anArray;
 		anArray = inObject;  // do assignment here, otherwise it's considered constructor...which won't addref
@@ -159,7 +159,7 @@ EStatusCode PDFParserTest::IterateObjectTypes(PDFObject* inObject,PDFParser& inP
 	}
 	else if(inObject->GetType() == PDFObject::ePDFObjectDictionary)
 	{
-		primitivesWriter.WriteKeyword(PDFObject::scPDFObjectTypeLabel[inObject->GetType()]);
+		primitivesWriter.WriteKeyword(PDFObject::scPDFObjectTypeLabel(inObject->GetType()));
 		++mTabLevel;
 		PDFObjectCastPtr<PDFDictionary> aDictionary;
 		aDictionary = inObject; // do assignment here, otherwise it's considered constructor...which won't addref
@@ -184,7 +184,7 @@ EStatusCode PDFParserTest::IterateObjectTypes(PDFObject* inObject,PDFParser& inP
 	}
 	else 
 	{
-		primitivesWriter.WriteKeyword(PDFObject::scPDFObjectTypeLabel[inObject->GetType()]);
+		primitivesWriter.WriteKeyword(PDFObject::scPDFObjectTypeLabel(inObject->GetType()));
 		return PDFHummus::eSuccess;
 	}
 	

--- a/PDFWriterTestPlayground/RecryptPDF.cpp
+++ b/PDFWriterTestPlayground/RecryptPDF.cpp
@@ -45,7 +45,7 @@ EStatusCode RecryptPDF::Run(const TestConfiguration& inTestConfiguration)
 			RelativeURLToLocalPath(inTestConfiguration.mSampleFileBase, "TestMaterials/PDFWithPassword.PDF"),
 			"user",
 			RelativeURLToLocalPath(inTestConfiguration.mSampleFileBase, "RecryptPDFWithPasswordToNothing.PDF"),
-			LogConfiguration::DefaultLogConfiguration,
+			LogConfiguration::DefaultLogConfiguration(),
 			PDFCreationSettings(true,true));
 		if (status != PDFHummus::eSuccess)
 		{
@@ -58,7 +58,7 @@ EStatusCode RecryptPDF::Run(const TestConfiguration& inTestConfiguration)
 			RelativeURLToLocalPath(inTestConfiguration.mSampleFileBase, "TestMaterials/PDFWithPassword.PDF"),
 			"user",
 			RelativeURLToLocalPath(inTestConfiguration.mSampleFileBase, "RecryptPDFWithPasswordToNewPassword.PDF"),
-			LogConfiguration::DefaultLogConfiguration,
+			LogConfiguration::DefaultLogConfiguration(),
 			PDFCreationSettings(true,true,EncryptionOptions("user1",4,"owner1")));
 		if (status != PDFHummus::eSuccess)
 		{
@@ -71,7 +71,7 @@ EStatusCode RecryptPDF::Run(const TestConfiguration& inTestConfiguration)
 			RelativeURLToLocalPath(inTestConfiguration.mSampleFileBase, "TestMaterials/Original.PDF"),
 			"",
 			RelativeURLToLocalPath(inTestConfiguration.mSampleFileBase, "RecryptPDFOriginalToPasswordProtected.PDF"),
-			LogConfiguration::DefaultLogConfiguration,
+			LogConfiguration::DefaultLogConfiguration(),
 			PDFCreationSettings(true, true, EncryptionOptions("user1", 4, "owner1")));
 		if (status != PDFHummus::eSuccess)
 		{


### PR DESCRIPTION
Dll's don't export the static member properties, and there will be undefined symbols at linking time.

Static member properties are converted to functions.