### PR TITLE
Fix "#ifndef PDFHUMMUS_NO_PNG" scopes

### DIFF
--- a/PDFWriter/DocumentContext.cpp
+++ b/PDFWriter/DocumentContext.cpp
@@ -2973,8 +2973,8 @@ EStatusCode DocumentContext::WriteFormForImage(
         {
             status = eFailure;
         }
-    }
 #endif
+	}
     return status;
 }
 

--- a/PDFWriter/PDFWriter.cpp
+++ b/PDFWriter/PDFWriter.cpp
@@ -263,6 +263,7 @@ PDFFormXObject* PDFWriter::CreateFormXObjectFromTIFFStream(IByteReaderWithPositi
 
 #endif
 
+#ifndef PDFHUMMUS_NO_PNG
 PDFFormXObject* PDFWriter::CreateFormXObjectFromPNGFile(const std::string& inPNGFilePath) {
 	return CreateFormXObjectFromPNGFile(inPNGFilePath, mObjectsContext.GetInDirectObjectsRegistry().AllocateNewObjectID());
 }
@@ -285,7 +286,7 @@ PDFFormXObject* PDFWriter::CreateFormXObjectFromPNGStream(IByteReaderWithPositio
 	return mDocumentContext.CreateFormXObjectFromPNGStream(inPNGStream, inFormXObjectId);
 }
 
-
+#endif
 
 PDFImageXObject* PDFWriter::CreateImageXObjectFromJPGFile(const std::string& inJPGFilePath,ObjectIDType inImageXObjectID)
 {

--- a/PDFWriterTestPlayground/PNGImageTest.cpp
+++ b/PDFWriterTestPlayground/PNGImageTest.cpp
@@ -18,6 +18,9 @@
 
    
 */
+
+#ifndef PDFHUMMUS_NO_PNG
+
 #include "PNGImageTest.h"
 #include "TestsRunner.h"
 #include "PDFWriter.h"
@@ -138,3 +141,5 @@ EStatusCode PNGImageTest::Run(const TestConfiguration& inTestConfiguration)
 }
 
 ADD_CATEGORIZED_TEST(PNGImageTest,"PDF Images")
+
+#endif


### PR DESCRIPTION
Hi, I am testing PDF-Writer with PDFHUMMUS_NO_PNG defined, and troubled with compiler errors.
I found some "#ifndef PDFHUMMUS_NO_PNG" scopes are wrong or missing.