### PR TITLE
m1 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(PDFHUMMUS)
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8.12)
 
 set(USE_BUNDLED TRUE CACHE BOOL "Whether to use bundled libraries")
 

--- a/FreeType/CMakeLists.txt
+++ b/FreeType/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6) 
+cmake_minimum_required (VERSION 2.8.12) 
 project(FreeType)
 
 set(FREETYPE_INCLUDE_DIRS ${FreeType_SOURCE_DIR}/include PARENT_SCOPE)

--- a/LibAesgm/CMakeLists.txt
+++ b/LibAesgm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6) 
+cmake_minimum_required (VERSION 2.8.12) 
 project(LibAesgm)
 
 set(LIBAESGM_INCLUDE_DIRS ${LibAesgm_SOURCE_DIR} PARENT_SCOPE)

--- a/LibJpeg/CMakeLists.txt
+++ b/LibJpeg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6) 
+cmake_minimum_required (VERSION 2.8.12) 
 project(LibJpeg)
 
 set(LIBJPEG_INCLUDE_DIRS ${LibJpeg_SOURCE_DIR} PARENT_SCOPE)

--- a/LibPng/CMakeLists.txt
+++ b/LibPng/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required (VERSION 2.6) 
+cmake_minimum_required (VERSION 2.8.12)
 project(LibPng)
 
 # https://github.com/julienr/libpng-android/issues/6
-if (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+if (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "aarch64" OR ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64")
     set(CMAKE_C_FLAGS -DPNG_ARM_NEON_OPT=0 ${CMAKE_C_FLAGS})
     message (STATUS "libPng Arm64 - disable fpu Neon optimization")
 endif()

--- a/LibTiff/CMakeLists.txt
+++ b/LibTiff/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6) 
+cmake_minimum_required (VERSION 2.8.12) 
 project(LibTiff)
 
 set(LIBTIFF_INCLUDE_DIRS ${LibTiff_SOURCE_DIR} PARENT_SCOPE)

--- a/PDFWriterTestPlayground/CMakeLists.txt
+++ b/PDFWriterTestPlayground/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(PDFWriterTestPlayground)
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8.12)
 
 
 add_executable(PDFWriterTestPlayground 

--- a/ZLib/CMakeLists.txt
+++ b/ZLib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6) 
+cmake_minimum_required (VERSION 2.8.12) 
 project (Zlib)
 
 include(CheckIncludeFile)


### PR DESCRIPTION
got a new m1. hummus compiling throws link errors for libpng neon. providing same treatment as was done for android  support - disabling neon on arm.

also...got warnings for coming deprecation of any version of cmake prior to 2.8.10...so updated cmake files to properly indicate that version as the new supported min.