### PR TITLE
remove dependence on std::binary_function to allow compilation as C++17

### DIFF
--- a/PDFWriter/CFFFileInput.h
+++ b/PDFWriter/CFFFileInput.h
@@ -152,9 +152,8 @@ typedef std::vector<EncodingsInfo*> EncodingsInfoVector;
 
 
 
-class StringLess : public std::binary_function<const char*,const char*,bool>
+struct StringLess
 {
-public:
 	bool operator( ) (const char* left, 
 						const char* right ) const
 	{

--- a/PDFWriter/PDFDictionary.h
+++ b/PDFWriter/PDFDictionary.h
@@ -27,9 +27,8 @@
 
 
 
-class PDFNameLess : public std::binary_function<const PDFName*,const PDFName*,bool>
+struct PDFNameLess
 {
-public:
 	bool operator( ) (const PDFName* left, 
 						const PDFName* right ) const
 	{

--- a/PDFWriter/Type1ToType2Converter.h
+++ b/PDFWriter/Type1ToType2Converter.h
@@ -51,9 +51,8 @@ struct Stem
 	long mExtent;
 };
 
-class StemLess : public std::binary_function<const Stem,const Stem,bool>
+struct StemLess
 {
-public:
 	bool operator( ) (const Stem& inLeft, 
 						const Stem& inRight ) const
 	{


### PR DESCRIPTION
Currently, PDF-Writer doesn't compile with a C++17 compiler (like VS2017 with option /std:c++17), because it uses std::binary_function, which is removed by C++17.

std::binary_function is not needed here, so my mods remove it.

Best Regards,
Mathias