### PR TITLE
Minor issues with DecryptionHelper

### DIFF
--- a/PDFWriter/DecryptionHelper.cpp
+++ b/PDFWriter/DecryptionHelper.cpp
@@ -36,6 +36,7 @@ limitations under the License.
 #include "InputRC4XcodeStream.h"
 #include "InputAESDecodeStream.h"
 #include "Trace.h"
+#include <memory>
 
 using namespace std;
 using namespace PDFHummus;
@@ -364,11 +365,11 @@ std::string DecryptionHelper::DecryptString(const std::string& inStringToDecrypt
 	if (!IsDecrypting() || !mXcryptStrings)
 		return inStringToDecrypt;
 
-	IByteReader* decryptStream = CreateDecryptionReader(new InputStringStream(inStringToDecrypt), mXcryptStrings->GetCurrentObjectKey(), mXcryptStrings->IsUsingAES());
-	if (decryptStream) {
+	std::auto_ptr<IByteReader> pDecryptStream(CreateDecryptionReader(new InputStringStream(inStringToDecrypt), mXcryptStrings->GetCurrentObjectKey(), mXcryptStrings->IsUsingAES()));
+	if (pDecryptStream.get()) {
 		OutputStringBufferStream outputStream;
 		OutputStreamTraits traits(&outputStream);
-		traits.CopyToOutputStream(decryptStream);
+		traits.CopyToOutputStream(pDecryptStream.get());
 
 		return outputStream.ToString();
 	}
@@ -440,6 +441,9 @@ XCryptionCommon* DecryptionHelper::GetCryptForStream(PDFStreamInput* inStream) {
 }
 
 void DecryptionHelper::OnObjectEnd(PDFObject* inObject) {
+	if (inObject == NULL)
+		return;
+	
 	// for streams, retain the encryption key with them, so i can later decrypt them when needed
 	if ((inObject->GetType() == PDFObject::ePDFObjectStream) && IsDecrypting()) {
 		XCryptionCommon* streamCryptFilter = GetCryptForStream((PDFStreamInput*)inObject);


### PR DESCRIPTION
DecryptionHelper::DecryptString leaked memory (according to valgrind). I made a fix, using auto_ptr. Also DecryptionHelper::OnObjectEnd caused access violation if inObject was null somehow.