### PR TITLE
Plug memory leaks in PDFModifiedPage

### DIFF
--- a/PDFWriter/PDFModifiedPage.cpp
+++ b/PDFWriter/PDFModifiedPage.cpp
@@ -52,6 +52,9 @@ PDFModifiedPage::PDFModifiedPage(PDFWriter* inWriter,unsigned long inPageIndex,b
 
 PDFModifiedPage::~PDFModifiedPage(void)
 {
+	for (PDFFormXObjectVector::iterator it = mContenxts.begin(); it != mContenxts.end(); ++it) {
+		delete *it;
+	}
 }
 
 AbstractContentContext* PDFModifiedPage::StartContentContext()
@@ -357,6 +360,9 @@ PDFHummus::EStatusCode PDFModifiedPage::WritePage()
 		}
 
 		objectContext.EndPDFStream(newStream);
+
+		delete newStream;
+		delete copyingContext;
 	} while (false);
 
 	return status;


### PR DESCRIPTION
PDFModifiedPage leaks some memory and this becomes a problem when modifying too many pages with a single process. This PR deletes the objects that remain in memory when destroying PDFModifiedPage.