### PR TITLE
bug: wrong CIDSet implementation

### DIFF
--- a/PDFWriter/CFFDescendentFontWriter.cpp
+++ b/PDFWriter/CFFDescendentFontWriter.cpp
@@ -100,7 +100,15 @@ EStatusCode CFFDescendentFontWriter::WriteFont(	ObjectIDType inDecendentObjectID
 
 	DescendentFontWriter descendentFontWriter;
 
-	return descendentFontWriter.WriteFont(inDecendentObjectID,inFontName,inFontInfo,inEncodedGlyphs,inObjectsContext,this);
+	return descendentFontWriter.WriteFont(
+		inDecendentObjectID,
+		inFontName,
+		inFontInfo,
+		inEncodedGlyphs,
+		inObjectsContext,
+		this,
+		inEncodedGlyphs.size() // the font program includes the glyphs 0...glyps.size using cid=sid. so cidset should be the same. 0..size.
+	);
 }
 
 static const std::string scCIDFontType0 = "CIDFontType0";

--- a/PDFWriter/DescendentFontWriter.h
+++ b/PDFWriter/DescendentFontWriter.h
@@ -46,13 +46,16 @@ public:
 	DescendentFontWriter(void);
 	~DescendentFontWriter(void);
 
-	// the IDescendentFontWriter input pointer will implement the font specific differences
-	virtual PDFHummus::EStatusCode WriteFont(	ObjectIDType inDecendentObjectID, 
+	PDFHummus::EStatusCode WriteFont(	ObjectIDType inDecendentObjectID, 
 									const std::string& inFontName,
 									FreeTypeFaceWrapper& inFontInfo,
 									const UIntAndGlyphEncodingInfoVector& inEncodedGlyphs,
 									ObjectsContext* inObjectsContext,
-									IDescendentFontWriter* inDescendentFontWriterHelper);
+									IDescendentFontWriter* inDescendentFontWriterHelper,
+									// the next one is for writing CID set. there's an assumption
+									// that all CIDs up to the max glyph are included in the font program,
+									// so that CIDset will include all up to (and including) CID glyph
+									unsigned int inMaxCIDGlyph);
 
 	// IFontDescriptorHelper implementation [would probably evolve at some point to IDescriptorWriterHelper...
 	virtual void WriteCharSet(	DictionaryContext* inDescriptorContext,
@@ -69,9 +72,9 @@ private:
 	IDescendentFontWriter* mWriterHelper;
 
 
-	void WriteWidths(	const UIntAndGlyphEncodingInfoVector& inEncodedGlyphs,
+	void WriteWidths(const UIntAndGlyphEncodingInfoVector& inEncodedGlyphs,
 						DictionaryContext* inFontContext);
 	void WriteCIDSystemInfo(ObjectIDType inCIDSystemInfoObjectID);
 	void WriteWidthsItem(bool inAllWidthsSame,const FTPosList& inWidths,unsigned short inFirstCID, unsigned short inLastCID);
-	void WriteCIDSet(const UIntAndGlyphEncodingInfoVector& inEncodedGlyphs);
+	void WriteCIDSet(unsigned int cidSetMaxGlyph);
 };

--- a/PDFWriter/TrueTypeDescendentFontWriter.cpp
+++ b/PDFWriter/TrueTypeDescendentFontWriter.cpp
@@ -66,7 +66,16 @@ EStatusCode TrueTypeDescendentFontWriter::WriteFont(	ObjectIDType inDecendentObj
 	}
 
 	DescendentFontWriter descendentFontWriter;
-	return descendentFontWriter.WriteFont(inDecendentObjectID,inFontName,inFontInfo,inEncodedGlyphs,inObjectsContext,this);
+
+	return descendentFontWriter.WriteFont(
+		inDecendentObjectID,
+		inFontName,
+		inFontInfo,
+		inEncodedGlyphs,
+		inObjectsContext,
+		this,
+		inEncodedGlyphs.back().first + 1 // the font program includes the glyphs 0...lastGlyphCode + 1 filling the intermediate missing glyphs with empties. so cidset should be the same. 0..lastGlyphCode + 1.
+	);	
 }
 
 static const std::string scCIDFontType2 = "CIDFontType2";

--- a/PDFWriterTesting/CIDSetWritingCFF.cpp
+++ b/PDFWriterTesting/CIDSetWritingCFF.cpp
@@ -1,0 +1,91 @@
+/*
+   Source File : CIDSetWritingCFF.cpp
+
+
+   Copyright 2011 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   
+*/
+#include "PDFWriter.h"
+#include "PDFPage.h"
+#include "PageContentContext.h"
+#include "PDFUsedFont.h"
+
+#include <iostream>
+
+#include "testing/TestIO.h"
+
+using namespace PDFHummus;
+
+
+int CIDSetWritingCFF(int argc, char* argv[])
+{
+	EStatusCode status = eSuccess;
+	PDFWriter pdfWriter;
+
+	do
+	{
+		status = pdfWriter.StartPDF(BuildRelativeOutputPath(argv,"CIDSetWritingCFF.pdf"),ePDFVersion14);
+		if(status != eSuccess)
+		{
+			cout<<"Failed to start file\n";
+			break;
+		}
+
+		PDFPage* page = new PDFPage();
+		page->SetMediaBox(PDFRectangle(0,0,595,842));
+		
+		PageContentContext* cxt = pdfWriter.StartPageContentContext(page);
+
+		AbstractContentContext::TextOptions textOptions(pdfWriter.GetFontForFile(
+																			BuildRelativeInputPath(
+                                                                            argv,
+                                                                            "fonts/KozGoPro-Regular.otf")),
+																			14,
+																			AbstractContentContext::eGray,
+																			0);
+
+		cxt->WriteText(75,600,"hello \xe6\x9c\x9d",textOptions);
+
+		status = pdfWriter.EndPageContentContext(cxt);
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to end content context\n";
+			break;
+		}
+
+		status = pdfWriter.WritePageAndRelease(page);
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to write page\n";
+			break;
+		}
+
+
+		status = pdfWriter.EndPDF();
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to end pdf\n";
+			break;
+		}
+
+	}while(false);
+
+
+	return status == eSuccess ? 0:1;
+}

--- a/PDFWriterTesting/CIDSetWritingTrueType.cpp
+++ b/PDFWriterTesting/CIDSetWritingTrueType.cpp
@@ -1,0 +1,91 @@
+/*
+   Source File : CIDSetWritingTrueType.cpp
+
+
+   Copyright 2011 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   
+*/
+#include "PDFWriter.h"
+#include "PDFPage.h"
+#include "PageContentContext.h"
+#include "PDFUsedFont.h"
+
+#include <iostream>
+
+#include "testing/TestIO.h"
+
+using namespace PDFHummus;
+
+
+int CIDSetWritingTrueType(int argc, char* argv[])
+{
+	EStatusCode status = eSuccess;
+	PDFWriter pdfWriter;
+
+	do
+	{
+		status = pdfWriter.StartPDF(BuildRelativeOutputPath(argv,"CIDSetWritingTrueType.pdf"),ePDFVersion14);
+		if(status != eSuccess)
+		{
+			cout<<"Failed to start file\n";
+			break;
+		}
+
+		PDFPage* page = new PDFPage();
+		page->SetMediaBox(PDFRectangle(0,0,595,842));
+		
+		PageContentContext* cxt = pdfWriter.StartPageContentContext(page);
+
+		AbstractContentContext::TextOptions textOptions(pdfWriter.GetFontForFile(
+																			BuildRelativeInputPath(
+                                                                            argv,
+                                                                            "fonts/yugothib.ttf")),
+																			14,
+																			AbstractContentContext::eGray,
+																			0);
+
+		cxt->WriteText(75,600,"hello \xe6\xb8\xb8\xe7\xaf\x89\xe8\xa6\x8b\xe5\x87\xba\xe3\x81\x97\xe6\x98\x8e\xe6\x9c\x9d\xe4\xbd\x93",textOptions);
+
+		status = pdfWriter.EndPageContentContext(cxt);
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to end content context\n";
+			break;
+		}
+
+		status = pdfWriter.WritePageAndRelease(page);
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to write page\n";
+			break;
+		}
+
+
+		status = pdfWriter.EndPDF();
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to end pdf\n";
+			break;
+		}
+
+	}while(false);
+
+
+	return status == eSuccess ? 0:1;
+}

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -10,6 +10,8 @@ create_test_sourcelist (Tests
   BasicModification.cpp
   BoxingBaseTest.cpp
   BufferedOutputStreamTest.cpp
+  CIDSetWritingTrueType.cpp
+  CIDSetWritingCFF.cpp
   CopyingAndMergingEmptyPages.cpp
   CustomLogTest.cpp
   DCTDecodeFilterTest.cpp


### PR DESCRIPTION
turns out the CIDSet implementation was wrong for either true type or open type.
it shouldn't match the glyphs that are used, but rather how they are represented in the font program

so instead of marking each bit per the glyph id is should:

- for true type mark 0 till max glyph including with all the glyphs between them also as i map them to blanks
- for open type the font program just uses 0...glyphs count as the cid indexes

so the final implementation is actually much simpler than it was....and also actually correct