### PR TITLE
bug: not all true types can use winansiencoding. need to check cmaps

### DIFF
--- a/PDFWriter/AbstractWrittenFont.cpp
+++ b/PDFWriter/AbstractWrittenFont.cpp
@@ -36,9 +36,10 @@
 
 using namespace PDFHummus;
 
-AbstractWrittenFont::AbstractWrittenFont(ObjectsContext* inObjectsContext)
+AbstractWrittenFont::AbstractWrittenFont(ObjectsContext* inObjectsContext, FreeTypeFaceWrapper* inFontInfo)
 {
 	mObjectsContext = inObjectsContext;
+	mFontInfo = inFontInfo;
 	mCIDRepresentation = NULL;
 	mANSIRepresentation = NULL;
 }

--- a/PDFWriter/AbstractWrittenFont.h
+++ b/PDFWriter/AbstractWrittenFont.h
@@ -32,7 +32,7 @@ class PDFParser;
 class AbstractWrittenFont : public IWrittenFont
 {
 public:
-	AbstractWrittenFont(ObjectsContext* inObjectsContext);
+	AbstractWrittenFont(ObjectsContext* inObjectsContext, FreeTypeFaceWrapper* inFontInfo);
 	virtual ~AbstractWrittenFont(void);
 
 	virtual void AppendGlyphs(const GlyphUnicodeMappingList& inGlyphsList,
@@ -47,6 +47,7 @@ protected:
 	WrittenFontRepresentation* mCIDRepresentation;
 	WrittenFontRepresentation* mANSIRepresentation;
 	ObjectsContext* mObjectsContext;
+	FreeTypeFaceWrapper* mFontInfo;
 
 	PDFHummus::EStatusCode WriteStateInDictionary(ObjectsContext* inStateWriter,DictionaryContext* inDerivedObjectDictionary);
 	PDFHummus::EStatusCode WriteStateAfterDictionary(ObjectsContext* inStateWriter);

--- a/PDFWriter/FreeTypeFaceWrapper.cpp
+++ b/PDFWriter/FreeTypeFaceWrapper.cpp
@@ -655,11 +655,11 @@ IWrittenFont* FreeTypeFaceWrapper::CreateWrittenFontObject(ObjectsContext* inObj
 			if(FT_Get_CID_Is_Internally_CID_Keyed(mFace,&isCID) != 0)
 				isCID = false;	
 
-			result = new WrittenFontCFF(inObjectsContext,isCID != 0, inFontIsToBeEmbedded); // CFF fonts should know if font is to be embedded, as the embedding code involves re-encoding of glyphs
+			result = new WrittenFontCFF(inObjectsContext, this,isCID != 0, inFontIsToBeEmbedded); // CFF fonts should know if font is to be embedded, as the embedding code involves re-encoding of glyphs
 		}
 		else if(strcmp(fontFormat,scTrueType) == 0)
 		{
-			result = new WrittenFontTrueType(inObjectsContext);
+			result = new WrittenFontTrueType(inObjectsContext, this);
 		}
 		else
 		{

--- a/PDFWriter/IWrittenFont.h
+++ b/PDFWriter/IWrittenFont.h
@@ -61,7 +61,7 @@ public:
 	/*
 		Write a font definition using the glyphs appended.
 	*/
-	virtual PDFHummus::EStatusCode WriteFontDefinition(FreeTypeFaceWrapper& inFontInfo,bool inEmbedFont) = 0;
+	virtual PDFHummus::EStatusCode WriteFontDefinition(bool inEmbedFont) = 0;
 
 	// state read and write
 	virtual PDFHummus::EStatusCode WriteState(ObjectsContext* inStateWriter,ObjectIDType inObjectID) = 0;

--- a/PDFWriter/PDFUsedFont.cpp
+++ b/PDFWriter/PDFUsedFont.cpp
@@ -122,7 +122,7 @@ EStatusCode PDFUsedFont::WriteFontDefinition()
     if(!mWrittenFont)
         return eSuccess;
     else
-        return mWrittenFont->WriteFontDefinition(mFaceWrapper, mEmbedFont);
+        return mWrittenFont->WriteFontDefinition(mEmbedFont);
 }
 
 EStatusCode PDFUsedFont::WriteState(ObjectsContext* inStateWriter,ObjectIDType inObjectID)

--- a/PDFWriter/WrittenFontCFF.cpp
+++ b/PDFWriter/WrittenFontCFF.cpp
@@ -34,7 +34,7 @@
 
 using namespace PDFHummus;
 
-WrittenFontCFF::WrittenFontCFF(ObjectsContext* inObjectsContext,bool inIsCID, bool inFontWillBeEmbedded):AbstractWrittenFont(inObjectsContext)
+WrittenFontCFF::WrittenFontCFF(ObjectsContext* inObjectsContext, FreeTypeFaceWrapper* inFontInfo, bool inIsCID, bool inFontWillBeEmbedded):AbstractWrittenFont(inObjectsContext, inFontInfo)
 {
 	mAvailablePositionsCount = 255;
 	mFreeList.push_back(UCharAndUChar(1,255)); 
@@ -161,7 +161,7 @@ unsigned char WrittenFontCFF::AllocateFromFreeList(unsigned int inGlyph)
 	return result;
 }
 
-EStatusCode WrittenFontCFF::WriteFontDefinition(FreeTypeFaceWrapper& inFontInfo,bool inEmbedFont)
+EStatusCode WrittenFontCFF::WriteFontDefinition(bool inEmbedFont)
 {
 	EStatusCode status = PDFHummus::eSuccess;
 	do
@@ -170,7 +170,7 @@ EStatusCode WrittenFontCFF::WriteFontDefinition(FreeTypeFaceWrapper& inFontInfo,
 		{
 			CFFANSIFontWriter fontWriter;
 
-			status = fontWriter.WriteFont(inFontInfo, mANSIRepresentation, mObjectsContext, inEmbedFont);
+			status = fontWriter.WriteFont(*mFontInfo, mANSIRepresentation, mObjectsContext, inEmbedFont);
 			if(status != PDFHummus::eSuccess)
 			{
 				TRACE_LOG("WrittenFontCFF::WriteFontDefinition, Failed to write Ansi font definition");
@@ -184,7 +184,7 @@ EStatusCode WrittenFontCFF::WriteFontDefinition(FreeTypeFaceWrapper& inFontInfo,
 			CIDFontWriter fontWriter;
 			CFFDescendentFontWriter descendentFontWriter;
 
-			status = fontWriter.WriteFont(inFontInfo, mCIDRepresentation, mObjectsContext, &descendentFontWriter, inEmbedFont);
+			status = fontWriter.WriteFont(*mFontInfo, mCIDRepresentation, mObjectsContext, &descendentFontWriter, inEmbedFont);
 			if(status != PDFHummus::eSuccess)
 			{
 				TRACE_LOG("WrittenFontCFF::WriteFontDefinition, Failed to write CID font definition");

--- a/PDFWriter/WrittenFontCFF.h
+++ b/PDFWriter/WrittenFontCFF.h
@@ -33,11 +33,11 @@ typedef std::list<UCharAndUChar> UCharAndUCharList;
 class WrittenFontCFF : public AbstractWrittenFont
 {
 public:
-	WrittenFontCFF(ObjectsContext* inObjectsContext,bool inIsCID, bool inFontWillBeEmbedded);
+	WrittenFontCFF(ObjectsContext* inObjectsContext, FreeTypeFaceWrapper* inFontInfo, bool inIsCID, bool inFontWillBeEmbedded);
 	virtual ~WrittenFontCFF(void);
 
 
-	virtual PDFHummus::EStatusCode WriteFontDefinition(FreeTypeFaceWrapper& inFontInfo, bool inEmbedFont);
+	virtual PDFHummus::EStatusCode WriteFontDefinition(bool inEmbedFont);
 
 	virtual PDFHummus::EStatusCode WriteState(ObjectsContext* inStateWriter,ObjectIDType inObjectId);
 	virtual PDFHummus::EStatusCode ReadState(PDFParser* inStateReader,ObjectIDType inObjectID);

--- a/PDFWriter/WrittenFontTrueType.h
+++ b/PDFWriter/WrittenFontTrueType.h
@@ -24,16 +24,18 @@
 class WrittenFontTrueType : public AbstractWrittenFont
 {
 public:
-	WrittenFontTrueType(ObjectsContext* inObjectsContext);
+	WrittenFontTrueType(ObjectsContext* inObjectsContext, FreeTypeFaceWrapper* inFontInfo);
 	~WrittenFontTrueType(void);
 
-	virtual PDFHummus::EStatusCode WriteFontDefinition(FreeTypeFaceWrapper& inFontInfo,bool inEmbedFont);
+	virtual PDFHummus::EStatusCode WriteFontDefinition(bool inEmbedFont);
 
 	virtual PDFHummus::EStatusCode WriteState(ObjectsContext* inStateWriter,ObjectIDType inObjectId);
 	virtual PDFHummus::EStatusCode ReadState(PDFParser* inStateReader,ObjectIDType inObjectID);
 
 
 private:
+    bool fontSupportsWinAnsiEncoding;
+
 	virtual bool AddToANSIRepresentation(	const GlyphUnicodeMappingList& inGlyphsList,
 											UShortList& outEncodedCharacters);
 
@@ -43,5 +45,9 @@ private:
 
 
 	virtual unsigned short EncodeCIDGlyph(unsigned int inGlyphId);
+
+    bool AddANSICandidates(const GlyphUnicodeMappingList& inGlyphsList, UShortList& ioCandidates);
+
+
 
 };

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -67,6 +67,7 @@ create_test_sourcelist (Tests
   TIFFImageTest.cpp
   TiffSpecialsTest.cpp
   TimerTest.cpp
+  TrueTypeAnsiWriteBug.cpp
   TrueTypeTest.cpp
   TTCTest.cpp
   Type1Test.cpp

--- a/PDFWriterTesting/TrueTypeAnsiWriteBug.cpp
+++ b/PDFWriterTesting/TrueTypeAnsiWriteBug.cpp
@@ -1,0 +1,105 @@
+/*
+   Source File : CIDSetWritingCFF.cpp
+
+
+   Copyright 2011 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   
+*/
+#include "PDFWriter.h"
+#include "PDFPage.h"
+#include "PageContentContext.h"
+#include "PDFUsedFont.h"
+
+#include <iostream>
+
+#include "testing/TestIO.h"
+
+using namespace PDFHummus;
+
+
+int TrueTypeAnsiWriteBug(int argc, char* argv[])
+{
+	EStatusCode status = eSuccess;
+	PDFWriter pdfWriter;
+
+	do
+	{
+		status = pdfWriter.StartPDF(BuildRelativeOutputPath(argv,"TrueTypeAnsiWriteBug.pdf"),ePDFVersion14);
+		if(status != eSuccess)
+		{
+			cout<<"Failed to start file\n";
+			break;
+		}
+
+		PDFPage* page = new PDFPage();
+		page->SetMediaBox(PDFRectangle(0,0,595,842));
+		
+		PageContentContext* cxt = pdfWriter.StartPageContentContext(page);
+
+		AbstractContentContext::TextOptions textOptions(pdfWriter.GetFontForFile(
+																			BuildRelativeInputPath(
+                                                                            argv,
+                                                                            "fonts/HelveticaNeue.ttc")),
+																			14,
+																			AbstractContentContext::eGray,
+																			0);
+
+		cxt->WriteText(75,600,"Helvetica Neue",textOptions);
+
+ 		GlyphUnicodeMappingList guml;
+		// Helve, but with direct glyphs writing
+ 		guml.push_back(GlyphUnicodeMapping(47, 72));
+ 		guml.push_back(GlyphUnicodeMapping(76, 101));
+ 		guml.push_back(GlyphUnicodeMapping(83, 108));
+ 		guml.push_back(GlyphUnicodeMapping(93, 118));
+ 		guml.push_back(GlyphUnicodeMapping(76, 101));
+ 		cxt->BT();
+ 		cxt->k(0,0,0,1);
+ 		cxt->Tm(1,0,0,1,10,600);
+ 		cxt->Tf(textOptions.font, 14);
+ 		cxt->Tj(guml);
+ 		cxt->ET();		
+
+		status = pdfWriter.EndPageContentContext(cxt);
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to end content context\n";
+			break;
+		}
+
+		status = pdfWriter.WritePageAndRelease(page);
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to write page\n";
+			break;
+		}
+
+
+		status = pdfWriter.EndPDF();
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to end pdf\n";
+			break;
+		}
+
+	}while(false);
+
+
+	return status == eSuccess ? 0:1;
+}


### PR DESCRIPTION
To resolve #255.

In order to use winansiencoding (or in other words...non cid encoding) for true type fonts, the embedded font program must contain a method to translate the winansiencoding glyph names to glyph ids. For this to happen, there should be either 3,1 cmap encoding existing (win unicode bmp) or 1,0 cmap (mac roman). helveticaneue, for instance, does not have this table and so the library should not attempt to build a winansiencoding representation, but go straight to cid. arial.ttf does have the right cmaps and so can use it.