### PR TITLE
End of stream isn't taken as a token while sometimes it should be

### DIFF
--- a/PDFWriter/PDFParserTokenizer.cpp
+++ b/PDFWriter/PDFParserTokenizer.cpp
@@ -264,7 +264,8 @@ BoolAndString PDFParserTokenizer::GetNextToken()
 				{
 					if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
 					{	
-						result.first = false;
+						if(mStream->NotEnded())
+							result.first = false;
 						break;
 					}
 					if(IsPDFWhiteSpace(buffer))


### PR DESCRIPTION
Sometimes end of stream should be taken as a token - if the stream is
not ended that mean there is an error, otherwise it was not successfully
just because we encounter the end of stream before reading any data.
