### PR TITLE
create a single lib target for PDFWriter and deps, called PDFWriterAll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ _.swp
 xcode/Build
 xcode/DerivedData
 
+#VSCode unswated#
+#################
+.vscode
+
 #unwanted other sources #
 ########################
 zlib-1.2.3

--- a/FreeType/CMakeLists.txt
+++ b/FreeType/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories (${FreeType_SOURCE_DIR}/include/src)
 include_directories (${FreeType_SOURCE_DIR}/include/freetype/internal)
 include_directories (${FreeType_SOURCE_DIR}/include/freetype/internal/services)
 
-add_library (FreeType
+add_library (FreeType_OBJLIB OBJECT
 #sources
 src/base/ftbbox.c
 src/base/ftgxval.c
@@ -65,6 +65,11 @@ include/freetype/config/ftoption.h
 include/freetype/config/ftstdlib.h
 include/ft2build.h
 )
+
+set(FreeType_OBJECTS $<TARGET_OBJECTS:FreeType_OBJLIB>)
+set(FreeType_OBJECTS $<TARGET_OBJECTS:FreeType_OBJLIB> PARENT_SCOPE)
+
+add_library(FreeType ${FreeType_OBJECTS})
 
 install(TARGETS FreeType
     RUNTIME DESTINATION bin COMPONENT dependencies

--- a/LibAesgm/CMakeLists.txt
+++ b/LibAesgm/CMakeLists.txt
@@ -4,7 +4,7 @@ project(LibAesgm)
 set(LIBAESGM_INCLUDE_DIRS ${LibAesgm_SOURCE_DIR} PARENT_SCOPE)
 set(LIBAESGM_LDFLAGS LibAesgm PARENT_SCOPE)
 
-add_library (LibAesgm
+add_library (LibAesgm_OBJLIB OBJECT
 #sources
 aescrypt.c
 aeskey.c
@@ -24,6 +24,10 @@ brg_endian.h
 brg_types.h
 
 )
+
+set(LibAesgm_OBJECTS $<TARGET_OBJECTS:LibAesgm_OBJLIB>)
+set(LibAesgm_OBJECTS $<TARGET_OBJECTS:LibAesgm_OBJLIB> PARENT_SCOPE)
+add_library(LibAesgm ${LibAesgm_OBJECTS})
 
 install(TARGETS LibAesgm
     RUNTIME DESTINATION bin COMPONENT dependencies

--- a/LibJpeg/CMakeLists.txt
+++ b/LibJpeg/CMakeLists.txt
@@ -4,7 +4,7 @@ project(LibJpeg)
 set(LIBJPEG_INCLUDE_DIRS ${LibJpeg_SOURCE_DIR} PARENT_SCOPE)
 set(LIBJPEG_LDFLAGS LibJpeg PARENT_SCOPE)
 
-add_library (LibJpeg 
+add_library (LibJpeg_OBJLIB OBJECT 
 #sources
 jaricom.c
 jcapimin.c
@@ -66,6 +66,9 @@ jversion.h
 
 )
 
+set(LibJpeg_OBJECTS $<TARGET_OBJECTS:LibJpeg_OBJLIB>)
+set(LibJpeg_OBJECTS $<TARGET_OBJECTS:LibJpeg_OBJLIB> PARENT_SCOPE)
+add_library(LibJpeg ${LibJpeg_OBJECTS})
 
 install(TARGETS LibJpeg
     RUNTIME DESTINATION bin COMPONENT dependencies

--- a/LibPng/CMakeLists.txt
+++ b/LibPng/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LIBPNG_LDFLAGS LibPng PARENT_SCOPE)
 include_directories (${ZLIB_INCLUDE_DIRS})
 
 
-add_library (LibPng 
+add_library (LibPng_OBJLIB OBJECT 
 #sources
 png.c
 pngerror.c
@@ -34,6 +34,11 @@ pnglibconf.h
 pngpriv.h
 pngstruct.h
 )
+
+set(LibPng_OBJECTS $<TARGET_OBJECTS:LibPng_OBJLIB>)
+set(LibPng_OBJECTS $<TARGET_OBJECTS:LibPng_OBJLIB> PARENT_SCOPE)
+add_library(LibPng ${LibPng_OBJECTS})
+
 
 target_link_libraries(LibPng ${ZLIB_LDFLAGS})
 

--- a/LibTiff/CMakeLists.txt
+++ b/LibTiff/CMakeLists.txt
@@ -24,7 +24,7 @@ add_definitions(
 -DTIF_PLATFORM_CONSOLE=1
 -DFILLODER_LSB2MSB=1)
 
-add_library (LibTiff 
+add_library (LibTiff_OBJLIB OBJECT 
 #sources
 tif_aux.c
 tif_close.c
@@ -83,6 +83,11 @@ uvcode.h
 
 
 )
+
+set(LibTiff_OBJECTS $<TARGET_OBJECTS:LibTiff_OBJLIB>)
+set(LibTiff_OBJECTS $<TARGET_OBJECTS:LibTiff_OBJLIB> PARENT_SCOPE)
+add_library(LibTiff ${LibTiff_OBJECTS})
+
 
 target_link_libraries(LibTiff ${ZLIB_LDFLAGS})
 

--- a/PDFWriter/CMakeLists.txt
+++ b/PDFWriter/CMakeLists.txt
@@ -34,7 +34,7 @@ endif(NOT PDFHUMMUS_NO_PNG)
 
 
 
-add_library (PDFWriter 
+add_library (PDFWriter_OBJLIB OBJECT
 #sources
 AbstractContentContext.cpp
 AbstractWrittenFont.cpp
@@ -368,6 +368,12 @@ WrittenFontTrueType.h
 XCryptionCommon.h
 XObjectContentContext.h
 )
+
+
+set(PDFWriter_OBJECTS $<TARGET_OBJECTS:PDFWriter_OBJLIB>)
+set(PDFWriter_OBJECTS $<TARGET_OBJECTS:PDFWriter_OBJLIB> PARENT_SCOPE)
+add_library(PDFWriter ${PDFWriter_OBJECTS})
+
 target_link_libraries(PDFWriter ${LIBAESGM_LDFLAGS} ${LIBJPEG_LDFLAGS} ${ZLIB_LDFLAGS} ${LIBTIFF_LDFLAGS} ${FREETYPE_LDFLAGS} ${LIBPNG_LDFLAGS})
 set_target_properties(PDFWriter PROPERTIES VERSION ${PDFWRITER_LIB_VERSION} SOVERSION ${PDFWRITER_SO_VERSION})
 
@@ -376,11 +382,22 @@ install(TARGETS PDFWriter
     ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
     LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
 )
+
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DESTINATION include
     FILES_MATCHING
     PATTERN "*.h"
 )
+
+if(CREATE_PDFWRITER_ALL)
+    set(ALL_OBJECTS ${PDFWriter_OBJECTS} ${FreeType_OBJECTS} ${LibAesgm_OBJECTS} ${LibJpeg_OBJECTS} ${LibTiff_OBJECTS} ${Zlib_OBJECTS} ${LibPng_OBJECTS})
+    add_library(PDFWriterAll ${ALL_OBJECTS})
+    install(TARGETS PDFWriterAll
+        RUNTIME DESTINATION bin COMPONENT libraries
+        ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
+        LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
+    )
+endif(CREATE_PDFWRITER_ALL)
 
 # groups definitions
 source_group("Document Context Level" FILES

--- a/ZLib/CMakeLists.txt
+++ b/ZLib/CMakeLists.txt
@@ -4,7 +4,7 @@ project (Zlib)
 set(ZLIB_INCLUDE_DIRS ${Zlib_SOURCE_DIR} PARENT_SCOPE)
 set(ZLIB_LDFLAGS Zlib PARENT_SCOPE)
 
-add_library (Zlib 
+add_library (Zlib_OBJLIB OBJECT 
 #sources
 adler32.c
 compress.c
@@ -35,6 +35,10 @@ zconf.h
 zlib.h
 zutil.h
 )
+
+set(Zlib_OBJECTS $<TARGET_OBJECTS:Zlib_OBJLIB>)
+set(Zlib_OBJECTS $<TARGET_OBJECTS:Zlib_OBJLIB> PARENT_SCOPE)
+add_library(Zlib ${Zlib_OBJECTS})
 
 
 install(TARGETS Zlib


### PR DESCRIPTION
add optional target PDFWriterAll (when configuring with CREATE_PDFWRITER_ALL=TRUE). This will create a single lib with PDFWriter and all it's dependencies that can be used as an alternative input for a project.
it's a step towards a potential [emscripten](https://github.com/kripken/emscripten) compilation.