### PR TITLE
chore: use NotoSerifCJK-Regular.ttc instead of NotoSerifCJKkr-Regular.otf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ Downloads
 # notes etc.
 etc
 
+#vscode unwanted#
+.vscode/compile_commands.json
+
 #xmake unwanted#
 ################
 .xmake

--- a/PDFWriterTesting/TextUsageBugs.cpp
+++ b/PDFWriterTesting/TextUsageBugs.cpp
@@ -54,7 +54,7 @@ static EStatusCode RunKoreanFontTest(char* argv[]) {
 		AbstractContentContext::TextOptions textOptions(pdfWriter.GetFontForFile(
 			BuildRelativeInputPath(
 				argv,
-				"fonts/NotoSerifCJKkr-Regular.otf")),
+				"fonts/NotoSerifCJK-Regular.ttc")),
 			14,
 			AbstractContentContext::eGray,
 			0);


### PR DESCRIPTION
`NotoSerifCJKkr-Regular.otf` is a subset of `NotoSerifCJK-Regular.ttc`, use ttc and remove otf to reduce the size of the git repo.