### PR TITLE
conf: setup to allow building libtiff to support ia32 envs in node

### DIFF
--- a/LibTiff/binding.gyp
+++ b/LibTiff/binding.gyp
@@ -30,6 +30,11 @@
                     "defines": [
                         'HAVE_UNISTD_H=1'
                     ]
+                }],
+                ['target_arch == "ia32"', {
+                    "defines": [
+                        'SIZEOF_SIZE_T=4'
+                    ]
                 }]
             ],     
             'include_dirs': [

--- a/LibTiff/tif_config.h
+++ b/LibTiff/tif_config.h
@@ -45,8 +45,10 @@
 /* Define to the home page for this package. */
 #define PACKAGE_URL ""
 
-/* Size of size_t */
+/* Size of size_t, allowing external override */
+#ifndef SIZEOF_SIZE_T
 #define SIZEOF_SIZE_T 8
+#endif
 
 
 /** Maximum number of TIFF IFDs that libtiff can iterate through in a file. */


### PR DESCRIPTION
update pdfwriter per node setup for ia32 supporting config for libtiff