### PR TITLE
feat: use stdint instead of cstdint, conforming to c99 instead of c+11

### DIFF
--- a/PDFWriter/TIFFImageHandler.h
+++ b/PDFWriter/TIFFImageHandler.h
@@ -81,7 +81,7 @@
 #include <string>
 #include <list>
 #include <utility>
-#include <cstdint>
+#include <stdint.h>
 
 
 


### PR DESCRIPTION
im using stdint.h instead of cstdint for allowing the same effect of compiling successfully on gcc, while allowing a bit more potential projects, those that are c99 but dont use c+11. 