### PR TITLE
chore: use NotoSerifCJK-Regular.ttc instead of NotoSerifCJKkr-Regular.otf

### DIFF
--- a/.github/workflows/ci-xmake-linux.yml
+++ b/.github/workflows/ci-xmake-linux.yml
@@ -1,4 +1,4 @@
-name: Build on linux
+name: xmake
 
 on:
   push:

--- a/.github/workflows/ci-xmake-linux.yml
+++ b/.github/workflows/ci-xmake-linux.yml
@@ -2,9 +2,9 @@ name: Build on linux
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-xmake-linux.yml
+++ b/.github/workflows/ci-xmake-linux.yml
@@ -21,7 +21,7 @@ jobs:
           echo "XMAKE_GLOBALDIR=${{ runner.workspace }}/.xmake-global" >> "${{ github.env }}"
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: v2.8.3
+          xmake-version: v2.8.6
       - name: update repo
         run: xmake repo -u
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ Downloads
 # notes etc.
 etc
 
+#vscode unwanted#
+.vscode/compile_commands.json
+
 #xmake unwanted#
 ################
 .xmake

--- a/PDFWriterTesting/TextUsageBugs.cpp
+++ b/PDFWriterTesting/TextUsageBugs.cpp
@@ -54,7 +54,7 @@ static EStatusCode RunKoreanFontTest(char* argv[]) {
 		AbstractContentContext::TextOptions textOptions(pdfWriter.GetFontForFile(
 			BuildRelativeInputPath(
 				argv,
-				"fonts/NotoSerifCJKkr-Regular.otf")),
+				"fonts/NotoSerifCJK-Regular.ttc")),
 			14,
 			AbstractContentContext::eGray,
 			0);


### PR DESCRIPTION
+ `NotoSerifCJKkr-Regular.otf` is a subset of `NotoSerifCJK-Regular.ttc`, use ttc and remove otf to reduce the size of the git repo.
+ enable xmake ci