### PR TITLE
include cstdint to fix compilation error on gcc 13

### DIFF
--- a/PDFWriter/TIFFImageHandler.h
+++ b/PDFWriter/TIFFImageHandler.h
@@ -81,7 +81,7 @@
 #include <string>
 #include <list>
 #include <utility>
-
+#include <cstdint>
 
 
 


### PR DESCRIPTION
I met compilation error on gcc 13. (work fine on gcc 12)

```
In file included from PDFWriter/DocumentContext.h:29,
                 from PDFWriter/PDFWriter.h:30,
                 from test_package.cpp:2:
/PDFWriter/TIFFImageHandler.h:142:9: error: ‘uint64_t’ does not name a type
  142 | typedef uint64_t tsize_t_compat;
      |         ^~~~~~~~
PDFWriter/TIFFImageHandler.h:83:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   82 | #include <list>
  +++ |+#include <cstdint>
   83 | #include <utility>
```

As compiler suggested, this patch include cstdint.
Please merge it if possible.