### PR TITLE
Galk.interpreters.limits implementation

### DIFF
--- a/PDFWriter/CharStringType1Interpreter.h
+++ b/PDFWriter/CharStringType1Interpreter.h
@@ -37,6 +37,7 @@ private:
 	IType1InterpreterImplementation* mImplementationHelper;
 	bool mGotEndChar;
 	LongList mPostScriptOperandStack;
+	unsigned short mSubrsNesting;
 
 	PDFHummus::EStatusCode ProcessCharString(InputCharStringDecodeStream* inCharStringToIntepret);
 	bool IsOperator(Byte inBuffer);

--- a/PDFWriter/CharStringType1Tracer.cpp
+++ b/PDFWriter/CharStringType1Tracer.cpp
@@ -34,7 +34,6 @@ CharStringType1Tracer::~CharStringType1Tracer(void)
 {
 }
 
-/*
 EStatusCode CharStringType1Tracer::TraceGlyphProgram(Byte inGlyphIndex, Type1Input* inType1Input, IByteWriter* inWriter)
 {
 	CharStringType1Interpreter interpreter;
@@ -51,7 +50,7 @@ EStatusCode CharStringType1Tracer::TraceGlyphProgram(Byte inGlyphIndex, Type1Inp
 	}
 
 	return interpreter.Intepret(*charString,this);
-}*/
+}
 
 EStatusCode CharStringType1Tracer::TraceGlyphProgram(const std::string& inGlyphName, Type1Input* inType1Input, IByteWriter* inWriter)
 {

--- a/PDFWriter/CharStringType2Flattener.cpp
+++ b/PDFWriter/CharStringType2Flattener.cpp
@@ -51,7 +51,7 @@ EStatusCode CharStringType2Flattener::WriteFlattenedGlyphProgram(unsigned short 
 
 	do
 	{
-		if(status != PDFHummus::eSuccess)
+		if(status != eSuccess)
 		{
 			TRACE_LOG("CharStringType2Flattener::Trace, Exception, cannot prepare for glyph interpretation");
 			break;
@@ -91,7 +91,7 @@ EStatusCode CharStringType2Flattener::ReadCharString(LongFilePositionType inChar
 EStatusCode CharStringType2Flattener::Type2InterpretNumber(const CharStringOperand& inOperand)
 {
 	mOperandsToWrite.push_back(inOperand);
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Flattener::Type2Hstem(const CharStringOperandList& inOperandList)
@@ -104,11 +104,11 @@ EStatusCode CharStringType2Flattener::Type2Hstem(const CharStringOperandList& in
 EStatusCode CharStringType2Flattener::WriteRegularOperator(unsigned short inOperatorCode)
 {
 	CharStringOperandList::iterator it = mOperandsToWrite.begin();
-	EStatusCode status = PDFHummus::eSuccess;
+	EStatusCode status = eSuccess;
 
-	for(; it != mOperandsToWrite.end() && PDFHummus::eSuccess == status;++it)
+	for(; it != mOperandsToWrite.end() && eSuccess == status;++it)
 		status = WriteCharStringOperand(*it);
-	if(status != PDFHummus::eFailure)
+	if(status != eFailure)
 		status = WriteCharStringOperator(inOperatorCode);
 
 	mOperandsToWrite.clear();
@@ -134,11 +134,11 @@ EStatusCode CharStringType2Flattener::WriteCharStringOperand(const CharStringOpe
 			byte0 = ((value >> 8) & 0xff) + 247;
 			byte1 = value & 0xff;
 
-			if(WriteByte(byte0) != PDFHummus::eSuccess)
-				return PDFHummus::eFailure;
+			if(WriteByte(byte0) != eSuccess)
+				return eFailure;
 
-			if(WriteByte(byte1) != PDFHummus::eSuccess)
-				return PDFHummus::eFailure;
+			if(WriteByte(byte1) != eSuccess)
+				return eFailure;
 		}
 		else if(-1131 <= value && value <= -108)
 		{
@@ -149,11 +149,11 @@ EStatusCode CharStringType2Flattener::WriteCharStringOperand(const CharStringOpe
 			byte0 = ((value >> 8) & 0xff) + 251;
 			byte1 = value & 0xff;
 
-			if(WriteByte(byte0) != PDFHummus::eSuccess)
-				return PDFHummus::eFailure;
+			if(WriteByte(byte0) != eSuccess)
+				return eFailure;
 
-			if(WriteByte(byte1) != PDFHummus::eSuccess)
-				return PDFHummus::eFailure;
+			if(WriteByte(byte1) != eSuccess)
+				return eFailure;
 		}
 		else if(-32768 <= value && value<= 32767)
 		{
@@ -162,17 +162,17 @@ EStatusCode CharStringType2Flattener::WriteCharStringOperand(const CharStringOpe
 			byte1 = (value >> 8) & 0xff;
 			byte2 = value & 0xff;
 
-			if(WriteByte(28) != PDFHummus::eSuccess)
-				return PDFHummus::eFailure;
+			if(WriteByte(28) != eSuccess)
+				return eFailure;
 
-			if(WriteByte(byte1) != PDFHummus::eSuccess)
-				return PDFHummus::eFailure;
+			if(WriteByte(byte1) != eSuccess)
+				return eFailure;
 
-			if(WriteByte(byte2) != PDFHummus::eSuccess)
-				return PDFHummus::eFailure;
+			if(WriteByte(byte2) != eSuccess)
+				return eFailure;
 		}
 		else
-			return PDFHummus::eFailure;
+			return eFailure;
 	}
 	else
 	{
@@ -185,35 +185,35 @@ EStatusCode CharStringType2Flattener::WriteCharStringOperand(const CharStringOpe
 		if(sign)
 			integerPart = -integerPart;
 
-		if(WriteByte(Byte(0xff)) != PDFHummus::eSuccess)
-			return PDFHummus::eFailure;
-		if(WriteByte(Byte((integerPart>>8) & 0xff)) != PDFHummus::eSuccess)
-			return PDFHummus::eFailure;
-		if(WriteByte(Byte(integerPart & 0xff)) != PDFHummus::eSuccess)
-			return PDFHummus::eFailure;
+		if(WriteByte(Byte(0xff)) != eSuccess)
+			return eFailure;
+		if(WriteByte(Byte((integerPart>>8) & 0xff)) != eSuccess)
+			return eFailure;
+		if(WriteByte(Byte(integerPart & 0xff)) != eSuccess)
+			return eFailure;
 
-		if(WriteByte(Byte((realPart>>8) & 0xff)) != PDFHummus::eSuccess)
-			return PDFHummus::eFailure;
-		if(WriteByte(Byte(realPart & 0xff)) != PDFHummus::eSuccess)
-			return PDFHummus::eFailure;
+		if(WriteByte(Byte((realPart>>8) & 0xff)) != eSuccess)
+			return eFailure;
+		if(WriteByte(Byte(realPart & 0xff)) != eSuccess)
+			return eFailure;
 
 	}
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Flattener::WriteCharStringOperator(unsigned short inOperatorCode)
 {
 	if((inOperatorCode & 0xff00) == 0x0c00)
 	{
-		if(WriteByte(0x0c) != PDFHummus::eSuccess)
-			return PDFHummus::eFailure;
+		if(WriteByte(0x0c) != eSuccess)
+			return eFailure;
 	}
 	return WriteByte(Byte(inOperatorCode & 0xff));
 }
 
 EStatusCode CharStringType2Flattener::WriteByte(Byte inValue)
 {
-	return (mWriter->Write(&inValue,1) == 1 ? PDFHummus::eSuccess : PDFHummus::eFailure);
+	return (mWriter->Write(&inValue,1) == 1 ? eSuccess : eFailure);
 }
 
 EStatusCode CharStringType2Flattener::Type2Vstem(const CharStringOperandList& inOperandList)
@@ -251,7 +251,7 @@ EStatusCode CharStringType2Flattener::Type2RRCurveto(const CharStringOperandList
 EStatusCode CharStringType2Flattener::Type2Return(const CharStringOperandList& inOperandList)
 {
 	// ignore returns
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Flattener::Type2Endchar(const CharStringOperandList& inOperandList)
@@ -266,31 +266,36 @@ EStatusCode CharStringType2Flattener::Type2Hstemhm(const CharStringOperandList& 
 	return WriteRegularOperator(18);
 }
 
-EStatusCode CharStringType2Flattener::Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter)
+EStatusCode CharStringType2Flattener::Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit)
 {
 	mStemsCount+= (unsigned short)(inOperandList.size() / 2);
 
-	if(WriteRegularOperator(19) != PDFHummus::eSuccess)
-		return PDFHummus::eFailure;
+	if(WriteRegularOperator(19) != eSuccess)
+		return eFailure;
 
-	return WriteStemMask(inProgramCounter);
+	return WriteStemMask(inProgramCounter, inReadLimit);
 }
 
-EStatusCode CharStringType2Flattener::WriteStemMask(Byte* inProgramCounter)
+EStatusCode CharStringType2Flattener::WriteStemMask(Byte* inProgramCounter,LongFilePositionType inReadLimit)
 {
 	unsigned short maskSize = mStemsCount/8 + (mStemsCount % 8 != 0 ? 1:0);
 
-	return mWriter->Write(inProgramCounter,maskSize) != maskSize ? PDFHummus::eFailure : PDFHummus::eSuccess;
+	if(maskSize > inReadLimit) {
+		TRACE_LOG2("CharStringType2Flattener::WriteStemMask, stem mask size is %d but can only read %ld, aborting", maskSize, inReadLimit);
+		return eFailure;
+	}
+
+	return mWriter->Write(inProgramCounter,maskSize) != maskSize ? eFailure : eSuccess;
 }
 
-EStatusCode CharStringType2Flattener::Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter)
+EStatusCode CharStringType2Flattener::Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit)
 {
 	mStemsCount+= (unsigned short)(inOperandList.size() / 2);
 
-	if(WriteRegularOperator(20) != PDFHummus::eSuccess)
-		return PDFHummus::eFailure;
+	if(WriteRegularOperator(20) != eSuccess)
+		return eFailure;
 
-	return WriteStemMask(inProgramCounter);
+	return WriteStemMask(inProgramCounter, inReadLimit);
 }
 
 EStatusCode CharStringType2Flattener::Type2Rmoveto(const CharStringOperandList& inOperandList)
@@ -462,7 +467,7 @@ EStatusCode CharStringType2Flattener::Type2Roll(const CharStringOperandList& inO
 
 CharString* CharStringType2Flattener::GetLocalSubr(long inSubrIndex)
 {
-	if(WriteSubrOperator(10) != PDFHummus::eSuccess)
+	if(WriteSubrOperator(10) != eSuccess)
 		return NULL;
 
 	return mHelper->GetLocalSubr(inSubrIndex);
@@ -472,13 +477,13 @@ EStatusCode CharStringType2Flattener::WriteSubrOperator(unsigned short inOperato
 {
 	if(mOperandsToWrite.size() > 0)
 	{
-		EStatusCode status = PDFHummus::eSuccess;
+		EStatusCode status = eSuccess;
 		mOperandsToWrite.pop_back(); // pop back parameter, which is the subr index
 
 		// now continue writing all operands
 		CharStringOperandList::iterator it = mOperandsToWrite.begin();
 
-		for(; it != mOperandsToWrite.end() && PDFHummus::eSuccess == status;++it)
+		for(; it != mOperandsToWrite.end() && eSuccess == status;++it)
 			status = WriteCharStringOperand(*it);
 
 		mOperandsToWrite.clear();
@@ -491,7 +496,7 @@ EStatusCode CharStringType2Flattener::WriteSubrOperator(unsigned short inOperato
 
 CharString* CharStringType2Flattener::GetGlobalSubr(long inSubrIndex)
 {
-	if(WriteSubrOperator(29) != PDFHummus::eSuccess)
+	if(WriteSubrOperator(29) != eSuccess)
 		return NULL;
 
 	return mHelper->GetGlobalSubr(inSubrIndex);

--- a/PDFWriter/CharStringType2Flattener.h
+++ b/PDFWriter/CharStringType2Flattener.h
@@ -51,8 +51,8 @@ public:
 	virtual PDFHummus::EStatusCode Type2Return(const CharStringOperandList& inOperandList) ;
 	virtual PDFHummus::EStatusCode Type2Endchar(const CharStringOperandList& inOperandList);
 	virtual PDFHummus::EStatusCode Type2Hstemhm(const CharStringOperandList& inOperandList);
-	virtual PDFHummus::EStatusCode Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter);
-	virtual PDFHummus::EStatusCode Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter);
+	virtual PDFHummus::EStatusCode Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit);
+	virtual PDFHummus::EStatusCode Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit);
 	virtual PDFHummus::EStatusCode Type2Rmoveto(const CharStringOperandList& inOperandList);
 	virtual PDFHummus::EStatusCode Type2Hmoveto(const CharStringOperandList& inOperandList);
 	virtual PDFHummus::EStatusCode Type2Vstemhm(const CharStringOperandList& inOperandList);
@@ -96,7 +96,7 @@ private:
 	CharStringOperandList mOperandsToWrite;
 
 	PDFHummus::EStatusCode WriteRegularOperator(unsigned short inOperatorCode);
-	PDFHummus::EStatusCode WriteStemMask(Byte* inProgramCounter);
+	PDFHummus::EStatusCode WriteStemMask(Byte* inProgramCounter,LongFilePositionType inReadLimit);
 	PDFHummus::EStatusCode WriteCharStringOperand(const CharStringOperand& inOperand);
 	PDFHummus::EStatusCode WriteCharStringOperator(unsigned short inOperatorCode);
 	PDFHummus::EStatusCode WriteByte(Byte inValue);

--- a/PDFWriter/CharStringType2Interpreter.cpp
+++ b/PDFWriter/CharStringType2Interpreter.cpp
@@ -47,15 +47,16 @@ EStatusCode CharStringType2Interpreter::Intepret(const CharString& inCharStringT
 		mGotEndChar = false;
 		mStemsCount = 0;
 		mCheckedWidth = false;
+		mSubrsNesting = 0;
 		if(!inImplementationHelper)
 		{
 			TRACE_LOG("CharStringType2Interpreter::Intepret, null implementation helper passed. pass a proper pointer!!");
-			status = PDFHummus::eFailure;
+			status = eFailure;
 			break;
 		}
 
 		status = mImplementationHelper->ReadCharString(inCharStringToIntepret.mStartPosition,inCharStringToIntepret.mEndPosition,&charString);	
-		if(status != PDFHummus::eSuccess)
+		if(status != eSuccess)
 		{
 			TRACE_LOG2("CharStringType2Interpreter::Intepret, failed to read charstring starting in %lld and ending in %lld",inCharStringToIntepret.mStartPosition,inCharStringToIntepret.mEndPosition);
 			break;
@@ -72,45 +73,55 @@ EStatusCode CharStringType2Interpreter::Intepret(const CharString& inCharStringT
 
 EStatusCode CharStringType2Interpreter::ProcessCharString(Byte* inCharString,LongFilePositionType inCharStringLength)
 {
-	EStatusCode status = PDFHummus::eSuccess;
+	EStatusCode status = eSuccess;
 	Byte* pointer = inCharString;
 	bool gotEndExecutionOperator = false;
 
 	while(pointer - inCharString < inCharStringLength &&
-			PDFHummus::eSuccess == status && 
+			eSuccess == status && 
 			!gotEndExecutionOperator &&
 			!mGotEndChar)
 	{
-		if(IsOperator(pointer))
+		LongFilePositionType readLimit = inCharStringLength - (pointer - inCharString); // should be at least 1
+
+		if(IsOperator(*pointer))
 		{
-			pointer = InterpretOperator(pointer,gotEndExecutionOperator);
+			pointer = InterpretOperator(pointer,gotEndExecutionOperator, readLimit);
 			if(!pointer)
-				status = PDFHummus::eFailure;
+				status = eFailure;
 		}
 		else
-		{
-			pointer = InterpretNumber(pointer);
+		{	
+			pointer = InterpretNumber(pointer, readLimit);
 			if(!pointer)
-				status = PDFHummus::eFailure;
+				status = eFailure;
+
+			if(mOperandStack.size() > MAX_ARGUMENTS_STACK_SIZE) {
+				TRACE_LOG1("CharStringType2Interpreter::ProcessCharString, reached maximum allows arguments count - %d, aborting", mOperandStack.size());
+				status = eFailure;
+			}
 		}
 	}
 	return status;
 }
 
-bool CharStringType2Interpreter::IsOperator(Byte* inProgramCounter)
+bool CharStringType2Interpreter::IsOperator(Byte inCurrentByte)
 {
-	return  ((*inProgramCounter) <= 27) || 
-			(29 <= (*inProgramCounter) && (*inProgramCounter) <= 31);
+	return  ((inCurrentByte) <= 27) || 
+			(29 <= (inCurrentByte) && (inCurrentByte) <= 31);
 			
 }
 
 
-Byte* CharStringType2Interpreter::InterpretNumber(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretNumber(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	CharStringOperand operand;
 	Byte* newPosition = inProgramCounter;
 
-	if(28 == *newPosition)
+	if(inReadLimit < 1)
+		return NULL; // error, cant read a single byte
+
+	if(28 == *newPosition && inReadLimit >= 3)
 	{
 		operand.IsInteger = true;
 		operand.IntegerValue = (short)(
@@ -123,19 +134,19 @@ Byte* CharStringType2Interpreter::InterpretNumber(Byte* inProgramCounter)
 		operand.IntegerValue = (short)*newPosition - 139;
 		++newPosition;
 	}
-	else if(247 <= *newPosition && *newPosition <= 250)
+	else if(247 <= *newPosition && *newPosition <= 250  && inReadLimit >= 2)
 	{
 		operand.IsInteger = true;
 		operand.IntegerValue = (*newPosition - 247) * 256 + *(newPosition + 1) + 108;
 		newPosition += 2;
 	}
-	else if(251 <= *newPosition && *newPosition <= 254)
+	else if(251 <= *newPosition && *newPosition <= 254  && inReadLimit >= 2)
 	{
 		operand.IsInteger = true;
 		operand.IntegerValue = -(short)(*newPosition - 251) * 256 - *(newPosition + 1) - 108;
 		newPosition += 2;
 	}
-	else if(255 == *newPosition)
+	else if(255 == *newPosition  && inReadLimit >= 5)
 	{
 		operand.IsInteger = false;
 		operand.RealValue = (short)(((unsigned short)(*(newPosition+1)) << 8) + (*(newPosition+2)));
@@ -156,7 +167,7 @@ Byte* CharStringType2Interpreter::InterpretNumber(Byte* inProgramCounter)
 	{
 		mOperandStack.push_back(operand);
 		EStatusCode status = mImplementationHelper->Type2InterpretNumber(operand);
-		if(status != PDFHummus::eSuccess)
+		if(status != eSuccess)
 			return NULL;
 
 	}
@@ -164,180 +175,188 @@ Byte* CharStringType2Interpreter::InterpretNumber(Byte* inProgramCounter)
 	return newPosition;
 }
 
-Byte* CharStringType2Interpreter::InterpretOperator(Byte* inProgramCounter,bool& outGotEndExecutionCommand)
+Byte* CharStringType2Interpreter::InterpretOperator(Byte* inProgramCounter,bool& outGotEndExecutionCommand,LongFilePositionType inReadLimit)
 {
 	unsigned short operatorValue;
 	Byte* newPosition = inProgramCounter;
 	outGotEndExecutionCommand = false;
+
+	if(inReadLimit < 1)
+		return NULL; // error, cant read a single byte	
 	
 	if(12 == *newPosition)
 	{
+		if(inReadLimit < 2)
+			return NULL;
+
 		operatorValue = 0x0c00 + *(newPosition + 1);
 		newPosition+=2;
+		inReadLimit-=2;
 	}
 	else
 	{
 		operatorValue = *newPosition;
 		++newPosition;
+		--inReadLimit;
 	}
 
 	switch(operatorValue)
 	{
 		case 1: // hstem
 			CheckWidth();
-			newPosition = InterpretHStem(newPosition);
+			newPosition = InterpretHStem(newPosition, inReadLimit);
 			break;
 		case 3: // vstem
 			CheckWidth();
-			newPosition = InterpretVStem(newPosition);
+			newPosition = InterpretVStem(newPosition, inReadLimit);
 			break;
 		case 4: // vmoveto
 			CheckWidth();
-			newPosition = InterpretVMoveto(newPosition);
+			newPosition = InterpretVMoveto(newPosition, inReadLimit);
 			break;
 		case 5: // rlineto
-			newPosition = InterpretRLineto(newPosition);
+			newPosition = InterpretRLineto(newPosition, inReadLimit);
 			break;
 		case 6: // hlineto
-			newPosition = InterpretHLineto(newPosition);
+			newPosition = InterpretHLineto(newPosition, inReadLimit);
 			break;
 		case 7: // vlineto
-			newPosition = InterpretVLineto(newPosition);
+			newPosition = InterpretVLineto(newPosition, inReadLimit);
 			break;
 		case 8: // rrcurveto
-			newPosition = InterpretRRCurveto(newPosition);
+			newPosition = InterpretRRCurveto(newPosition, inReadLimit);
 			break;
 		case 10: // callsubr
-			newPosition = InterpretCallSubr(newPosition);
+			newPosition = InterpretCallSubr(newPosition, inReadLimit);
 			break;
 		case 11: // return
-			newPosition = InterpretReturn(newPosition);
+			newPosition = InterpretReturn(newPosition, inReadLimit);
 			outGotEndExecutionCommand = true;
 			break;
 		case 14: // endchar
 			CheckWidth();
-			newPosition = InterpretEndChar(newPosition);
+			newPosition = InterpretEndChar(newPosition, inReadLimit);
 			break;
 		case 18: // hstemhm
 			CheckWidth();
-			newPosition = InterpretHStemHM(newPosition);
+			newPosition = InterpretHStemHM(newPosition, inReadLimit);
 			break;
 		case 19: // hintmask
 			CheckWidth();
-			newPosition = InterpretHintMask(newPosition);
+			newPosition = InterpretHintMask(newPosition, inReadLimit);
 			break;
 		case 20: // cntrmask
 			CheckWidth();
-			newPosition = InterpretCntrMask(newPosition);
+			newPosition = InterpretCntrMask(newPosition, inReadLimit);
 			break;
 		case 21: // rmoveto
 			CheckWidth();
-			newPosition = InterpretRMoveto(newPosition);
+			newPosition = InterpretRMoveto(newPosition, inReadLimit);
 			break;
 		case 22: // hmoveto
 			CheckWidth();
-			newPosition = InterpretHMoveto(newPosition);
+			newPosition = InterpretHMoveto(newPosition, inReadLimit);
 			break;
 		case 23: // vstemhm
 			CheckWidth();
-			newPosition = InterpretVStemHM(newPosition);
+			newPosition = InterpretVStemHM(newPosition, inReadLimit);
 			break;
 		case 24: // rcurveline
-			newPosition = InterpretRCurveLine(newPosition);
+			newPosition = InterpretRCurveLine(newPosition, inReadLimit);
 			break;
 		case 25: // rlinecurve
-			newPosition = InterpretRLineCurve(newPosition);
+			newPosition = InterpretRLineCurve(newPosition, inReadLimit);
 			break;
 		case 26: // vvcurveto
-			newPosition = InterpretVVCurveto(newPosition);
+			newPosition = InterpretVVCurveto(newPosition, inReadLimit);
 			break;
 		case 27: // hhcurveto
-			newPosition = InterpretHHCurveto(newPosition);
+			newPosition = InterpretHHCurveto(newPosition, inReadLimit);
 			break;
 		case 29: // callgsubr
-			newPosition = InterpretCallGSubr(newPosition);
+			newPosition = InterpretCallGSubr(newPosition, inReadLimit);
 			break;
 		case 30: // vhcurveto
-			newPosition = InterpretVHCurveto(newPosition);
+			newPosition = InterpretVHCurveto(newPosition, inReadLimit);
 			break;
 		case 31: // hvcurveto
-			newPosition = InterpretHVCurveto(newPosition);
+			newPosition = InterpretHVCurveto(newPosition, inReadLimit);
 			break;
 		
 		case 0x0c00: // dotsection, depracated
 			// ignore
 			break;
 		case 0x0c03: // and
-			newPosition = InterpretAnd(newPosition);
+			newPosition = InterpretAnd(newPosition, inReadLimit);
 			break;
 		case 0x0c04: // or
-			newPosition = InterpretOr(newPosition);
+			newPosition = InterpretOr(newPosition, inReadLimit);
 			break;
 		case 0x0c05: // not
-			newPosition = InterpretNot(newPosition);
+			newPosition = InterpretNot(newPosition, inReadLimit);
 			break;
 		case 0x0c09: // abs
-			newPosition = InterpretAbs(newPosition);
+			newPosition = InterpretAbs(newPosition, inReadLimit);
 			break;
 		case 0x0c0a: // add
-			newPosition = InterpretAdd(newPosition);
+			newPosition = InterpretAdd(newPosition, inReadLimit);
 			break;
 		case 0x0c0b: // sub
-			newPosition = InterpretSub(newPosition);
+			newPosition = InterpretSub(newPosition, inReadLimit);
 			break;
 		case 0x0c0c: // div
-			newPosition = InterpretDiv(newPosition);
+			newPosition = InterpretDiv(newPosition, inReadLimit);
 			break;
 		case 0x0c0e: // neg
-			newPosition = InterpretNeg(newPosition);
+			newPosition = InterpretNeg(newPosition, inReadLimit);
 			break;
 		case 0x0c0f: // eq
-			newPosition = InterpretEq(newPosition);
+			newPosition = InterpretEq(newPosition, inReadLimit);
 			break;
 		case 0x0c12: // drop
-			newPosition = InterpretDrop(newPosition);
+			newPosition = InterpretDrop(newPosition, inReadLimit);
 			break;
 		case 0x0c14: // put
-			newPosition = InterpretPut(newPosition);
+			newPosition = InterpretPut(newPosition, inReadLimit);
 			break;
 		case 0x0c15: // get
-			newPosition = InterpretGet(newPosition);
+			newPosition = InterpretGet(newPosition, inReadLimit);
 			break;
 		case 0x0c16: // ifelse
-			newPosition = InterpretIfelse(newPosition);
+			newPosition = InterpretIfelse(newPosition, inReadLimit);
 			break;
 		case 0x0c17: // random
-			newPosition = InterpretRandom(newPosition);
+			newPosition = InterpretRandom(newPosition, inReadLimit);
 			break;
 		case 0x0c18: // mul
-			newPosition = InterpretMul(newPosition);
+			newPosition = InterpretMul(newPosition, inReadLimit);
 			break;
 		case 0x0c1a: // sqrt
-			newPosition = InterpretSqrt(newPosition);
+			newPosition = InterpretSqrt(newPosition, inReadLimit);
 			break;
 		case 0x0c1b: // dup
-			newPosition = InterpretDup(newPosition);
+			newPosition = InterpretDup(newPosition, inReadLimit);
 			break;
 		case 0x0c1c: // exch
-			newPosition = InterpretExch(newPosition);
+			newPosition = InterpretExch(newPosition, inReadLimit);
 			break;
 		case 0x0c1d: // index
-			newPosition = InterpretIndex(newPosition);
+			newPosition = InterpretIndex(newPosition, inReadLimit);
 			break;
 		case 0x0c1e: // roll
-			newPosition = InterpretRoll(newPosition);
+			newPosition = InterpretRoll(newPosition, inReadLimit);
 			break;
 		case 0x0c22: // hflex
-			newPosition = InterpretHFlex(newPosition);
+			newPosition = InterpretHFlex(newPosition, inReadLimit);
 			break;
 		case 0x0c23: // flex
-			newPosition = InterpretFlex(newPosition);
+			newPosition = InterpretFlex(newPosition, inReadLimit);
 			break;
 		case 0x0c24: // hflex1
-			newPosition = InterpretHFlex1(newPosition);
+			newPosition = InterpretHFlex1(newPosition, inReadLimit);
 			break;
 		case 0x0c25: // flex1
-			newPosition = InterpretFlex1(newPosition);
+			newPosition = InterpretFlex1(newPosition, inReadLimit);
 			break;
 	}
 	return newPosition;
@@ -353,28 +372,28 @@ void CharStringType2Interpreter::CheckWidth()
 	}
 }
 
-Byte* CharStringType2Interpreter::InterpretHStem(Byte* inProgramCounter)
-{
-	mStemsCount+= (unsigned short)(mOperandStack.size() / 2);
+EStatusCode CharStringType2Interpreter::AddStemsCount(unsigned short inBy) {
+	if(mStemsCount + inBy > MAX_STEM_HINTS_SIZE) {
+		TRACE_LOG3("CharStringType2Interpreter::AddStemsCount, about to add %d stem hintss to current %d stem hints. This will breach the upper limit of %d, aborting.", inBy, mStemsCount, MAX_STEM_HINTS_SIZE);
+		return eFailure;
+	}
+	mStemsCount+= inBy;
 
-	EStatusCode status = mImplementationHelper->Type2Hstem(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	return eSuccess;
+}
+
+Byte* CharStringType2Interpreter::InterpretHStem(Byte* inProgramCounter, LongFilePositionType inReadLimit)
+{
+	EStatusCode status = AddStemsCount((unsigned short)(mOperandStack.size() / 2));
+	if(status != eSuccess)
+		return NULL;
+
+	status = mImplementationHelper->Type2Hstem(mOperandStack);
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
-}
-
-EStatusCode CharStringType2Interpreter::ClearNFromStack(unsigned short inCount)
-{
-	if(mOperandStack.size() >= inCount)
-	{
-		for(unsigned short i=0;i<inCount;++i)
-			mOperandStack.pop_back();
-		return PDFHummus::eSuccess;
-	}
-	else
-		return PDFHummus::eFailure;
 }
 
 void CharStringType2Interpreter::ClearStack()
@@ -382,22 +401,24 @@ void CharStringType2Interpreter::ClearStack()
 	mOperandStack.clear();
 }
 
-Byte* CharStringType2Interpreter::InterpretVStem(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretVStem(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
-	mStemsCount+= (unsigned short)(mOperandStack.size() / 2);
+	EStatusCode status = AddStemsCount((unsigned short)(mOperandStack.size() / 2));
+	if(status != eSuccess)
+		return NULL;	
 
-	EStatusCode status = mImplementationHelper->Type2Vstem(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	status = mImplementationHelper->Type2Vstem(mOperandStack);
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretVMoveto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretVMoveto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Vmoveto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
@@ -405,51 +426,52 @@ Byte* CharStringType2Interpreter::InterpretVMoveto(Byte* inProgramCounter)
 	
 }
 
-Byte* CharStringType2Interpreter::InterpretRLineto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretRLineto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Rlineto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretHLineto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretHLineto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Hlineto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretVLineto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretVLineto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Vlineto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretRRCurveto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretRRCurveto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2RRCurveto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretCallSubr(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretCallSubr(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	CharString* aCharString = NULL;
 	if(mOperandStack.size() < 1)
 		return NULL;
+
 
 	aCharString = mImplementationHelper->GetLocalSubr(mOperandStack.back().IntegerValue);
 	mOperandStack.pop_back();
@@ -461,17 +483,26 @@ Byte* CharStringType2Interpreter::InterpretCallSubr(Byte* inProgramCounter)
 		
 		do
 		{
-			if(status != PDFHummus::eSuccess)
+			if(status != eSuccess)
 			{
 				TRACE_LOG2("CharStringType2Interpreter::InterpretCallSubr, failed to read charstring starting in %lld and ending in %lld",aCharString->mStartPosition,aCharString->mEndPosition);
 				break;
 			}
 			
+			++mSubrsNesting;
+			
+			if(mSubrsNesting > MAX_SUBR_NESTING_STACK_SIZE) {
+				TRACE_LOG1("CharStringType2Interpreter::InterpretCallSubr, max call stack level reached at %d. aborting", MAX_SUBR_NESTING_STACK_SIZE);
+				status = eFailure;
+				break;
+			}
+
 			status = ProcessCharString(charString,aCharString->mEndPosition - aCharString->mStartPosition);
+			--mSubrsNesting;
 		}while(false);
 
 		delete charString;
-		if(status != PDFHummus::eSuccess)
+		if(status != eSuccess)
 			return NULL;
 		else
 			return inProgramCounter;
@@ -482,19 +513,19 @@ Byte* CharStringType2Interpreter::InterpretCallSubr(Byte* inProgramCounter)
 	}
 }
 
-Byte* CharStringType2Interpreter::InterpretReturn(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretReturn(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Return(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretEndChar(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretEndChar(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Endchar(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	mGotEndChar = true;
@@ -502,122 +533,136 @@ Byte* CharStringType2Interpreter::InterpretEndChar(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretHStemHM(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretHStemHM(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
-	mStemsCount+= (unsigned short)(mOperandStack.size() / 2);
+	EStatusCode status = AddStemsCount((unsigned short)(mOperandStack.size() / 2));
+	if(status != eSuccess)
+		return NULL;
 
-	EStatusCode status = mImplementationHelper->Type2Hstemhm(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	status = mImplementationHelper->Type2Hstemhm(mOperandStack);
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretHintMask(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretHintMask(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
-	mStemsCount+= (unsigned short)(mOperandStack.size() / 2); // assuming this is a shortcut of dropping vstem if got arguments
+	EStatusCode status = AddStemsCount((unsigned short)(mOperandStack.size() / 2)); // assuming this is a shortcut of dropping vstem if got arguments
+	if(status != eSuccess)
+		return NULL;	
 
-	EStatusCode status = mImplementationHelper->Type2Hintmask(mOperandStack,inProgramCounter);
-	if(status != PDFHummus::eSuccess)
+	status = mImplementationHelper->Type2Hintmask(mOperandStack,inProgramCounter, inReadLimit);
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
-	return inProgramCounter+(mStemsCount/8 + (mStemsCount % 8 != 0 ? 1:0));
+	LongFilePositionType programCounterStemReadSize = (mStemsCount/8 + (mStemsCount % 8 != 0 ? 1:0));
+	if(programCounterStemReadSize > inReadLimit)
+		return NULL;
+	return inProgramCounter+programCounterStemReadSize;
 }
 
-Byte* CharStringType2Interpreter::InterpretCntrMask(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretCntrMask(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
-	mStemsCount+= (unsigned short)(mOperandStack.size() / 2); // assuming this is a shortcut of dropping vstem if got arguments
+	EStatusCode status = AddStemsCount((unsigned short)(mOperandStack.size() / 2)); // assuming this is a shortcut of dropping vstem if got arguments
+	if(status != eSuccess)
+		return NULL;	
 
-	EStatusCode status = mImplementationHelper->Type2Cntrmask(mOperandStack,inProgramCounter);
-	if(status != PDFHummus::eSuccess)
+	status = mImplementationHelper->Type2Cntrmask(mOperandStack,inProgramCounter, inReadLimit);
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
-	return inProgramCounter+(mStemsCount/8 + (mStemsCount % 8 != 0 ? 1:0) );
+	LongFilePositionType programCounterStemReadSize = (mStemsCount/8 + (mStemsCount % 8 != 0 ? 1:0));
+	if(programCounterStemReadSize > inReadLimit)
+		return NULL;
+	return inProgramCounter+programCounterStemReadSize;
 }
 
-Byte* CharStringType2Interpreter::InterpretRMoveto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretRMoveto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Rmoveto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretHMoveto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretHMoveto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Hmoveto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretVStemHM(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretVStemHM(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
-	mStemsCount+= (unsigned short)(mOperandStack.size() / 2);
+	EStatusCode status = AddStemsCount((unsigned short)(mOperandStack.size() / 2));
+	if(status != eSuccess)
+		return NULL;	
 
-	EStatusCode status = mImplementationHelper->Type2Vstemhm(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	status = mImplementationHelper->Type2Vstemhm(mOperandStack);
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretRCurveLine(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretRCurveLine(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Rcurveline(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretRLineCurve(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretRLineCurve(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Rlinecurve(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretVVCurveto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretVVCurveto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Vvcurveto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretHHCurveto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretHHCurveto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Hhcurveto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretCallGSubr(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretCallGSubr(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	CharString* aCharString = NULL;
 	if(mOperandStack.size() < 1)
 		return NULL;
 
+
 	aCharString = mImplementationHelper->GetGlobalSubr(mOperandStack.back().IntegerValue);
-		
 	mOperandStack.pop_back();
 
 	if(aCharString != NULL)
@@ -627,17 +672,26 @@ Byte* CharStringType2Interpreter::InterpretCallGSubr(Byte* inProgramCounter)
 		
 		do
 		{
-			if(status != PDFHummus::eSuccess)
+			if(status != eSuccess)
 			{
-				TRACE_LOG2("CharStringType2Interpreter::InterpretCallSubr, failed to read charstring starting in %lld and ending in %lld",aCharString->mStartPosition,aCharString->mEndPosition);
+				TRACE_LOG2("CharStringType2Interpreter::InterpretCallGSubr, failed to read charstring starting in %lld and ending in %lld",aCharString->mStartPosition,aCharString->mEndPosition);
 				break;
 			}
-			
+
+			++mSubrsNesting;
+
+			if(mSubrsNesting > MAX_SUBR_NESTING_STACK_SIZE) {
+				TRACE_LOG1("CharStringType2Interpreter::InterpretCallGSubr, max call stack level reached at %d. aborting", MAX_SUBR_NESTING_STACK_SIZE);
+				status = eFailure;
+				break;
+			}
+
 			status = ProcessCharString(charString,aCharString->mEndPosition - aCharString->mStartPosition);
+			--mSubrsNesting;
 		}while(false);
 
 		delete charString;
-		if(status != PDFHummus::eSuccess)
+		if(status != eSuccess)
 			return NULL;
 		else
 			return inProgramCounter;
@@ -648,30 +702,30 @@ Byte* CharStringType2Interpreter::InterpretCallGSubr(Byte* inProgramCounter)
 	}
 }
 
-Byte* CharStringType2Interpreter::InterpretVHCurveto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretVHCurveto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Vhcurveto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretHVCurveto(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretHVCurveto(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Hvcurveto(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretAnd(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretAnd(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2And(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -695,10 +749,10 @@ Byte* CharStringType2Interpreter::InterpretAnd(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretOr(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretOr(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Or(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -721,10 +775,10 @@ Byte* CharStringType2Interpreter::InterpretOr(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretNot(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretNot(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Not(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand value;
@@ -742,10 +796,10 @@ Byte* CharStringType2Interpreter::InterpretNot(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretAbs(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretAbs(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Abs(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand value;
@@ -766,10 +820,10 @@ Byte* CharStringType2Interpreter::InterpretAbs(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretAdd(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretAdd(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Add(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -801,10 +855,10 @@ Byte* CharStringType2Interpreter::InterpretAdd(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretSub(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretSub(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Sub(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -836,10 +890,10 @@ Byte* CharStringType2Interpreter::InterpretSub(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretDiv(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretDiv(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Div(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -871,10 +925,10 @@ Byte* CharStringType2Interpreter::InterpretDiv(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretNeg(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretNeg(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Neg(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand value;
@@ -895,10 +949,10 @@ Byte* CharStringType2Interpreter::InterpretNeg(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretEq(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretEq(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Eq(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -923,10 +977,10 @@ Byte* CharStringType2Interpreter::InterpretEq(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretDrop(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretDrop(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Drop(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	if(mOperandStack.size() < 1)
@@ -936,10 +990,10 @@ Byte* CharStringType2Interpreter::InterpretDrop(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretPut(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretPut(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Put(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -958,10 +1012,10 @@ Byte* CharStringType2Interpreter::InterpretPut(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretGet(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretGet(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Get(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand value;
@@ -982,10 +1036,10 @@ Byte* CharStringType2Interpreter::InterpretGet(Byte* inProgramCounter)
 		return NULL;
 }
 
-Byte* CharStringType2Interpreter::InterpretIfelse(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretIfelse(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Ifelse(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -1025,10 +1079,10 @@ Byte* CharStringType2Interpreter::InterpretIfelse(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretRandom(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretRandom(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Random(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand newOperand;
@@ -1040,10 +1094,10 @@ Byte* CharStringType2Interpreter::InterpretRandom(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretMul(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretMul(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Mul(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -1075,10 +1129,10 @@ Byte* CharStringType2Interpreter::InterpretMul(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretSqrt(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretSqrt(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Sqrt(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand value;
@@ -1096,20 +1150,23 @@ Byte* CharStringType2Interpreter::InterpretSqrt(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretDup(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretDup(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Dup(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
+
+	if(mOperandStack.size() < 1)
+		return NULL;		
 
 	mOperandStack.push_back(mOperandStack.back());
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretExch(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretExch(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Exch(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -1130,10 +1187,10 @@ Byte* CharStringType2Interpreter::InterpretExch(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretIndex(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretIndex(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Index(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand value;
@@ -1153,10 +1210,10 @@ Byte* CharStringType2Interpreter::InterpretIndex(Byte* inProgramCounter)
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretRoll(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretRoll(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Roll(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	CharStringOperand valueA;
@@ -1181,6 +1238,9 @@ Byte* CharStringType2Interpreter::InterpretRoll(Byte* inProgramCounter)
 		mOperandStack.pop_back();
 	}
 
+	if (shiftAmount != 0 && groupToShift.size() == 0) // make sure that if there's a shift, there's what to shift
+		return NULL;
+
 	if(shiftAmount > 0)
 	{
 		for(long j=0; j < shiftAmount;++j)
@@ -1196,42 +1256,41 @@ Byte* CharStringType2Interpreter::InterpretRoll(Byte* inProgramCounter)
 			groupToShift.push_back(groupToShift.front());
 			groupToShift.pop_front();
 		}
-
 	}
-	
+	// put back the rolled group
 	for(long i=0; i < itemsCount;++i)
 	{
-		mOperandStack.push_back(mOperandStack.front());
-		mOperandStack.pop_front();
+		mOperandStack.push_back(groupToShift.front());
+		groupToShift.pop_front();
 	}
 
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretHFlex(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretHFlex(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Hflex(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretFlex(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretFlex(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Flex(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
 	return inProgramCounter;
 }
 
-Byte* CharStringType2Interpreter::InterpretHFlex1(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretHFlex1(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Hflex1(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();
@@ -1239,10 +1298,10 @@ Byte* CharStringType2Interpreter::InterpretHFlex1(Byte* inProgramCounter)
 
 }
 
-Byte* CharStringType2Interpreter::InterpretFlex1(Byte* inProgramCounter)
+Byte* CharStringType2Interpreter::InterpretFlex1(Byte* inProgramCounter, LongFilePositionType inReadLimit)
 {
 	EStatusCode status = mImplementationHelper->Type2Flex1(mOperandStack);
-	if(status != PDFHummus::eSuccess)
+	if(status != eSuccess)
 		return NULL;
 
 	ClearStack();

--- a/PDFWriter/CharStringType2Interpreter.h
+++ b/PDFWriter/CharStringType2Interpreter.h
@@ -24,8 +24,11 @@
 #include "CharStringDefinitions.h"
 
 #include <vector>
+#include <list>
 
-
+#define MAX_ARGUMENTS_STACK_SIZE 48
+#define MAX_STEM_HINTS_SIZE 96
+#define MAX_SUBR_NESTING_STACK_SIZE 10
 
 typedef std::vector<CharStringOperand> CharStringOperandVector;
 
@@ -45,62 +48,63 @@ private:
 	bool mGotEndChar;
 	CharStringOperandVector mStorage;
 	bool mCheckedWidth;
+	unsigned short mSubrsNesting;
 
 
 	PDFHummus::EStatusCode ProcessCharString(Byte* inCharString,LongFilePositionType inCharStringLength);
-	bool IsOperator(Byte* inProgramCounter);
-	Byte* InterpretNumber(Byte* inProgramCounter);
-	Byte* InterpretOperator(Byte* inProgramCounter,bool& outGotEndExecutionCommand);
+	bool IsOperator(Byte inCurrentByte);
+	Byte* InterpretNumber(Byte* inProgramCounter,LongFilePositionType inReadLimit);
+	Byte* InterpretOperator(Byte* inProgramCounter,bool& outGotEndExecutionCommand,LongFilePositionType inReadLimit);
+	PDFHummus::EStatusCode AddStemsCount(unsigned short inBy);
 
-	PDFHummus::EStatusCode ClearNFromStack(unsigned short inCount);
 	void ClearStack();
 	void CheckWidth();
 
-	Byte* InterpretHStem(Byte* inProgramCounter);
-	Byte* InterpretVStem(Byte* inProgramCounter);
-	Byte* InterpretVMoveto(Byte* inProgramCounter);
-	Byte* InterpretRLineto(Byte* inProgramCounter);
-	Byte* InterpretHLineto(Byte* inProgramCounter);
-	Byte* InterpretVLineto(Byte* inProgramCounter);
-	Byte* InterpretRRCurveto(Byte* inProgramCounter);
-	Byte* InterpretCallSubr(Byte* inProgramCounter);
-	Byte* InterpretReturn(Byte* inProgramCounter);
-	Byte* InterpretEndChar(Byte* inProgramCounter);
-	Byte* InterpretHStemHM(Byte* inProgramCounter);
-	Byte* InterpretHintMask(Byte* inProgramCounter);
-	Byte* InterpretCntrMask(Byte* inProgramCounter);
-	Byte* InterpretRMoveto(Byte* inProgramCounter);
-	Byte* InterpretHMoveto(Byte* inProgramCounter);
-	Byte* InterpretVStemHM(Byte* inProgramCounter);
-	Byte* InterpretRCurveLine(Byte* inProgramCounter);
-	Byte* InterpretRLineCurve(Byte* inProgramCounter);
-	Byte* InterpretVVCurveto(Byte* inProgramCounter);
-	Byte* InterpretHHCurveto(Byte* inProgramCounter);
-	Byte* InterpretCallGSubr(Byte* inProgramCounter);
-	Byte* InterpretVHCurveto(Byte* inProgramCounter);
-	Byte* InterpretHVCurveto(Byte* inProgramCounter);
-	Byte* InterpretAnd(Byte* inProgramCounter);
-	Byte* InterpretOr(Byte* inProgramCounter);
-	Byte* InterpretNot(Byte* inProgramCounter);
-	Byte* InterpretAbs(Byte* inProgramCounter);
-	Byte* InterpretAdd(Byte* inProgramCounter);
-	Byte* InterpretSub(Byte* inProgramCounter);
-	Byte* InterpretDiv(Byte* inProgramCounter);
-	Byte* InterpretNeg(Byte* inProgramCounter);
-	Byte* InterpretEq(Byte* inProgramCounter);
-	Byte* InterpretDrop(Byte* inProgramCounter);
-	Byte* InterpretPut(Byte* inProgramCounter);
-	Byte* InterpretGet(Byte* inProgramCounter);
-	Byte* InterpretIfelse(Byte* inProgramCounter);
-	Byte* InterpretRandom(Byte* inProgramCounter);
-	Byte* InterpretMul(Byte* inProgramCounter);
-	Byte* InterpretSqrt(Byte* inProgramCounter);
-	Byte* InterpretDup(Byte* inProgramCounter);
-	Byte* InterpretExch(Byte* inProgramCounter);
-	Byte* InterpretIndex(Byte* inProgramCounter);
-	Byte* InterpretRoll(Byte* inProgramCounter);
-	Byte* InterpretHFlex(Byte* inProgramCounter);
-	Byte* InterpretFlex(Byte* inProgramCounter);
-	Byte* InterpretHFlex1(Byte* inProgramCounter);
-	Byte* InterpretFlex1(Byte* inProgramCounter);
+	Byte* InterpretHStem(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretVStem(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretVMoveto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretRLineto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretHLineto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretVLineto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretRRCurveto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretCallSubr(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretReturn(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretEndChar(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretHStemHM(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretHintMask(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretCntrMask(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretRMoveto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretHMoveto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretVStemHM(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretRCurveLine(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretRLineCurve(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretVVCurveto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretHHCurveto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretCallGSubr(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretVHCurveto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretHVCurveto(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretAnd(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretOr(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretNot(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretAbs(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretAdd(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretSub(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretDiv(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretNeg(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretEq(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretDrop(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretPut(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretGet(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretIfelse(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretRandom(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretMul(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretSqrt(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretDup(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretExch(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretIndex(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretRoll(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretHFlex(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretFlex(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretHFlex1(Byte* inProgramCounter, LongFilePositionType inReadLimit);
+	Byte* InterpretFlex1(Byte* inProgramCounter, LongFilePositionType inReadLimit);
 };

--- a/PDFWriter/CharStringType2Interpreter.h
+++ b/PDFWriter/CharStringType2Interpreter.h
@@ -26,10 +26,6 @@
 #include <vector>
 #include <list>
 
-#define MAX_ARGUMENTS_STACK_SIZE 48
-#define MAX_STEM_HINTS_SIZE 96
-#define MAX_SUBR_NESTING_STACK_SIZE 10
-
 typedef std::vector<CharStringOperand> CharStringOperandVector;
 
 class CharStringType2Interpreter

--- a/PDFWriter/CharStringType2Tracer.cpp
+++ b/PDFWriter/CharStringType2Tracer.cpp
@@ -52,7 +52,7 @@ EStatusCode CharStringType2Tracer::TraceGlyphProgram(unsigned short inFontIndex,
 
 	do
 	{
-		if(status != PDFHummus::eSuccess)
+		if(status != eSuccess)
 		{
 			TRACE_LOG("CharStringType2Tracer::Trace, Exception, cannot prepare for glyph interpretation");
 			break;
@@ -84,7 +84,7 @@ EStatusCode CharStringType2Tracer::Type2InterpretNumber(const CharStringOperand&
 		mPrimitiveWriter.WriteInteger(inOperand.IntegerValue);
 	else
 		mPrimitiveWriter.WriteDouble(inOperand.RealValue);
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Hstem(const CharStringOperandList& inOperandList)
@@ -92,7 +92,7 @@ EStatusCode CharStringType2Tracer::Type2Hstem(const CharStringOperandList& inOpe
 	mStemsCount+= (unsigned short)(inOperandList.size() / 2);
 
 	mPrimitiveWriter.WriteKeyword("hstem");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Vstem(const CharStringOperandList& inOperandList)
@@ -100,43 +100,43 @@ EStatusCode CharStringType2Tracer::Type2Vstem(const CharStringOperandList& inOpe
 	mStemsCount+= (unsigned short)(inOperandList.size() / 2);
 
 	mPrimitiveWriter.WriteKeyword("vstem");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Vmoveto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("vstem");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Rlineto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("rlineto");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Hlineto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("hlineto");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Vlineto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("vlineto");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2RRCurveto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("rrcurveto");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Return(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("return");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Endchar(const CharStringOperandList& inOperandList)
@@ -145,7 +145,7 @@ EStatusCode CharStringType2Tracer::Type2Endchar(const CharStringOperandList& inO
 	// and provides for CFFFileInput own intepreter implementation.
 
 	mPrimitiveWriter.WriteKeyword("endchar");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Hstemhm(const CharStringOperandList& inOperandList)
@@ -153,22 +153,28 @@ EStatusCode CharStringType2Tracer::Type2Hstemhm(const CharStringOperandList& inO
 	mStemsCount+= (unsigned short)(inOperandList.size() / 2);
 
 	mPrimitiveWriter.WriteKeyword("hstemhm");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
-EStatusCode CharStringType2Tracer::Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter)
+EStatusCode CharStringType2Tracer::Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit)
 {
 	mStemsCount+= (unsigned short)(inOperandList.size() / 2);
 
-	WriteStemMask(inProgramCounter);
+	if(WriteStemMask(inProgramCounter, inReadLimit) != eSuccess)
+		return eFailure;
 	mPrimitiveWriter.WriteKeyword("hintmask");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
-void CharStringType2Tracer::WriteStemMask(Byte* inProgramCounter)
+EStatusCode CharStringType2Tracer::WriteStemMask(Byte* inProgramCounter,LongFilePositionType inReadLimit)
 {
 	unsigned short maskSize = mStemsCount/8 + (mStemsCount % 8 != 0 ? 1:0);
 	char buffer[3];
+
+	if(maskSize > inReadLimit) {
+		TRACE_LOG2("CharStringType2Tracer::WriteStemMask, stem mask size is %d but can only read %ld, aborting", maskSize, inReadLimit);
+		return eFailure;
+	}
 
 	mWriter->Write((const Byte*)"(",1);
 	for(unsigned short i=0;i<maskSize;++i)
@@ -182,27 +188,29 @@ void CharStringType2Tracer::WriteStemMask(Byte* inProgramCounter)
 	}
 
 	mWriter->Write((const Byte*)")",1);
+	return eSuccess;
 }
 
-EStatusCode CharStringType2Tracer::Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter)
+EStatusCode CharStringType2Tracer::Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit)
 {
 	mStemsCount+= (unsigned short)(inOperandList.size() / 2);
 
-	WriteStemMask(inProgramCounter);
+	if(WriteStemMask(inProgramCounter, inReadLimit) != eSuccess)
+		return eFailure;
 	mPrimitiveWriter.WriteKeyword("cntrmask");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Rmoveto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("rmoveto");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Hmoveto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("hmoveto");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Vstemhm(const CharStringOperandList& inOperandList)
@@ -210,187 +218,187 @@ EStatusCode CharStringType2Tracer::Type2Vstemhm(const CharStringOperandList& inO
 	mStemsCount+= (unsigned short)(inOperandList.size() / 2);
 
 	mPrimitiveWriter.WriteKeyword("vstemhm");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Rcurveline(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("rcurveline");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Rlinecurve(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("rlinecurve");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Vvcurveto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("vvcurveto");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Hvcurveto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("hvcurveto");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Hhcurveto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("hhcurveto");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Vhcurveto(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("vhcurveto");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Hflex(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("hflex");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Hflex1(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("hflex1");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Flex(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("flex");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Flex1(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("flex1");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2And(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("and");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Or(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("or");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Not(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("not");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Abs(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("abs");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Add(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("add");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Sub(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("sub");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Div(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("div");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Neg(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("neg");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Eq(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("eq");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Drop(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("drop");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Put(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("put");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Get(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("get");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Ifelse(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("ifelse");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Random(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("random");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Mul(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("mul");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Sqrt(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("sqrt");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Dup(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("dup");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Exch(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("exch");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Index(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("index");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 EStatusCode CharStringType2Tracer::Type2Roll(const CharStringOperandList& inOperandList)
 {
 	mPrimitiveWriter.WriteKeyword("roll");
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 CharString* CharStringType2Tracer::GetLocalSubr(long inSubrIndex)

--- a/PDFWriter/CharStringType2Tracer.h
+++ b/PDFWriter/CharStringType2Tracer.h
@@ -50,8 +50,8 @@ public:
 	virtual PDFHummus::EStatusCode Type2Return(const CharStringOperandList& inOperandList) ;
 	virtual PDFHummus::EStatusCode Type2Endchar(const CharStringOperandList& inOperandList);
 	virtual PDFHummus::EStatusCode Type2Hstemhm(const CharStringOperandList& inOperandList);
-	virtual PDFHummus::EStatusCode Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter);
-	virtual PDFHummus::EStatusCode Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter);
+	virtual PDFHummus::EStatusCode Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit);
+	virtual PDFHummus::EStatusCode Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit);
 	virtual PDFHummus::EStatusCode Type2Rmoveto(const CharStringOperandList& inOperandList);
 	virtual PDFHummus::EStatusCode Type2Hmoveto(const CharStringOperandList& inOperandList);
 	virtual PDFHummus::EStatusCode Type2Vstemhm(const CharStringOperandList& inOperandList);
@@ -94,5 +94,5 @@ private:
 	PrimitiveObjectsWriter mPrimitiveWriter;
 	unsigned short mStemsCount;
 
-	void WriteStemMask(Byte* inProgramCounter);
+	PDFHummus::EStatusCode WriteStemMask(Byte* inProgramCounter,LongFilePositionType inReadLimit);
 };

--- a/PDFWriter/IType2InterpreterImplementation.h
+++ b/PDFWriter/IType2InterpreterImplementation.h
@@ -42,8 +42,8 @@ public:
 	virtual PDFHummus::EStatusCode Type2Return(const CharStringOperandList& inOperandList) =0;
 	virtual PDFHummus::EStatusCode Type2Endchar(const CharStringOperandList& inOperandList)=0;
 	virtual PDFHummus::EStatusCode Type2Hstemhm(const CharStringOperandList& inOperandList)=0;
-	virtual PDFHummus::EStatusCode Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter)=0;
-	virtual PDFHummus::EStatusCode Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter)=0;
+	virtual PDFHummus::EStatusCode Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit)=0;
+	virtual PDFHummus::EStatusCode Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit)=0;
 	virtual PDFHummus::EStatusCode Type2Rmoveto(const CharStringOperandList& inOperandList)=0;
 	virtual PDFHummus::EStatusCode Type2Hmoveto(const CharStringOperandList& inOperandList)=0;
 	virtual PDFHummus::EStatusCode Type2Vstemhm(const CharStringOperandList& inOperandList)=0;
@@ -105,8 +105,8 @@ public:
 	virtual PDFHummus::EStatusCode Type2Return(const CharStringOperandList& inOperandList) {(void) inOperandList; return PDFHummus::eSuccess;}
 	virtual PDFHummus::EStatusCode Type2Endchar(const CharStringOperandList& inOperandList){(void) inOperandList; return PDFHummus::eSuccess;}
 	virtual PDFHummus::EStatusCode Type2Hstemhm(const CharStringOperandList& inOperandList){(void) inOperandList; return PDFHummus::eSuccess;}
-	virtual PDFHummus::EStatusCode Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter){(void) inOperandList; (void) (void) inOperandList; return PDFHummus::eSuccess;}
-	virtual PDFHummus::EStatusCode Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter){return PDFHummus::eSuccess;}
+	virtual PDFHummus::EStatusCode Type2Hintmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit){(void) inOperandList; (void) (void) inOperandList; return PDFHummus::eSuccess;}
+	virtual PDFHummus::EStatusCode Type2Cntrmask(const CharStringOperandList& inOperandList,Byte* inProgramCounter,LongFilePositionType inReadLimit){return PDFHummus::eSuccess;}
 	virtual PDFHummus::EStatusCode Type2Rmoveto(const CharStringOperandList& inOperandList){(void) inOperandList; return PDFHummus::eSuccess;}
 	virtual PDFHummus::EStatusCode Type2Hmoveto(const CharStringOperandList& inOperandList){(void) inOperandList; return PDFHummus::eSuccess;}
 	virtual PDFHummus::EStatusCode Type2Vstemhm(const CharStringOperandList& inOperandList){(void) inOperandList; return PDFHummus::eSuccess;}

--- a/PDFWriter/Type1Input.cpp
+++ b/PDFWriter/Type1Input.cpp
@@ -103,7 +103,7 @@ void Type1Input::Reset()
 
 EStatusCode Type1Input::ReadType1File(IByteReaderWithPosition* inType1)
 {
-	EStatusCode status = PDFHummus::eSuccess;
+	EStatusCode status = eSuccess;
 	BoolAndString token;
 
 
@@ -112,11 +112,11 @@ EStatusCode Type1Input::ReadType1File(IByteReaderWithPosition* inType1)
 	do
 	{
 		status = mPFBDecoder.Assign(inType1);
-		if(status != PDFHummus::eSuccess)
+		if(status != eSuccess)
 			break;
 
 		// the fun about pfb decoding is that it's pretty much token based...so let's do some tokening
-		while(mPFBDecoder.NotEnded() && PDFHummus::eSuccess == status)
+		while(mPFBDecoder.NotEnded() && eSuccess == status)
 		{
 			token = mPFBDecoder.GetNextToken();
 			status = mPFBDecoder.GetInternalState();
@@ -134,7 +134,7 @@ EStatusCode Type1Input::ReadType1File(IByteReaderWithPosition* inType1)
 			if(token.second.compare("begin") == 0)
 			{
 				status = ReadFontDictionary();
-				if(status != PDFHummus::eSuccess)
+				if(status != eSuccess)
 					break;
 			}
 
@@ -144,7 +144,7 @@ EStatusCode Type1Input::ReadType1File(IByteReaderWithPosition* inType1)
 			if(token.second.compare("/Private") == 0)
 			{
 				status = ReadPrivateDictionary();
-				if(status != PDFHummus::eSuccess)
+				if(status != eSuccess)
 					break;
 			}
 			
@@ -167,10 +167,10 @@ bool Type1Input::IsComment(const std::string& inToken)
 
 EStatusCode Type1Input::ReadFontDictionary()
 {
-	EStatusCode status = PDFHummus::eSuccess;
+	EStatusCode status = eSuccess;
 	BoolAndString token;
 
-	while(mPFBDecoder.NotEnded() && PDFHummus::eSuccess == status)
+	while(mPFBDecoder.NotEnded() && eSuccess == status)
 	{
 		token = mPFBDecoder.GetNextToken();
 		status = mPFBDecoder.GetInternalState();
@@ -232,7 +232,7 @@ EStatusCode Type1Input::ReadFontDictionary()
 		if(token.second.compare("/Encoding") == 0)
 		{
 			status = ParseEncoding();
-			if(PDFHummus::eSuccess == status)
+			if(eSuccess == status)
 				CalculateReverseEncoding();
 			continue;
 		}
@@ -248,7 +248,7 @@ EStatusCode Type1Input::ReadFontDictionary()
 
 EStatusCode Type1Input::ReadFontInfoDictionary()
 {
-	EStatusCode status = PDFHummus::eSuccess;
+	EStatusCode status = eSuccess;
 	BoolAndString token;
 
   // initialize some values to defaults
@@ -256,7 +256,7 @@ EStatusCode Type1Input::ReadFontInfoDictionary()
   mFontInfoDictionary.UnderlinePosition = 0.0;
   mFontInfoDictionary.UnderlineThickness = 0.0;
   
-	while(mPFBDecoder.NotEnded() && PDFHummus::eSuccess == status)
+	while(mPFBDecoder.NotEnded() && eSuccess == status)
 	{
 		token = mPFBDecoder.GetNextToken();
 		status = mPFBDecoder.GetInternalState();
@@ -342,24 +342,24 @@ std::string Type1Input::FromPSName(const std::string& inPostScriptName)
 
 EStatusCode Type1Input::ParseDoubleArray(double* inArray,int inArraySize)
 {
-	EStatusCode status = PDFHummus::eSuccess;
+	EStatusCode status = eSuccess;
 
 	// skip the [ or {
 	BoolAndString token = mPFBDecoder.GetNextToken();
 	if(!token.first)
-		return PDFHummus::eFailure;
+		return eFailure;
 
-	for(int i=0; i < inArraySize && PDFHummus::eSuccess == status;++i)
+	for(int i=0; i < inArraySize && eSuccess == status;++i)
 	{
 		token = mPFBDecoder.GetNextToken();
-		status = token.first ? PDFHummus::eSuccess:PDFHummus::eFailure;
+		status = token.first ? eSuccess:eFailure;
 		inArray[i] = Double(token.second);
 	}
 
 	// skip the last ] or }
 	token = mPFBDecoder.GetNextToken();
 	if(!token.first)
-		return PDFHummus::eFailure;
+		return eFailure;
 
 	return status;
 
@@ -368,11 +368,11 @@ EStatusCode Type1Input::ParseDoubleArray(double* inArray,int inArraySize)
 EStatusCode Type1Input::ParseEncoding()
 {
 	BoolAndString token = mPFBDecoder.GetNextToken();
-	EStatusCode status = PDFHummus::eSuccess;
+	EStatusCode status = eSuccess;
 	int encodingIndex = 0;
 
 	if(!token.first)
-		return PDFHummus::eFailure;
+		return eFailure;
 
 	// checking for standard encoding
 	if(token.second.compare("StandardEncoding") == 0)
@@ -382,8 +382,8 @@ EStatusCode Type1Input::ParseEncoding()
 		// skip the def
 		BoolAndString token = mPFBDecoder.GetNextToken();
 		if(!token.first)
-			return PDFHummus::eFailure;
-		return PDFHummus::eSuccess;
+			return eFailure;
+		return eSuccess;
 	}
 
 	// not standard encoding, parse custom encoding
@@ -397,7 +397,7 @@ EStatusCode Type1Input::ParseEncoding()
 			break;
 	}
 	if(!token.first)
-		return PDFHummus::eFailure;
+		return eFailure;
 
 	// k. now parse the repeats of "dup index charactername put"
 	// till the first occurence of "readonly" or "def".
@@ -413,7 +413,7 @@ EStatusCode Type1Input::ParseEncoding()
 		encodingIndex = Int(token.second);
 		if(encodingIndex < 0 || encodingIndex > 255)
 		{
-			status = PDFHummus::eFailure;
+			status = eFailure;
 			break;
 		}
 		
@@ -431,8 +431,8 @@ EStatusCode Type1Input::ParseEncoding()
 		// get next row first token [dup or end]
 		token = mPFBDecoder.GetNextToken();
 	}
-	if(!token.first || status != PDFHummus::eSuccess)
-		return PDFHummus::eFailure;
+	if(!token.first || status != eSuccess)
+		return eFailure;
 
 	return status;
 }
@@ -475,11 +475,11 @@ void Type1Input::CalculateReverseEncoding()
 EStatusCode Type1Input::ReadPrivateDictionary()
 {
 
-	EStatusCode status = PDFHummus::eSuccess;
+	EStatusCode status = eSuccess;
     bool readCharString = false; // don't leave before you read CharStrings. so i'm having a little flag
 	BoolAndString token;
 
-	while(mPFBDecoder.NotEnded() && PDFHummus::eSuccess == status)
+	while(mPFBDecoder.NotEnded() && eSuccess == status)
 	{
 		token = mPFBDecoder.GetNextToken();
 		status = mPFBDecoder.GetInternalState();
@@ -601,7 +601,7 @@ EStatusCode Type1Input::ParseIntVector(std::vector<int>& inVector)
 	// skip the [ or {
 	BoolAndString token = mPFBDecoder.GetNextToken();
 	if(!token.first)
-		return PDFHummus::eFailure;
+		return eFailure;
 
 
 	while(token.first)
@@ -612,7 +612,7 @@ EStatusCode Type1Input::ParseIntVector(std::vector<int>& inVector)
 
 		inVector.push_back(Int(token.second));
 	}
-	return token.first ? PDFHummus::eSuccess:PDFHummus::eFailure;
+	return token.first ? eSuccess:eFailure;
 }
 
 EStatusCode Type1Input::ParseDoubleVector(std::vector<double>& inVector)
@@ -620,7 +620,7 @@ EStatusCode Type1Input::ParseDoubleVector(std::vector<double>& inVector)
 	// skip the [ or {
 	BoolAndString token = mPFBDecoder.GetNextToken();
 	if(!token.first)
-		return PDFHummus::eFailure;
+		return eFailure;
 
 
 	while(token.first)
@@ -631,7 +631,7 @@ EStatusCode Type1Input::ParseDoubleVector(std::vector<double>& inVector)
 
 		inVector.push_back(Double(token.second));
 	}
-	return token.first ? PDFHummus::eSuccess:PDFHummus::eFailure;
+	return token.first ? eSuccess:eFailure;
 }
 
 EStatusCode Type1Input::ParseSubrs()
@@ -641,13 +641,13 @@ EStatusCode Type1Input::ParseSubrs()
 	// get the subrs count
 	BoolAndString token = mPFBDecoder.GetNextToken();
 	if(!token.first)
-		return PDFHummus::eFailure;
+		return eFailure;
 
 	mSubrsCount = Long(token.second);
     if(mSubrsCount == 0)
     {
         mSubrs = NULL;
-        return PDFHummus::eSuccess;
+        return eSuccess;
     }
     else
         mSubrs = new Type1CharString[mSubrsCount];
@@ -663,7 +663,7 @@ EStatusCode Type1Input::ParseSubrs()
 			break;
 	}
 	if(!token.first)
-		return PDFHummus::eFailure;
+		return eFailure;
 
 	for(long i=0;i<mSubrsCount && token.first;++i)
 	{
@@ -700,7 +700,7 @@ EStatusCode Type1Input::ParseSubrs()
 		}
 	}
 	if(!token.first)
-		return PDFHummus::eFailure;
+		return eFailure;
 
 	return mPFBDecoder.GetInternalState();
 }
@@ -719,11 +719,11 @@ EStatusCode Type1Input::ParseCharstrings()
 			break;
 	}
 	if(!token.first)
-		return PDFHummus::eFailure;
+		return eFailure;
 
 	// Charstrings look like this:
 	// charactername nbytes RD ~n~binary~bytes~ ND
-	while(token.first && mPFBDecoder.GetInternalState() == PDFHummus::eSuccess)
+	while(token.first && mPFBDecoder.GetInternalState() == eSuccess)
 	{
 		token = mPFBDecoder.GetNextToken();
 
@@ -796,7 +796,7 @@ EStatusCode Type1Input::CalculateDependenciesForCharIndex(	Byte inCharStringInde
 	if(!charString)
 	{
 		TRACE_LOG("Type1Input::CalculateDependenciesForCharIndex, Exception, cannot find glyph index");
-		return PDFHummus::eFailure;
+		return eFailure;
 	}
 
 	mCurrentDependencies = &ioDependenciesInfo;
@@ -814,7 +814,7 @@ EStatusCode Type1Input::CalculateDependenciesForCharIndex(const std::string& inC
 	if(it == mCharStrings.end())
 	{
 		TRACE_LOG("Type1Input::CalculateDependenciesForCharIndex, Exception, cannot find glyph from name");
-		return PDFHummus::eFailure;
+		return eFailure;
 	}
 
 	mCurrentDependencies = &ioDependenciesInfo;
@@ -840,12 +840,17 @@ Type1CharString* Type1Input::GetSubr(long inSubrIndex)
 
 EStatusCode Type1Input::Type1Seac(const LongList& inOperandList)
 {
+	if(inOperandList.size() < 2) {
+		TRACE_LOG1("Type1Input::Type1Seac exception, there should be 2 parameters provided for seac operation but only %d provided",inOperandList.size());
+		return eFailure;		
+	}
+
 	LongList::const_reverse_iterator it = inOperandList.rbegin();
 
 	mCurrentDependencies->mCharCodes.insert((Byte)*it);
 	++it;
 	mCurrentDependencies->mCharCodes.insert((Byte)*it);
-	return PDFHummus::eSuccess;
+	return eSuccess;
 }
 
 bool Type1Input::IsOtherSubrSupported(long inOtherSubrsIndex)

--- a/PDFWriter/Type1ToType2Converter.h
+++ b/PDFWriter/Type1ToType2Converter.h
@@ -68,7 +68,7 @@ typedef std::set<Stem,StemLess> StemSet;
 typedef std::set<size_t> SizeTSet;
 typedef std::map<Stem,size_t,StemLess> StemToSizeTMap;
 
-class Type1ToType2Converter : IType1InterpreterImplementation
+class Type1ToType2Converter : public IType1InterpreterImplementation
 {
 public:
 	Type1ToType2Converter(void);


### PR DESCRIPTION
Following a recent look into type2 fonts implementation in the library i realized there's not much there by way of securing the usage of type2 and type1 fonts. they are interpreted in order to create relevant representations in and outcome pdf, but there's no checks into the validity of glyph operators within glyphs charstrings.
This can be be problematic if you are creating a PDF that includes a faulty (or even malicious) font. normally this would not be the case...you are using fonts that you know, but if you are a general purpose mechanism allowing users to submit their fonts, there's a bit of a chance that an erring font might find it's way into your mechanism.

then you would like protections from simple things like a glyph subroutine calling another one and it in turn calling back the source subroutine, which would create an endless loop. Or just reading 2 arguments from the stack for an or operator when there's just one.

hummus will now abort in such case, rather than just reading from places it shouldn't read, with a useful trace log so you know what happened.

To avoid subr endless loop i'm holding now type2 and type1 charstrings limitations, which requires a max depth of nesting of 10. There's also arguments limit (24 for type 1, 48 for type 1), and type 2 also defines a stem hint limit, so those are upheld as well, aborting in case a font breaches those limitations.

all this should protect users of the library that use fonts from unknown source a bit better.

_note that this has nothing to do with the parser, this is a purely writer MR_.

Also...found 2 errors. roll operator for type 2 and get operator for type 1 had errors in their implementations...not sure it had a really interesting effective meaning.