### PR TITLE
Fix infinite loop

### DIFF
--- a/PDFWriter/ArrayOfInputStreamsStream.cpp
+++ b/PDFWriter/ArrayOfInputStreamsStream.cpp
@@ -83,7 +83,14 @@ LongBufferSizeType ArrayOfInputStreamsStream::Read(Byte* inBuffer,LongBufferSize
 		// read from current stream
 		IByteReader* reader = GetActiveStream();
 		if (reader && reader->NotEnded()) {
-			readAmount+= reader->Read(inBuffer + readAmount, inBufferSize - readAmount);
+			LongBufferSizeType readThisTime = reader->Read(inBuffer + readAmount, inBufferSize - readAmount);
+			if (readThisTime) {
+				readAmount += readThisTime;
+			}
+			else {
+				// otherwise infinite loop
+				break;
+			}
 		}
 	}
 	return readAmount;


### PR DESCRIPTION
reader->Read() can return 0 when it encounters a stream error.  This will cause an infinite hang here