### PR TITLE
Add Fl alias and stream null check to avoid crashes

### DIFF
--- a/PDFWriter/InputStreamSkipperStream.cpp
+++ b/PDFWriter/InputStreamSkipperStream.cpp
@@ -53,7 +53,7 @@ IOBasicTypes::LongBufferSizeType InputStreamSkipperStream::Read(IOBasicTypes::By
 
 bool InputStreamSkipperStream::NotEnded()
 {
-	return mStream->NotEnded();
+	return mStream ? mStream->NotEnded() : false;
 }
 
 

--- a/PDFWriter/PDFParser.cpp
+++ b/PDFWriter/PDFParser.cpp
@@ -1925,8 +1925,9 @@ EStatusCodeAndIByteReader PDFParser::CreateFilterForStream(IByteReader* inStream
 	do
 	{
 
-		if(inFilterName->GetValue() == "FlateDecode")
+		if(inFilterName->GetValue() == "FlateDecode" || inFilterName->GetValue() == "Fl")
 		{
+			// Fl is an alias for FlateDecode in rare cases like HP Exstream software
 			InputFlateDecodeStream* flateStream;
 			flateStream = new InputFlateDecodeStream(NULL); // assigning null, so later delete, if failure occurs won't delete the input stream
 			result = flateStream;


### PR DESCRIPTION
Fix for https://github.com/galkahana/PDF-Writer/issues/167 in case it helps anyone else with PDF-Writer / hummus crashes on HP Exstream pdf files where they're using an "Fl" alias instead of "FlateDecode".

All regular tests passing. (61 tests succeeded, 0 tests failed.)