### PR TITLE
xref parsing corrections

### DIFF
--- a/PDFWriter/PDFParser.h
+++ b/PDFWriter/PDFParser.h
@@ -216,7 +216,7 @@ private:
 	PDFHummus::EStatusCode ParsePagesIDs(PDFDictionary* inPageNode,ObjectIDType inNodeObjectID);
 	PDFHummus::EStatusCode ParsePagesIDs(PDFDictionary* inPageNode,ObjectIDType inNodeObjectID,unsigned long& ioCurrentPageIndex);
 	PDFHummus::EStatusCode ParsePreviousXrefs(PDFDictionary* inTrailer);
-	void MergeXrefWithMainXref(XrefEntryInputVector& inTableToMerge,ObjectIDType inMergedTableSize);
+	PDFHummus::EStatusCode MergeXrefWithMainXref(XrefEntryInputVector& inTableToMerge,ObjectIDType inMergedTableSize);
 	PDFHummus::EStatusCode ParseFileDirectory();
 	PDFHummus::EStatusCode BuildXrefTableAndTrailerFromXrefStream(long long inXrefStreamObjectID);
 	// an overload for cases where the xref stream object is already parsed
@@ -263,5 +263,5 @@ private:
 	void GoBackTillLineStart();
 	bool IsPDFWhiteSpace(IOBasicTypes::Byte inCharacter);
 
-	void ExtendXrefToSize(XrefEntryInputVector& inXrefTable, ObjectIDType inXrefSize);
+	PDFHummus::EStatusCode ExtendXrefToSize(XrefEntryInputVector& inXrefTable, ObjectIDType inXrefSize);
 };


### PR DESCRIPTION
- per @julianhille  suggestion [here](https://github.com/galkahana/PDF-Writer/pull/186#discussion_r1040519253) the xref size validation check is moved to `ExtendXrefToSize`. This method is shared by callers performing the check size as part of their code...better to avoid forgetting to check there by moving the check to the shared code. plus we reuse the share (look....it's less code :))