### PR TITLE
exclude pdfwriter testing from git archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # exclude tests from exported git archives
-export-ignore PDFWriterTesting
+PDFWriterTesting export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# exclude tests from exported git archives
+export-ignore PDFWriterTesting

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,13 +153,13 @@ endif(NOT USE_BUNDLED)
 
 ADD_SUBDIRECTORY(PDFWriter)
 
-if(PROJECT_IS_TOP_LEVEL)
+if(PROJECT_IS_TOP_LEVEL AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/PDFWriterTesting)
     # avoid installing the testing lib altogether when included in another project.
     # it's annoying when in parent all, and more annoying to then get the tests added
     # to the parent project ctest.
     enable_testing()
     ADD_SUBDIRECTORY(PDFWriterTesting)
-endif(PROJECT_IS_TOP_LEVEL)
+endif()
 
 include(InstallRequiredSystemLibraries)
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")


### PR DESCRIPTION
To resolve #243, this MR use .gitattributes to exclude PDFWriterTesting from archives.
This will mean no future packages of PDFWriter will include PDFWriterTesting, allowing for a highly diminished and effective downloads for users of PDFWriter.
This allows continuing adding test cases to PDFWriter without increasing the users downloaded package.