### PR TITLE
avoiding dual hex encoding for TJ command

### DIFF
--- a/PDFWriter/AbstractContentContext.cpp
+++ b/PDFWriter/AbstractContentContext.cpp
@@ -1152,8 +1152,6 @@ EStatusCode AbstractContentContext::WriteTextCommandWithDirectGlyphSelection(con
 			stringStream.Write((const Byte*)formattingBuffer, 1);
 			formattingBuffer[0] = (*it) & 0x00ff;
 			stringStream.Write((const Byte*)formattingBuffer, 1);
-			//SAFE_SPRINTF_2(formattingBuffer,5,"%02x%02x",((*it)>>8) & 0x00ff,(*it) & 0x00ff);
-			//stringStream.Write((const Byte*)formattingBuffer,4);
 		}
 		inTextCommand->WriteHexStringCommand(stringStream.ToString());
 	}
@@ -1246,8 +1244,10 @@ EStatusCode AbstractContentContext::TJ(const GlyphUnicodeMappingListOrDoubleList
 			{
 				for(itEncoded = itEncodedList->begin();itEncoded!= itEncodedList->end();++itEncoded)
 				{
-					SAFE_SPRINTF_2(formattingBuffer,5,"%02x%02x",((*itEncoded)>>8) & 0x00ff,(*itEncoded) & 0x00ff);
-					stringStream.Write((const Byte*)formattingBuffer,4);
+					formattingBuffer[0] = ((*itEncoded) >> 8) & 0x00ff;
+					stringStream.Write((const Byte*)formattingBuffer, 1);
+					formattingBuffer[0] = (*itEncoded) & 0x00ff;
+					stringStream.Write((const Byte*)formattingBuffer, 1);					
 				}
 				stringOrDoubleList.push_back(StringOrDouble(stringStream.ToString()));
 				stringStream.Reset();

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -100,7 +100,7 @@ endif(APPLE)
 
 # Add all the ADD_TEST for each test (reusing the create_test_sourcelist list minus the generated executable)
 set (TestsToRun ${Tests})
-remove (TestsToRun PDFWriterTesting.cpp)
+list(REMOVE_ITEM TestsToRun PDFWriterTesting.cpp)
 foreach (test ${TestsToRun})
   get_filename_component (TName ${test} NAME_WE)
   add_test (NAME ${TName} COMMAND PDFWriterTesting ${TName} ${CMAKE_CURRENT_SOURCE_DIR}/Materials ${CMAKE_BINARY_DIR}/Testing/Output)

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -100,9 +100,7 @@ endif(APPLE)
 
 # Add all the ADD_TEST for each test (reusing the create_test_sourcelist list minus the generated executable)
 set (TestsToRun ${Tests})
-list(REMOVE_ITEM TestsToRun PDFWriterTesting.cpp)
-
-message("${TestsToRun}")
+list(REMOVE_AT TestsToRun 0) # removing first item which is PDFWriterTesting. started getting a full path for it, so moved to REMOVE_AT instead of REMOVE_ITEM with the file name
 
 foreach (test ${TestsToRun})
   get_filename_component (TName ${test} NAME_WE)

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -101,6 +101,9 @@ endif(APPLE)
 # Add all the ADD_TEST for each test (reusing the create_test_sourcelist list minus the generated executable)
 set (TestsToRun ${Tests})
 list(REMOVE_ITEM TestsToRun PDFWriterTesting.cpp)
+
+message("${TestsToRun}")
+
 foreach (test ${TestsToRun})
   get_filename_component (TName ${test} NAME_WE)
   add_test (NAME ${TName} COMMAND PDFWriterTesting ${TName} ${CMAKE_CURRENT_SOURCE_DIR}/Materials ${CMAKE_BINARY_DIR}/Testing/Output)

--- a/PDFWriterTesting/UnicodeTextUsage.cpp
+++ b/PDFWriterTesting/UnicodeTextUsage.cpp
@@ -77,7 +77,19 @@ int UnicodeTextUsage(int argc, char* argv[])
 
 		EStatusCode encodingStatus = contentContext->Tj("hello \xD7\x92");
 		if (encodingStatus != PDFHummus::eSuccess)
-			cout << "Could not find some of the glyphs for this font";
+			cout << "Could not find some of the glyphs for this font Tj";
+
+		contentContext->Tm(30, 0, 0, 30, 78.4252, 562.8997);
+		StringOrDoubleList textAndPos;
+
+		textAndPos.push_back(StringOrDouble("hell"));
+		textAndPos.push_back(-50*30);
+		textAndPos.push_back(StringOrDouble("o \xD7\x92"));
+
+		encodingStatus = contentContext->TJ(textAndPos);
+		if (encodingStatus != PDFHummus::eSuccess)
+			cout << "Could not find some of the glyphs for this font using TJ";
+
 
 		// continue even if failed...want to see how it looks like
 		contentContext->ET();


### PR DESCRIPTION
To fix the effect described in https://github.com/galkahana/PDF-Writer/issues/253, drop the initial encoding to hex and just do the CID code writing.

A bug corrected for Tj long time ago didn't get to TJ. 