### PR TITLE
Automated tests

### DIFF
--- a/PDFWriter/CMYKRGBColor.cpp
+++ b/PDFWriter/CMYKRGBColor.cpp
@@ -51,5 +51,11 @@ CMYKRGBColor::CMYKRGBColor(unsigned char inC,unsigned char inM, unsigned char in
 	RGBComponents[0] = RGBComponents[1] = RGBComponents[2] = 0;
 }
 
-const CMYKRGBColor CMYKRGBColor::CMYKBlack(0,0,0,255);
-const CMYKRGBColor CMYKRGBColor::CMYKWhite(0,0,0,0);
+const CMYKRGBColor& CMYKRGBColor::CMYKBlack(){
+	static CMYKRGBColor oCMYKBlack(0, 0, 0, 255);
+	return oCMYKBlack;
+};
+const CMYKRGBColor& CMYKRGBColor::CMYKWhite(){
+	static CMYKRGBColor oCMYKWhite(0, 0, 0, 0);
+	return oCMYKWhite;
+};

--- a/PDFWriter/CMYKRGBColor.h
+++ b/PDFWriter/CMYKRGBColor.h
@@ -34,7 +34,7 @@ public:
 	unsigned char RGBComponents[3];
 	unsigned char CMYKComponents[4];
 
-	static const CMYKRGBColor CMYKBlack;
-	static const CMYKRGBColor CMYKWhite;
+	static const CMYKRGBColor& CMYKBlack();
+	static const CMYKRGBColor& CMYKWhite();
 };
 

--- a/PDFWriter/InfoDictionary.cpp
+++ b/PDFWriter/InfoDictionary.cpp
@@ -49,12 +49,12 @@ void InfoDictionary::Reset()
 {
 	mAdditionalInfoEntries.clear();
 	Trapped = EInfoTrappedUnknown;
-	Title = PDFTextString::Empty;
-	Author = PDFTextString::Empty;
-	Subject = PDFTextString::Empty;
-	Keywords = PDFTextString::Empty;
-	Creator = PDFTextString::Empty;
-	Producer = PDFTextString::Empty;
+	Title = PDFTextString::Empty();
+	Author = PDFTextString::Empty();
+	Subject = PDFTextString::Empty();
+	Keywords = PDFTextString::Empty();
+	Creator = PDFTextString::Empty();
+	Producer = PDFTextString::Empty();
 	CreationDate.SetTime(-1);
 	ModDate.SetTime(-1);
 }
@@ -85,7 +85,7 @@ PDFTextString InfoDictionary::GetAdditionalInfoEntry(const std::string& inKey)
 	StringToPDFTextString::iterator it = mAdditionalInfoEntries.find(inKey);
 
 	if(it == mAdditionalInfoEntries.end())
-		return PDFTextString::Empty;
+		return PDFTextString::Empty();
 	else
 		return it->second;
 }

--- a/PDFWriter/PDFDate.cpp
+++ b/PDFWriter/PDFDate.cpp
@@ -199,6 +199,9 @@ void PDFDate::SetToCurrentTime()
 	int status;
 #if defined(WIN32) && !defined(__MINGW32__) // (using MS methods)
 	status = _get_timezone(&timeZoneSecondsDifference);
+	long dstbias;
+	_get_dstbias(&dstbias);
+	timeZoneSecondsDifference += dstbias; // also dst shall be added to pure zone difference.
 #elif defined (__GNUC__)
 	struct tm *gmTime;
 
@@ -209,7 +212,7 @@ void PDFDate::SetToCurrentTime()
 
 	/* Using local time epoch get the GM Time */
 	gmTime = gmtime(&localEpoch);
-
+	gmTime->tm_isdst = -1;
 	/* Convert gm time in to epoch format */
 	gmEpoch = mktime(gmTime);
 
@@ -236,7 +239,7 @@ void PDFDate::SetToCurrentTime()
 		}
 		else
 		{
-			UTC = timeZoneSecondsDifference > 0 ? eLater:eEarlier;
+			UTC = timeZoneSecondsDifference > 0 ? eEarlier : eLater;
 			HourFromUTC = (int)(labs(timeZoneSecondsDifference) / 3600);
 			MinuteFromUTC = (int)((labs(timeZoneSecondsDifference) - (labs(timeZoneSecondsDifference) / 3600)*3600) / 60);
 		}

--- a/PDFWriter/PDFObjectParser.cpp
+++ b/PDFWriter/PDFObjectParser.cpp
@@ -292,13 +292,19 @@ PDFObject* PDFObjectParser::ParseLiteralString(const std::string& inToken)
 			++i;
 			if('0' <= *it && *it <= '7')
 			{
-				buffer = (*it - '0') * 64;
-				++it;
-				++i;
-				buffer += (*it - '0') * 8;
-				++it;
-				++i;
-				buffer += (*it - '0');
+				buffer = (*it - '0');
+				if (i+1 < inToken.size() && '0' <= *(it+1) && *(it+1) <= '7'){
+					++it;
+					++i;
+					buffer = buffer << 3;
+					buffer += (*it - '0');
+					if (i + 1 < inToken.size() && '0' <= *(it + 1) && *(it + 1) <= '7'){
+						++it;
+						++i;
+						buffer = buffer << 3;
+						buffer += (*it - '0');
+					}
+				}
 			}
 			else
 			{
@@ -392,21 +398,33 @@ PDFObject* PDFObjectParser::ParseHexadecimalString(const std::string& inToken)
 std::string PDFObjectParser::DecodeHexString(const std::string inStringToDecode) {
 	std::stringbuf stringBuffer;
 	std::string content = inStringToDecode;
-	Byte buffer;
 
-	// pad with ending 0
-	if (content.length() % 2 != 0)
-		content.push_back('0');
 
 	std::string::const_iterator it = content.begin();
-
+	BoolAndByte buffer(false, 0); // bool part = 'is first char in buffer?', Byte part = 'the first hex-decoded char'
 	for (; it != content.end(); ++it)
 	{
-		buffer = GetHexValue(*it).second * 16;
-		++it;
-		buffer += GetHexValue(*it).second;
-		stringBuffer.sputn((const char*)&buffer, 1);
+		BoolAndByte parse = GetHexValue(*it);
+		if (parse.first){
+			if (buffer.first){
+				Byte hexbyte = (buffer.second << 4) | parse.second;
+				buffer.first = false;
+				stringBuffer.sputn((const char*)&hexbyte, 1);
+			}
+			else{
+				buffer.first = true;
+				buffer.second = parse.second;
+			}
+		}
 	}
+
+	// pad with ending 0
+	if (buffer.first){
+		Byte hexbyte = buffer.second << 4;
+		stringBuffer.sputn((const char*)&hexbyte, 1);
+	}
+
+	// decode utf16 here?
 
 	return stringBuffer.str();
 
@@ -663,8 +681,10 @@ BoolAndByte PDFObjectParser::GetHexValue(Byte inValue)
 		return BoolAndByte(true,inValue - 'a' + 10);
 	else
 	{
-		TRACE_LOG1("PDFObjectParser::GetHexValue, unrecongnized hex value - %c",inValue);
-		return BoolAndByte(false,inValue);
+		if (!isspace(inValue)){
+			TRACE_LOG1("PDFObjectParser::GetHexValue, unrecongnized hex value - %c", inValue);
+		}
+		return BoolAndByte(false, inValue);
 	}
 }
 

--- a/PDFWriter/PDFTextString.cpp
+++ b/PDFWriter/PDFTextString.cpp
@@ -39,7 +39,10 @@ PDFTextString::~PDFTextString(void)
 {
 }
 
-const PDFTextString PDFTextString::Empty;
+const PDFTextString& PDFTextString::Empty(){
+	static PDFTextString pdf_text_string_empty;
+	return pdf_text_string_empty;
+};
 
 PDFTextString& PDFTextString::FromUTF8(const std::string& inString)
 {

--- a/PDFWriter/PDFTextString.h
+++ b/PDFWriter/PDFTextString.h
@@ -57,7 +57,7 @@ public:
 	// set from encoded string
 	PDFTextString& operator=(const std::string& inString);
 
-	static const PDFTextString Empty;
+	static const PDFTextString& Empty();
 
 private:
 

--- a/PDFWriterTestPlayground/CMakeLists.txt
+++ b/PDFWriterTestPlayground/CMakeLists.txt
@@ -44,6 +44,7 @@ PDFCopyingContextTest.cpp
 PDFDateTest.cpp
 PDFEmbedTest.cpp
 PDFObjectCastTest.cpp
+PDFObjectParserTest.cpp
 PDFParserTest.cpp
 PDFTextStringTest.cpp
 PFBStreamTest.cpp
@@ -110,6 +111,7 @@ PDFCopyingContextTest.h
 PDFDateTest.h
 PDFEmbedTest.h
 PDFObjectCastTest.h
+PDFObjectParserTest.h
 PDFParserTest.h
 PDFTextStringTest.h
 PFBStreamTest.h
@@ -136,6 +138,10 @@ UnicodeTextUsage.h
 
 source_group(Main FILES
 PDFWriterTestPlayground.cpp
+)
+
+source_group("Tests\\Parse" FILES
+PDFObjectParserTest.cpp
 )
 
 source_group("TestingSystem\\Hummus Paths" FILES

--- a/PDFWriterTestPlayground/PDFObjectParserTest.cpp
+++ b/PDFWriterTestPlayground/PDFObjectParserTest.cpp
@@ -1,0 +1,381 @@
+/*
+Source File : PDFObjectParserTest.cpp
+
+
+Copyright 2011 Gal Kahana PDFWriter
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+*/
+#include "PDFObjectParserTest.h"
+#include "PDFParser.h"
+#include "PDFObjectParser.h"
+#include "OutputFile.h"
+#include "IByteWriterWithPosition.h"
+#include "PDFObjectCast.h"
+#include "PDFObject.h"
+#include "PDFLiteralString.h"
+#include "PDFHexString.h"
+#include "ParsedPrimitiveHelper.h"
+#include "PDFTextString.h"
+
+#include <iostream>
+#include <sstream>
+
+using namespace std;
+using namespace PDFHummus;
+
+
+class InputInterfaceToStream : public IByteReader, public IReadPositionProvider{
+private:
+	string mInput;
+	string::size_type mLen, mPos;
+public:
+	virtual IOBasicTypes::LongBufferSizeType Read(IOBasicTypes::Byte* inBuffer, IOBasicTypes::LongBufferSizeType inBufferSize){
+		const char* data = mInput.data();
+		if (!NotEnded())  return 0;
+		size_t size = mLen - mPos;
+		if (size > inBufferSize) size = inBufferSize;
+		memcpy(inBuffer, &data[mPos], size);
+		mPos += size;
+		return size;
+	}
+
+	virtual bool NotEnded() { return mPos < mLen; };
+
+	virtual IOBasicTypes::LongFilePositionType GetCurrentPosition(){
+		return static_cast<IOBasicTypes::LongFilePositionType>(mPos);
+	};
+	
+	void setInput(const string& input){
+		mInput = input;
+		mLen = input.size();
+		mPos = 0;
+	}
+	
+	const string& getInput() const{
+		return mInput;
+	}
+
+	InputInterfaceToStream()
+		: mInput("")
+		, mLen(0)
+		, mPos(0)
+	{}
+
+	virtual ~InputInterfaceToStream(){}
+
+};
+
+class PDFObjectParserTestLogHelper{
+private:
+	OutputFile mOutput;
+public:
+	PDFObjectParserTestLogHelper(){}
+
+	~PDFObjectParserTestLogHelper(){}
+
+	EStatusCode openLog(const string& path){
+		return mOutput.OpenFile(path);
+
+	}
+
+	template <class T>
+	PDFObjectParserTestLogHelper& operator<<(T out){
+		ostringstream ss;
+		ss << out;
+		mOutput.GetOutputStream()->Write((const unsigned char*)ss.str().c_str(), ss.str().size());
+		return *this;
+	}
+
+
+};
+
+template<class _resultObjectType>
+class ExpectedResult{
+private:
+	RefCountPtr<PDFObject> mObject;
+	PDFObjectCastPtr<_resultObjectType> mTypedObject;
+public:
+	ExpectedResult(PDFObject* object)
+	: mObject(object) // ParseNewObject constructs with refcount 1
+	{
+		mTypedObject = object; // addrefs if valid object
+	}
+	~ExpectedResult(){}
+
+	int setResult(const string& input, const string& expected, PDFObjectParserTestLogHelper& log){
+		if (!mObject){
+			log << "Failed parse: no object parsed from input: '"<< input << "'";
+			return 1;
+		}
+		if (!!mObject && !mTypedObject){
+			int object_type = mObject->GetType();
+			string result_type = "invalid";
+			if (object_type >= 0 && object_type <= PDFObject::ePDFObjectSymbol){
+				result_type = PDFObject::scPDFObjectTypeLabel(mObject->GetType());
+			}
+
+			log << "Failed parse. Expected '" << PDFObject::scPDFObjectTypeLabel(_resultObjectType::eType) << "' got '"
+				<< result_type << "' from input: '" << input << "'\n";
+			return 1;
+		}
+		string result = PDFTextString(ParsedPrimitiveHelper(mTypedObject.GetPtr()).ToString()).ToUTF8String();
+		if (result != expected){
+			log << "Failed parse. Expected '" << expected << "' got '"
+				<< result << "' from input: '" << input << "'\n";
+			return 1;
+		}
+		log << "Parse passed: '" << input << "'\n";
+		return 0;
+	}
+
+};
+
+
+
+PDFObjectParserTest::PDFObjectParserTest()
+{
+
+}
+
+
+PDFObjectParserTest::~PDFObjectParserTest()
+{
+}
+
+
+
+EStatusCode PDFObjectParserTest::Run(const TestConfiguration& inTestConfiguration)
+{
+	int failures = 0;
+	PDFObjectParserTestLogHelper log;
+	if (log.openLog(RelativeURLToLocalPath(inTestConfiguration.mSampleFileBase, "PDFObjectParserTest.txt")) != eSuccess){
+		cout << "failed to initialize log output\n";
+		return eFailure;
+	}
+
+
+	PDFParser parser;
+	PDFObjectParser*  pObjectParser = &parser.GetObjectParser();
+
+	if (ParseCommentedTokens(pObjectParser,&log) == eFailure){
+		++failures;
+	}
+
+	if (ParseHexStringTokens(pObjectParser,&log) == eFailure){
+		++failures;
+	}
+
+	if (ParseLiteralStringTokens(pObjectParser,&log) == eFailure){
+		++failures;
+	}
+
+
+
+	if (failures > 0){
+		cout << "Failed tests in PDFObjectParserTest: " << failures << endl;
+		return eFailure;
+	}
+	return eSuccess;
+}
+
+
+EStatusCode PDFObjectParserTest::ParseCommentedTokens(PDFObjectParser* objectParser, PDFObjectParserTestLogHelper* log){
+	int failures = 0;
+	InputInterfaceToStream input;
+	RefCountPtr<PDFObject> object;
+
+
+	{
+		input.setInput("(val%ami)");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFLiteralString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "val%ami", *log);
+	};
+
+	/*
+	// I don't know what this should return. Currently it returns 'x41 x54 x20' which is wrong (parse error?)
+	{
+		input.setInput("<41%\n42>");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFHexString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "AB", *log);
+	};*/
+
+
+
+
+	if (failures > 0){
+			cout << "Failed tests in PDFObjectParserTest::ParseCommentedTokens: " << failures << endl;
+			return eFailure;
+		}
+	return eSuccess;
+}
+EStatusCode PDFObjectParserTest::ParseHexStringTokens(PDFObjectParser* objectParser, PDFObjectParserTestLogHelper* log){
+	int failures = 0;
+	InputInterfaceToStream input;
+	RefCountPtr<PDFObject> object;
+
+	{
+		input.setInput("<>");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFHexString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "", *log);
+	};
+
+	{
+		input.setInput("<   >");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFHexString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "", *log);
+	};
+
+	{
+		input.setInput("<\n>");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFHexString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "", *log);
+	};
+
+
+	{
+		input.setInput("< 41   4 2 >");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFHexString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "AB", *log);
+	};
+
+	{
+		input.setInput("<04000201>");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFHexString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), string("\x04\x00\x02\x01",4), *log);
+	};
+
+	{
+		input.setInput("<feff00410042>");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFHexString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "\x41\x42", *log);
+	};
+
+	{
+		input.setInput("<f e f f 0 04 10042>");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFHexString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "\x41\x42", *log);
+	};
+
+	{
+		input.setInput("<5>");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFHexString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "\x50", *log);
+	};
+
+	if (failures > 0){
+		cout << "Failed tests in PDFObjectParserTest::ParseHexStringTokens: " << failures << endl;
+		return eFailure;
+	}
+	return eSuccess;
+}
+EStatusCode PDFObjectParserTest::ParseLiteralStringTokens(PDFObjectParser* objectParser, PDFObjectParserTestLogHelper* log){
+	int failures = 0;
+	InputInterfaceToStream input;
+	RefCountPtr<PDFObject> object;
+
+	{
+		input.setInput("()");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFLiteralString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "", *log);
+	};
+
+	{
+		input.setInput("( )");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFLiteralString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), " ", *log);
+	};
+
+	{
+		input.setInput("( \n )");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFLiteralString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), " \n ", *log);
+	};
+	{
+		input.setInput("( \\\n )");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFLiteralString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "  ", *log);
+	};
+
+	{
+		input.setInput("( ( ) )");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFLiteralString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), " ( ) ", *log);
+	};
+
+	{
+		input.setInput("( \\( \\) )");
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFLiteralString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), " ( ) ", *log);
+	};
+
+	{
+		input.setInput("(\\101\\102)"); // in hex: 41 42
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFLiteralString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "AB", *log);
+	};
+
+	{
+		input.setInput(string("(\\376\\377\\0\\101)",16)); // in hex this is: fe ff 00 41
+		objectParser->SetReadStream(&input, &input);
+		ExpectedResult<PDFLiteralString> result(objectParser->ParseNewObject());
+
+		failures += result.setResult(input.getInput(), "A", *log);
+	};
+
+
+	if (failures > 0){
+		cout << "Failed tests in PDFObjectParserTest::ParseLiteralStringTokens: " << failures << endl;
+		return eFailure;
+	}
+	return eSuccess;
+}
+
+ADD_CATEGORIZED_TEST(PDFObjectParserTest, "Parsing")
+

--- a/PDFWriterTestPlayground/PDFObjectParserTest.h
+++ b/PDFWriterTestPlayground/PDFObjectParserTest.h
@@ -1,0 +1,45 @@
+/*
+Source File : PDFObjectParserTest.h
+
+
+Copyright 2011 Gal Kahana PDFWriter
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+*/
+#pragma once
+#include "TestsRunner.h"
+
+class PDFObjectParser;
+
+class PDFObjectParserTestLogHelper;
+
+
+class PDFObjectParserTest : public ITestUnit
+{
+public:
+	PDFObjectParserTest();
+	virtual ~PDFObjectParserTest();
+	virtual PDFHummus::EStatusCode Run(const TestConfiguration& inTestConfiguration);
+
+
+private:
+	PDFHummus::EStatusCode ParseCommentedTokens(PDFObjectParser* objectParser, PDFObjectParserTestLogHelper* log);
+	PDFHummus::EStatusCode ParseHexStringTokens(PDFObjectParser* objectParser, PDFObjectParserTestLogHelper* log);
+	PDFHummus::EStatusCode ParseLiteralStringTokens(PDFObjectParser* objectParser, PDFObjectParserTestLogHelper* log);
+	
+	
+	
+};
+


### PR DESCRIPTION
PDFDate and PDFObjectParser fixes.
For PDFDate: I can't test mac. In vs2013 the gcc code works, no need to ifdef for msvc. Maybe also works for mac.