### PR TITLE
bug: Fix possible null pointer when /First does not exist

### DIFF
--- a/PDFWriter/PDFParser.cpp
+++ b/PDFWriter/PDFParser.cpp
@@ -1710,7 +1710,7 @@ PDFObject* PDFParser::ParseExistingInDirectStreamObject(ObjectIDType inObjectId)
 		ObjectIDType objectsCount = (ObjectIDType)streamObjectsCount->GetValue();
 
 		PDFObjectCastPtr<PDFInteger> firstStreamObjectPosition(QueryDictionaryObject(streamDictionary.GetPtr(),"First"));
-		if(!streamObjectsCount)
+		if(!firstStreamObjectPosition)
 		{
 			TRACE_LOG1("PDFParser::ParseExistingInDirectStreamObject, no First key in stream dictionary %ld",objectStreamID);
 			status = PDFHummus::eFailure;


### PR DESCRIPTION
Seems to be a typo, otherwise this can lead to the following null pointer when /First does not exist.

```
Program received signal SIGSEGV, Segmentation fault.
0x0000555555789696 in PDFInteger::GetValue (this=0x0) at PDF-Writer/PDFWriter/PDFInteger.cpp:34
34		return mValue;

#0  0x0000555555789696 in PDFInteger::GetValue (this=0x0)
    at PDF-Writer/PDFWriter/PDFInteger.cpp:34
#1  0x000055555574de05 in PDFParser::ParseExistingInDirectStreamObject (this=0x7ffff5d09060, inObjectId=10)
    at PDF-Writer/PDFWriter/PDFParser.cpp:1762
#2  0x000055555574ad36 in PDFParser::ParseNewObject (this=0x7ffff5d09060, inObjectId=10)
    at PDF-Writer/PDFWriter/PDFParser.cpp:730
#3  0x000055555573fed6 in PDFParser::ParsePagesObjectIDs (this=0x7ffff5d09060)
    at PDF-Writer/PDFWriter/PDFParser.cpp:848
#4  0x000055555573b6a1 in PDFParser::StartPDFParsing (this=0x7ffff5d09060, inSourceStream=0x7ffff5d09020, inOptions=...)
    at PDF-Writer/PDFWriter/PDFParser.cpp:139
```