### PR TITLE
Free memory for created stream to avoid memory leak.

### DIFF
--- a/PDFWriter/PDFModifiedPage.cpp
+++ b/PDFWriter/PDFModifiedPage.cpp
@@ -331,7 +331,7 @@ PDFHummus::EStatusCode PDFModifiedPage::WritePage()
 			primitivesWriter.SetStreamForWriting(newStream->GetWriteStream());
 			primitivesWriter.WriteKeyword("q");
 			objectContext.EndPDFStream(newStream);
-
+			delete newStream;
 		}
 
 		// last but not least, create the actual content stream object, placing the form


### PR DESCRIPTION
Hello ! 

After investigating the leak from https://github.com/galkahana/HummusJS/issues/259 I found that in some case a stream is created and then another one is allocated without freeing the previous one.