### PR TITLE
fix: harsher hex string parsing to avoid more dire parsing errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 # Soname
 # MAJOR is incremented when symbols are removed or changed in an incompatible way
 # MINOR is incremented when new symbols are added
-project(PDFHummus VERSION 4.5.1)
+project(PDFHummus VERSION 4.5.2)
 
 
 option(USE_BUNDLED  "Whether to use bundled libraries" TRUE)


### PR DESCRIPTION
running fuzz tests on my mac for the text extraction project was failing erratically for one of the files (526).

also recreating a decompressed version didn't work.

traced the first problem to a too permissive hex string parsing which caused over-reads.

and the second problem to a too restrictive zip decoding issue where end of stream error canceled the whole stream reading. which is a shame cause it could parse something worthwhile till then, like in this case.