### PR TITLE
adding safeguards so input of oxffff glyph id isn't problematic

### DIFF
--- a/PDFWriter/TrueTypeDescendentFontWriter.cpp
+++ b/PDFWriter/TrueTypeDescendentFontWriter.cpp
@@ -24,6 +24,7 @@
 #include "TrueTypeEmbeddedFontWriter.h"
 #include "ObjectsContext.h"
 #include "IndirectObjectsReferenceRegistry.h"
+#include "Trace.h"
 
 using namespace PDFHummus;
 
@@ -55,6 +56,10 @@ EStatusCode TrueTypeDescendentFontWriter::WriteFont(	ObjectIDType inDecendentObj
 	// reset embedded font object ID (and flag...to whether it was actually embedded or not, which may 
 	// happen due to font embedding restrictions)
 	mEmbeddedFontFileObjectID = 0;
+	if(inEncodedGlyphs.back().first == 0xFFFF) {
+		TRACE_LOG("TrueTypeDescendentFontWriter::WriteFont, glyphs list includes a glyph id of 0xFFFF which is out of bounds for true type");
+		return eFailure;	
+	}
 	unsigned int subsetFontSize = inEncodedGlyphs.back().first + 1;
 
 	if (inEmbedFont)
@@ -62,7 +67,7 @@ EStatusCode TrueTypeDescendentFontWriter::WriteFont(	ObjectIDType inDecendentObj
 		TrueTypeEmbeddedFontWriter embeddedFontWriter;
 		EStatusCode status = embeddedFontWriter.WriteEmbeddedFont(inFontInfo, GetOrderedKeys(inEncodedGlyphs), inObjectsContext, mEmbeddedFontFileObjectID);
 
-		if (PDFHummus::eFailure == status)
+		if (eFailure == status)
 			return status;
 
 		// subset font size may have changed due to the inclusion of dependent glyphs

--- a/PDFWriter/TrueTypeEmbeddedFontWriter.cpp
+++ b/PDFWriter/TrueTypeEmbeddedFontWriter.cpp
@@ -154,7 +154,14 @@ EStatusCode TrueTypeEmbeddedFontWriter::CreateTrueTypeSubset(	FreeTypeFaceWrappe
 		// so - bottom line - the glyphs count will actually be 1 more than the maxium glyph index.
 		// and from here i'll just place the glyphs in their original indexes, and fill in the 
 		// vacant glyphs with empties.
-		mSubsetFontGlyphsCount = subsetGlyphIDs.back() + 1;
+		unsigned short maxGlyf = subsetGlyphIDs.back();
+		if(maxGlyf >= mTrueTypeInput.mMaxp.NumGlyphs)
+		{
+			TRACE_LOG2("TrueTypeEmbeddedFontWriter::CreateTrueTypeSubset, error, maximum requested glyph index %ld is larger than the maximum glyph index for this font which is %ld. ",maxGlyf,mTrueTypeInput.mMaxp.NumGlyphs-1);
+			status = eFailure;
+			break;
+		}
+		mSubsetFontGlyphsCount = maxGlyf + 1;
 		
 		mFontFileStream.Assign(&outFontProgram);
 		mPrimitivesWriter.SetOpenTypeStream(&mFontFileStream);


### PR DESCRIPTION
see issue #255 .

adding checks that glyph ids are not illegal. glyph id can come from user input or some error, so might cause unexpected issues. 
in descendent font checking against max possible value which is 0xffff -1, later when there's more information about the font checking against max glyph id which is glyph count - 1. glyph count in turn is unsigned short, and so this check includes the oxffff -1 range.