### PR TITLE
bug: pop_back of empty list in CharStringType2Interpreter::InterpretCallSubr

### DIFF
--- a/PDFWriter/CharStringType2Interpreter.cpp
+++ b/PDFWriter/CharStringType2Interpreter.cpp
@@ -452,9 +452,8 @@ Byte* CharStringType2Interpreter::InterpretCallSubr(Byte* inProgramCounter)
 		return NULL;
 
 	aCharString = mImplementationHelper->GetLocalSubr(mOperandStack.back().IntegerValue);
-	if (mOperandStack.size() > 0) {
+	if(mOperandStack.size() > 0)
 		mOperandStack.pop_back();
-	}
 
 	if(aCharString != NULL)
 	{

--- a/PDFWriter/CharStringType2Interpreter.cpp
+++ b/PDFWriter/CharStringType2Interpreter.cpp
@@ -452,7 +452,9 @@ Byte* CharStringType2Interpreter::InterpretCallSubr(Byte* inProgramCounter)
 		return NULL;
 
 	aCharString = mImplementationHelper->GetLocalSubr(mOperandStack.back().IntegerValue);
-	mOperandStack.pop_back();
+	if (mOperandStack.size() > 0) {
+		mOperandStack.pop_back();
+	}
 
 	if(aCharString != NULL)
 	{


### PR DESCRIPTION
It fixes the crash problem of #237, but the glyph still fails to write to PDF

Here is the code to reproduce the bug:
```
#include "PDFWriter/PageContentContext.h"
#include "PDFWriter/PDFPage.h"
#include "PDFWriter/PDFWriter.h"

#include <iostream>
using namespace std;

int main(int argc, char **argv)
{
	PDFWriter pdfWriter;
	pdfWriter.StartPDF("test.pdf", ePDFVersionMax);

	PDFUsedFont* font1 = pdfWriter.GetFontForFile("/Users/da/Library/Fonts/NotoSerifCJK-Regular.ttc", 2);

	AbstractContentContext::TextOptions textOptions1(font1, 20, AbstractContentContext::eGray, 0);

	PDFPage* page = new PDFPage();
	page->SetMediaBox(PDFRectangle(0, 0, 595, 842));
	PageContentContext* contentContext = pdfWriter.StartPageContentContext(page);

	const char* test = "这是默认的"; // 默 is still missing here
	contentContext->WriteText(50, 750, test, textOptions1);

	pdfWriter.EndPageContentContext(contentContext);
	pdfWriter.WritePage(page);
	delete page;

	std::cout << "before end page" << "\n";
	pdfWriter.EndPDF();
	return 0;
}
```