### PR TITLE
Pdfa 1a

### DIFF
--- a/PDFWriter/DocumentContext.cpp
+++ b/PDFWriter/DocumentContext.cpp
@@ -171,12 +171,12 @@ void DocumentContext::WriteHeaderComment(EPDFVersion inPDFVersion)
 	}
 }
 
-static const IOBasicTypes::Byte scBinaryBytesArray[] = {'%',0xBD,0xBE,0xBC,'\r','\n'}; // might imply that i need a newline writer here....an underlying primitives-token context
+static const IOBasicTypes::Byte scBinaryBytesArray[] = {'%',0xBD,0xBE,0xBC,0xB5,'\r','\n'}; // might imply that i need a newline writer here....an underlying primitives-token context
 
 void DocumentContext::Write4BinaryBytes()
 {
 	IByteWriterWithPosition *freeContextOutput = mObjectsContext->StartFreeContext();
-	freeContextOutput->Write(scBinaryBytesArray,6);
+	freeContextOutput->Write(scBinaryBytesArray,7);
 	mObjectsContext->EndFreeContext();
 }
 

--- a/PDFWriter/PDFWriter.cpp
+++ b/PDFWriter/PDFWriter.cpp
@@ -714,7 +714,8 @@ EStatusCode PDFWriter::ModifyPDFForStream(
     }
 
     mObjectsContext.SetOutputStream(inModifiedDestinationStream);
-
+    mObjectsContext.WriteTokenSeparator(eTokenSeparatorEndLine);
+    
     mIsModified = true;
 
     return SetupStateFromModifiedStream(inModifiedSourceStream, thisOrDefaultVersion(inPDFVersion), inPDFCreationSettings);


### PR DESCRIPTION
Hi @galkahana,

First of all, thank you for your wok in this library and glad to see you have come back to it.

While using PDFWriter for a project we have detected that if the original document is pdfa-1a compliant simply recreating it or modifying it using some new IUs broke the standard validation (tested with: Verapdf and Avepdf).

As you can see the modifications are minimal but effective. 

- The `DocumentContext.cpp` one comes straight from the ISO19005-1 standard clause 6.1.2, just added a new >127 byte
- The `PDFWriter.cpp` one is caused when we try to modify a PDF file using IUs, the first oject was added in the same line as the %%EOF of the original document causing an error in the validation. Just added a new line separator in ModifyPDFForStream in the same way that it was done in the ModifyPDF function above.

Attached you can see a screenshot of the xml report that avepdf provided with the error and a screenshot the chunk of the PDF where we have highlighted where the error that avepdf is complaining about is made:

![pdfavalidation_xml](https://github.com/galkahana/PDF-Writer/assets/1834051/1adb5ece-9446-4e37-9a85-7512613ba337)

![ModifyWithIUs_error_chunk](https://github.com/galkahana/PDF-Writer/assets/1834051/e82e7c34-bf9b-450f-a994-be893e79d822)




