### PR TITLE
handle indirect Kids object

### DIFF
--- a/PDFWriter/PDFParser.cpp
+++ b/PDFWriter/PDFParser.cpp
@@ -887,7 +887,10 @@ EStatusCode PDFParser::ParsePagesIDs(PDFDictionary* inPageNode,ObjectIDType inNo
 		else if(scPages == objectType->GetValue())
 		{
 			// a Page tree node
-			PDFObjectCastPtr<PDFArray> kidsObject(inPageNode->QueryDirectObject("Kids"));
+			PDFObject* pKids= inPageNode->QueryDirectObject("Kids");
+			if (pKids->GetType() == PDFObject::ePDFObjectIndirectObjectReference)
+				pKids= ParseExistingInDirectObject(((PDFIndirectObjectReference*)pKids)->mObjectID);
+			PDFObjectCastPtr<PDFArray> kidsObject(pKids);
 			if(!kidsObject)
 			{
 				TRACE_LOG("PDFParser::ParsePagesIDs, unable to find page kids array");

--- a/PDFWriter/PDFParser.cpp
+++ b/PDFWriter/PDFParser.cpp
@@ -888,7 +888,7 @@ EStatusCode PDFParser::ParsePagesIDs(PDFDictionary* inPageNode,ObjectIDType inNo
 		{
 			// a Page tree node
 			PDFObject* pKids= inPageNode->QueryDirectObject("Kids");
-			if (pKids->GetType() == PDFObject::ePDFObjectIndirectObjectReference)
+			if (pKids && pKids->GetType() == PDFObject::ePDFObjectIndirectObjectReference)
 				pKids= ParseExistingInDirectObject(((PDFIndirectObjectReference*)pKids)->mObjectID);
 			PDFObjectCastPtr<PDFArray> kidsObject(pKids);
 			if(!kidsObject)


### PR DESCRIPTION
Old Oracle Reports generates PDFs with indirect Kids object.
E.g.
3 0 obj
<<
/Type /Pages
/Kids 4 0 R
/Count 5 0 R
>>
endobj

4 0 obj
[ 6 0 R 18 0 R 21 0 R 24 0 R ]
endobj