### PR TITLE
feat: properly treat errors from recording out of bounds positions in very large files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,6 +69,24 @@
         "variant": "cpp",
         "algorithm": "cpp",
         "tiffio.h": "c",
-        "utility": "cpp"
+        "utility": "cpp",
+        "bit": "cpp",
+        "charconv": "cpp",
+        "format": "cpp",
+        "iterator": "cpp",
+        "xfacet": "cpp",
+        "xiosbase": "cpp",
+        "xlocale": "cpp",
+        "xlocbuf": "cpp",
+        "xlocinfo": "cpp",
+        "xlocmes": "cpp",
+        "xlocmon": "cpp",
+        "xlocnum": "cpp",
+        "xloctime": "cpp",
+        "xmemory": "cpp",
+        "xstring": "cpp",
+        "xtr1common": "cpp",
+        "xtree": "cpp",
+        "xutility": "cpp"
     }
 }

--- a/PDFWriter/ANSIFontWriter.h
+++ b/PDFWriter/ANSIFontWriter.h
@@ -62,8 +62,8 @@ private:
 	void WriteWidths(DictionaryContext* inFontContext);
 	void CalculateDifferences();
 	void WriteEncoding(DictionaryContext* inFontContext);
-	void WriteEncodingDictionary();
-	void WriteToUnicodeMap(ObjectIDType inToUnicodeMap);
+	PDFHummus::EStatusCode WriteEncodingDictionary();
+	PDFHummus::EStatusCode WriteToUnicodeMap(ObjectIDType inToUnicodeMap);
 	void WriteGlyphEntry(IByteWriter* inWriter,unsigned short inEncodedCharacter,const ULongVector& inUnicodeValues);
 
 	FreeTypeFaceWrapper* mFontInfo;

--- a/PDFWriter/AbstractContentContext.cpp
+++ b/PDFWriter/AbstractContentContext.cpp
@@ -243,6 +243,7 @@ unsigned long AbstractContentContext::ColorValueForName(const std::string& inCol
 AbstractContentContext::AbstractContentContext(PDFHummus::DocumentContext* inDocumentContext)
 {
 	mDocumentContext = inDocumentContext;
+	mCurrentStatusCode = eSuccess;
 }
 
 AbstractContentContext::~AbstractContentContext(void)
@@ -261,9 +262,9 @@ void AbstractContentContext::AssertProcsetAvailable(const std::string& inProcset
 
 
 static const std::string scAddRectangleToPath = "re";
-void AbstractContentContext::re(double inLeft,double inBottom, double inWidth,double inHeight)
+EStatusCode AbstractContentContext::re(double inLeft,double inBottom, double inWidth,double inHeight)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inLeft);
@@ -271,114 +272,127 @@ void AbstractContentContext::re(double inLeft,double inBottom, double inWidth,do
 	mPrimitiveWriter.WriteDouble(inWidth);
 	mPrimitiveWriter.WriteDouble(inHeight);
 	mPrimitiveWriter.WriteKeyword(scAddRectangleToPath);
+	return GetCurrentStatusCode();
 }
 
 static const std::string scFill = "f";
-void AbstractContentContext::f()
+EStatusCode AbstractContentContext::f()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword(scFill);
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::S()
+EStatusCode AbstractContentContext::S()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("S");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::s()
+EStatusCode AbstractContentContext::s()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("s");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::F()
+EStatusCode AbstractContentContext::F()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("F");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::fStar()
+EStatusCode AbstractContentContext::fStar()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("f*");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::B()
+EStatusCode AbstractContentContext::B()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("B");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::BStar()
+EStatusCode AbstractContentContext::BStar()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("B*");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::b()
+EStatusCode AbstractContentContext::b()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("b");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::bStar()
+EStatusCode AbstractContentContext::bStar()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("b*");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::n()
+EStatusCode AbstractContentContext::n()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("n");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::m(double inX,double inY)
+EStatusCode AbstractContentContext::m(double inX,double inY)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inX);
 	mPrimitiveWriter.WriteDouble(inY);
 	mPrimitiveWriter.WriteKeyword("m");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::l(double inX,double inY)
+EStatusCode AbstractContentContext::l(double inX,double inY)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inX);
 	mPrimitiveWriter.WriteDouble(inY);
 	mPrimitiveWriter.WriteKeyword("l");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::c(	double inX1,double inY1, 
+EStatusCode AbstractContentContext::c(	double inX1,double inY1, 
 							double inX2, double inY2, 
 							double inX3, double inY3)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inX1);
@@ -388,12 +402,13 @@ void AbstractContentContext::c(	double inX1,double inY1,
 	mPrimitiveWriter.WriteDouble(inX3);
 	mPrimitiveWriter.WriteDouble(inY3);
 	mPrimitiveWriter.WriteKeyword("c");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::v(	double inX2,double inY2, 
+EStatusCode AbstractContentContext::v(	double inX2,double inY2, 
 							double inX3, double inY3)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inX2);
@@ -401,12 +416,13 @@ void AbstractContentContext::v(	double inX2,double inY2,
 	mPrimitiveWriter.WriteDouble(inX3);
 	mPrimitiveWriter.WriteDouble(inY3);
 	mPrimitiveWriter.WriteKeyword("v");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::y(	double inX1,double inY1, 
+EStatusCode AbstractContentContext::y(	double inX1,double inY1, 
 							double inX3, double inY3)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inX1);
@@ -414,19 +430,21 @@ void AbstractContentContext::y(	double inX1,double inY1,
 	mPrimitiveWriter.WriteDouble(inX3);
 	mPrimitiveWriter.WriteDouble(inY3);
 	mPrimitiveWriter.WriteKeyword("y");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::h()
+EStatusCode AbstractContentContext::h()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("h");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::q()
+EStatusCode AbstractContentContext::q()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("q");
@@ -435,11 +453,13 @@ void AbstractContentContext::q()
     IContentContextListenerSet::iterator it = mListeners.begin();
     for(; it != mListeners.end();++it)
         (*it)->Onq(this);
+
+	return GetCurrentStatusCode();
 }
 
 EStatusCode AbstractContentContext::Q()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("Q");
@@ -449,12 +469,12 @@ EStatusCode AbstractContentContext::Q()
     for(; it != mListeners.end();++it)
         (*it)->OnQ(this);
     
-    return status;
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::cm(double inA, double inB, double inC, double inD, double inE, double inF)
+EStatusCode AbstractContentContext::cm(double inA, double inB, double inC, double inD, double inE, double inF)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inA);
@@ -464,47 +484,52 @@ void AbstractContentContext::cm(double inA, double inB, double inC, double inD, 
 	mPrimitiveWriter.WriteDouble(inE);
 	mPrimitiveWriter.WriteDouble(inF);
 	mPrimitiveWriter.WriteKeyword("cm");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::w(double inLineWidth)
+EStatusCode AbstractContentContext::w(double inLineWidth)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inLineWidth);
 	mPrimitiveWriter.WriteKeyword("w");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::J(int inLineCapStyle)
+EStatusCode AbstractContentContext::J(int inLineCapStyle)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteInteger(inLineCapStyle);
 	mPrimitiveWriter.WriteKeyword("J");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::j(int inLineJoinStyle)
+EStatusCode AbstractContentContext::j(int inLineJoinStyle)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteInteger(inLineJoinStyle);
 	mPrimitiveWriter.WriteKeyword("j");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::M(double inMiterLimit)
+EStatusCode AbstractContentContext::M(double inMiterLimit)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inMiterLimit);
 	mPrimitiveWriter.WriteKeyword("M");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::d(double* inDashArray, int inDashArrayLength, double inDashPhase)
+EStatusCode AbstractContentContext::d(double* inDashArray, int inDashArrayLength, double inDashPhase)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.StartArray();
@@ -513,177 +538,195 @@ void AbstractContentContext::d(double* inDashArray, int inDashArrayLength, doubl
 	mPrimitiveWriter.EndArray(eTokenSeparatorSpace);
 	mPrimitiveWriter.WriteDouble(inDashPhase);
 	mPrimitiveWriter.WriteKeyword("d");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::ri(const std::string& inRenderingIntentName)
+EStatusCode AbstractContentContext::ri(const std::string& inRenderingIntentName)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteName(inRenderingIntentName);
 	mPrimitiveWriter.WriteKeyword("ri");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::i(int inFlatness)
+EStatusCode AbstractContentContext::i(int inFlatness)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteInteger(inFlatness);
 	mPrimitiveWriter.WriteKeyword("i");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::gs(const std::string& inGraphicStateName)
+EStatusCode AbstractContentContext::gs(const std::string& inGraphicStateName)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteName(inGraphicStateName);
 	mPrimitiveWriter.WriteKeyword("gs");
+	return GetCurrentStatusCode();
 }
 
 
-void AbstractContentContext::CS(const std::string& inColorSpaceName)
+EStatusCode AbstractContentContext::CS(const std::string& inColorSpaceName)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteName(inColorSpaceName);
 	mPrimitiveWriter.WriteKeyword("CS");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::cs(const std::string& inColorSpaceName)
+EStatusCode AbstractContentContext::cs(const std::string& inColorSpaceName)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteName(inColorSpaceName);
 	mPrimitiveWriter.WriteKeyword("cs");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::SC(double* inColorComponents, int inColorComponentsLength)
+EStatusCode AbstractContentContext::SC(double* inColorComponents, int inColorComponentsLength)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	for(int i=0;i<inColorComponentsLength;++i)
 		mPrimitiveWriter.WriteDouble(inColorComponents[i]);
 	mPrimitiveWriter.WriteKeyword("SC");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::SCN(double* inColorComponents, int inColorComponentsLength)
+EStatusCode AbstractContentContext::SCN(double* inColorComponents, int inColorComponentsLength)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	for(int i=0;i<inColorComponentsLength;++i)
 		mPrimitiveWriter.WriteDouble(inColorComponents[i]);
 	mPrimitiveWriter.WriteKeyword("SCN");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::SCN(double* inColorComponents, int inColorComponentsLength,const std::string& inPatternName)
+EStatusCode AbstractContentContext::SCN(double* inColorComponents, int inColorComponentsLength,const std::string& inPatternName)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	for(int i=0;i<inColorComponentsLength;++i)
 		mPrimitiveWriter.WriteDouble(inColorComponents[i]);
 	mPrimitiveWriter.WriteName(inPatternName);
 	mPrimitiveWriter.WriteKeyword("SCN");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::SCN(const std::string& inPatternName)
+EStatusCode AbstractContentContext::SCN(const std::string& inPatternName)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteName(inPatternName);
 	mPrimitiveWriter.WriteKeyword("SCN");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::sc(double* inColorComponents, int inColorComponentsLength)
+EStatusCode AbstractContentContext::sc(double* inColorComponents, int inColorComponentsLength)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	for(int i=0;i<inColorComponentsLength;++i)
 		mPrimitiveWriter.WriteDouble(inColorComponents[i]);
 	mPrimitiveWriter.WriteKeyword("sc");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::scn(double* inColorComponents, int inColorComponentsLength)
+EStatusCode AbstractContentContext::scn(double* inColorComponents, int inColorComponentsLength)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	for(int i=0;i<inColorComponentsLength;++i)
 		mPrimitiveWriter.WriteDouble(inColorComponents[i]);
 	mPrimitiveWriter.WriteKeyword("scn");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::scn(double* inColorComponents, int inColorComponentsLength,const std::string& inPatternName)
+EStatusCode AbstractContentContext::scn(double* inColorComponents, int inColorComponentsLength,const std::string& inPatternName)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	for(int i=0;i<inColorComponentsLength;++i)
 		mPrimitiveWriter.WriteDouble(inColorComponents[i]);
 	mPrimitiveWriter.WriteName(inPatternName);
 	mPrimitiveWriter.WriteKeyword("scn");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::scn(const std::string& inPatternName)
+EStatusCode AbstractContentContext::scn(const std::string& inPatternName)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteName(inPatternName);
 	mPrimitiveWriter.WriteKeyword("scn");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::G(double inGray)
+EStatusCode AbstractContentContext::G(double inGray)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inGray);
 	mPrimitiveWriter.WriteKeyword("G");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::g(double inGray)
+EStatusCode AbstractContentContext::g(double inGray)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inGray);
 	mPrimitiveWriter.WriteKeyword("g");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::RG(double inR,double inG,double inB)
+EStatusCode AbstractContentContext::RG(double inR,double inG,double inB)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inR);
 	mPrimitiveWriter.WriteDouble(inG);
 	mPrimitiveWriter.WriteDouble(inB);
 	mPrimitiveWriter.WriteKeyword("RG");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::rg(double inR,double inG,double inB)
+EStatusCode AbstractContentContext::rg(double inR,double inG,double inB)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inR);
 	mPrimitiveWriter.WriteDouble(inG);
 	mPrimitiveWriter.WriteDouble(inB);
 	mPrimitiveWriter.WriteKeyword("rg");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::K(double inC,double inM,double inY,double inK)
+EStatusCode AbstractContentContext::K(double inC,double inM,double inY,double inK)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inC);
@@ -691,11 +734,12 @@ void AbstractContentContext::K(double inC,double inM,double inY,double inK)
 	mPrimitiveWriter.WriteDouble(inY);
 	mPrimitiveWriter.WriteDouble(inK);
 	mPrimitiveWriter.WriteKeyword("K");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::k(double inC,double inM,double inY,double inK)
+EStatusCode AbstractContentContext::k(double inC,double inM,double inY,double inK)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteDouble(inC);
@@ -703,76 +747,84 @@ void AbstractContentContext::k(double inC,double inM,double inY,double inK)
 	mPrimitiveWriter.WriteDouble(inY);
 	mPrimitiveWriter.WriteDouble(inK);
 	mPrimitiveWriter.WriteKeyword("k");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::W()
+EStatusCode AbstractContentContext::W()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("W");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::WStar()
+EStatusCode AbstractContentContext::WStar()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteKeyword("W*");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::Do(const std::string& inXObjectName)
+EStatusCode AbstractContentContext::Do(const std::string& inXObjectName)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 
 	mPrimitiveWriter.WriteName(inXObjectName);	
 	mPrimitiveWriter.WriteKeyword("Do");	
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::Tc(double inCharacterSpace)
+EStatusCode AbstractContentContext::Tc(double inCharacterSpace)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteDouble(inCharacterSpace);
 	mPrimitiveWriter.WriteKeyword("Tc");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::Tw(double inWordSpace)
+EStatusCode AbstractContentContext::Tw(double inWordSpace)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteDouble(inWordSpace);
 	mPrimitiveWriter.WriteKeyword("Tw");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::Tz(int inHorizontalScaling)
+EStatusCode AbstractContentContext::Tz(int inHorizontalScaling)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteInteger(inHorizontalScaling);
 	mPrimitiveWriter.WriteKeyword("Tz");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::TL(double inTextLeading)
+EStatusCode AbstractContentContext::TL(double inTextLeading)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteDouble(inTextLeading);
 	mPrimitiveWriter.WriteKeyword("TL");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::TfLow(const std::string& inFontName,double inFontSize)
+EStatusCode AbstractContentContext::TfLow(const std::string& inFontName,double inFontSize)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
@@ -782,71 +834,78 @@ void AbstractContentContext::TfLow(const std::string& inFontName,double inFontSi
 
 	mGraphicStack.GetCurrentState().mPlacedFontName = inFontName;
 	mGraphicStack.GetCurrentState().mPlacedFontSize = inFontSize;
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::Tr(int inRenderingMode)
+EStatusCode AbstractContentContext::Tr(int inRenderingMode)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteInteger(inRenderingMode);
 	mPrimitiveWriter.WriteKeyword("Tr");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::Ts(double inFontRise)
+EStatusCode AbstractContentContext::Ts(double inFontRise)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteDouble(inFontRise);
 	mPrimitiveWriter.WriteKeyword("Ts");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::BT()
+EStatusCode AbstractContentContext::BT()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteKeyword("BT");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::ET()
+EStatusCode AbstractContentContext::ET()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteKeyword("ET");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::Td(double inTx, double inTy)
+EStatusCode AbstractContentContext::Td(double inTx, double inTy)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteDouble(inTx);
 	mPrimitiveWriter.WriteDouble(inTy);
 	mPrimitiveWriter.WriteKeyword("Td");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::TD(double inTx, double inTy)
+EStatusCode AbstractContentContext::TD(double inTx, double inTy)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteDouble(inTx);
 	mPrimitiveWriter.WriteDouble(inTy);
 	mPrimitiveWriter.WriteKeyword("TD");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::Tm(double inA, double inB, double inC, double inD, double inE, double inF)
+EStatusCode AbstractContentContext::Tm(double inA, double inB, double inC, double inD, double inE, double inF)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
@@ -857,63 +916,69 @@ void AbstractContentContext::Tm(double inA, double inB, double inC, double inD, 
 	mPrimitiveWriter.WriteDouble(inE);
 	mPrimitiveWriter.WriteDouble(inF);
 	mPrimitiveWriter.WriteKeyword("Tm");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::TStar()
+EStatusCode AbstractContentContext::TStar()
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteKeyword("T*");
+	return GetCurrentStatusCode();
 }
 
 
-void AbstractContentContext::TjLow(const std::string& inText)
+EStatusCode AbstractContentContext::TjLow(const std::string& inText)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteLiteralString(inText);
 	mPrimitiveWriter.WriteKeyword("Tj");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::TjHexLow(const std::string& inText)
+EStatusCode AbstractContentContext::TjHexLow(const std::string& inText)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteHexString(inText);
 	mPrimitiveWriter.WriteKeyword("Tj");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::QuoteLow(const std::string& inText)
+EStatusCode AbstractContentContext::QuoteLow(const std::string& inText)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteLiteralString(inText);
 	mPrimitiveWriter.WriteKeyword("'");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::QuoteHexLow(const std::string& inText)
+EStatusCode AbstractContentContext::QuoteHexLow(const std::string& inText)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
 	mPrimitiveWriter.WriteHexString(inText);
 	mPrimitiveWriter.WriteKeyword("Quote");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::DoubleQuoteLow(	double inWordSpacing, 
+EStatusCode AbstractContentContext::DoubleQuoteLow(	double inWordSpacing, 
 											double inCharacterSpacing, 
 											const std::string& inText)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
@@ -921,11 +986,12 @@ void AbstractContentContext::DoubleQuoteLow(	double inWordSpacing,
 	mPrimitiveWriter.WriteDouble(inCharacterSpacing);
 	mPrimitiveWriter.WriteLiteralString(inText);
 	mPrimitiveWriter.WriteKeyword("\"");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::DoubleQuoteHexLow(double inWordSpacing, double inCharacterSpacing, const std::string& inText)
+EStatusCode AbstractContentContext::DoubleQuoteHexLow(double inWordSpacing, double inCharacterSpacing, const std::string& inText)
 {
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
@@ -933,12 +999,13 @@ void AbstractContentContext::DoubleQuoteHexLow(double inWordSpacing, double inCh
 	mPrimitiveWriter.WriteDouble(inCharacterSpacing);
 	mPrimitiveWriter.WriteHexString(inText);
 	mPrimitiveWriter.WriteKeyword("\"");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::TJLow(const StringOrDoubleList& inStringsAndSpacing)
+EStatusCode AbstractContentContext::TJLow(const StringOrDoubleList& inStringsAndSpacing)
 {
 	StringOrDoubleList::const_iterator it = inStringsAndSpacing.begin();
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
@@ -955,12 +1022,13 @@ void AbstractContentContext::TJLow(const StringOrDoubleList& inStringsAndSpacing
 	mPrimitiveWriter.EndArray(eTokenSeparatorSpace);
 
 	mPrimitiveWriter.WriteKeyword("TJ");
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::TJHexLow(const StringOrDoubleList& inStringsAndSpacing)
+EStatusCode AbstractContentContext::TJHexLow(const StringOrDoubleList& inStringsAndSpacing)
 {
 	StringOrDoubleList::const_iterator it = inStringsAndSpacing.begin();
-	RenewStreamConnection();
+	RenewStreamConnectAndStoreResult();
 	AssertProcsetAvailable(KProcsetPDF);
 	AssertProcsetAvailable(KProcsetText);
 
@@ -977,6 +1045,7 @@ void AbstractContentContext::TJHexLow(const StringOrDoubleList& inStringsAndSpac
 	mPrimitiveWriter.EndArray(eTokenSeparatorSpace);
 
 	mPrimitiveWriter.WriteKeyword("TJ");
+	return GetCurrentStatusCode();
 }
 
 void AbstractContentContext::SetCurrentFont(PDFUsedFont* inFontReference) 
@@ -1282,17 +1351,24 @@ EStatusCode AbstractContentContext::TJ(const GlyphUnicodeMappingListOrDoubleList
 	return PDFHummus::eSuccess;	
 }
 
-void AbstractContentContext::WriteFreeCode(const std::string& inFreeCode)
+EStatusCode AbstractContentContext::WriteFreeCode(const std::string& inFreeCode)
 {
-    RenewStreamConnection();
-    mPrimitiveWriter.GetWritingStream()->Write((const Byte*)(inFreeCode.c_str()),inFreeCode.length());
+    RenewStreamConnectAndStoreResult();
+	IByteWriter* stream = mPrimitiveWriter.GetWritingStream();
+	if(!!stream)
+    	stream->Write((const Byte*)(inFreeCode.c_str()),inFreeCode.length());
+	return GetCurrentStatusCode();
 }
-void AbstractContentContext::WriteFreeCode(IByteReader* inFreeCodeSource)
+
+EStatusCode AbstractContentContext::WriteFreeCode(IByteReader* inFreeCodeSource)
 {
-	RenewStreamConnection();
-    
-    OutputStreamTraits traits(mPrimitiveWriter.GetWritingStream());
-    traits.CopyToOutputStream(inFreeCodeSource);
+	RenewStreamConnectAndStoreResult();
+	IByteWriter* stream = mPrimitiveWriter.GetWritingStream();
+	if(!!stream) {
+		OutputStreamTraits traits(stream);
+		traits.CopyToOutputStream(inFreeCodeSource);
+	}    
+	return GetCurrentStatusCode();
 }
 
 void AbstractContentContext::AddContentContextListener(IContentContextListener* inExtender)
@@ -1305,21 +1381,22 @@ void AbstractContentContext::RemoveContentContextListener(IContentContextListene
     mListeners.erase(inExtender);
 }
 
-void AbstractContentContext::DrawRectangle(double inLeft,double inBottom,double inWidth,double inHeight,const GraphicOptions& inOptions)
+EStatusCode AbstractContentContext::DrawRectangle(double inLeft,double inBottom,double inWidth,double inHeight,const GraphicOptions& inOptions)
 {
 	SetupColor(inOptions);
 	if(inOptions.drawingType == eStroke)
 		w(inOptions.strokeWidth);
 	re(inLeft,inBottom,inWidth,inHeight);
 	FinishPath(inOptions);
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::DrawSquare(double inLeft,double inBottom,double inEdge,const GraphicOptions& inOptions)
+EStatusCode AbstractContentContext::DrawSquare(double inLeft,double inBottom,double inEdge,const GraphicOptions& inOptions)
 {
-	DrawRectangle(inLeft,inBottom,inEdge,inEdge,inOptions);
+	return DrawRectangle(inLeft,inBottom,inEdge,inEdge,inOptions);
 }
 
-void AbstractContentContext::DrawCircle(double inCenterX,double inCenterY,double inRadius,const GraphicOptions& inOptions)
+EStatusCode AbstractContentContext::DrawCircle(double inCenterX,double inCenterY,double inRadius,const GraphicOptions& inOptions)
 {
     const double magic = 0.551784;
     double x = inCenterX;
@@ -1335,13 +1412,14 @@ void AbstractContentContext::DrawCircle(double inCenterX,double inCenterY,double
     c(x+rmagic,y+r,x+r,y+rmagic,x+r,y);
     c(x+r,y-rmagic,x+rmagic,y-r,x,y-r);
     c(x-rmagic,y-r,x-r,y-rmagic,x-r,y);
-	FinishPath(inOptions);
+	FinishPath(inOptions);	
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::DrawPath(const DoubleAndDoublePairList& inPathPoints,const GraphicOptions& inOptions)
+EStatusCode AbstractContentContext::DrawPath(const DoubleAndDoublePairList& inPathPoints,const GraphicOptions& inOptions)
 {
 	if(inPathPoints.size() == 0)
-		return;
+		return GetCurrentStatusCode();
 
 	SetupColor(inOptions);
 	if(inOptions.drawingType == eStroke)
@@ -1353,24 +1431,25 @@ void AbstractContentContext::DrawPath(const DoubleAndDoublePairList& inPathPoint
 	for(;it!=inPathPoints.end();++it)
 		l(it->first,it->second);
 	FinishPath(inOptions);
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::SetupColor(const GraphicOptions& inOptions)
+EStatusCode AbstractContentContext::SetupColor(const GraphicOptions& inOptions)
 {
-	SetupColor(inOptions.drawingType,inOptions.colorValue,inOptions.colorSpace, inOptions.opacity);
+	return SetupColor(inOptions.drawingType,inOptions.colorValue,inOptions.colorSpace, inOptions.opacity);
 }
 
-void AbstractContentContext::SetupColor(const TextOptions& inOptions)
+EStatusCode AbstractContentContext::SetupColor(const TextOptions& inOptions)
 {
-	SetupColor(eFill,inOptions.colorValue,inOptions.colorSpace, inOptions.opacity);
+	return SetupColor(eFill,inOptions.colorValue,inOptions.colorSpace, inOptions.opacity);
 }
 
 
-void AbstractContentContext::SetupColor(EDrawingType inDrawingType,unsigned long inColorValue,EColorSpace inColorSpace, double inOpacity)
+EStatusCode AbstractContentContext::SetupColor(EDrawingType inDrawingType,unsigned long inColorValue,EColorSpace inColorSpace, double inOpacity)
 {
 	if(inDrawingType != eStroke &&
 		inDrawingType != eFill)
-		return;
+		return GetCurrentStatusCode();
 
 	SetOpacity(inOpacity);
 	switch(inColorSpace)
@@ -1411,9 +1490,10 @@ void AbstractContentContext::SetupColor(EDrawingType inDrawingType,unsigned long
 				break;
 			}
 	}
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::FinishPath(const GraphicOptions& inOptions)
+EStatusCode AbstractContentContext::FinishPath(const GraphicOptions& inOptions)
 {
 	switch(inOptions.drawingType)
 	{
@@ -1439,6 +1519,7 @@ void AbstractContentContext::FinishPath(const GraphicOptions& inOptions)
 			}
 
 	}
+	return GetCurrentStatusCode();
 }
 
 EStatusCode AbstractContentContext::EncodeWithCurrentFont(const std::string& inText,GlyphUnicodeMappingList& outGlyphsUnicodeMapping) {
@@ -1458,7 +1539,7 @@ EStatusCode AbstractContentContext::EncodeWithCurrentFont(const std::string& inT
 	return encodingStatus;
 }
 
-void AbstractContentContext::WriteText(double inX,double inY,const std::string& inText,const TextOptions& inOptions)
+EStatusCode AbstractContentContext::WriteText(double inX,double inY,const std::string& inText,const TextOptions& inOptions)
 {
 	if(inOptions.font)
 	{
@@ -1526,9 +1607,10 @@ void AbstractContentContext::WriteText(double inX,double inY,const std::string& 
 
 	// flush what glyphs are remaining in shared context
 	sharedDrawingContext.Flush();
+	return GetCurrentStatusCode();
 }
 
-void AbstractContentContext::DrawImage(double inX,double inY,const std::string& inImagePath,const ImageOptions& inOptions)
+EStatusCode AbstractContentContext::DrawImage(double inX,double inY,const std::string& inImagePath,const ImageOptions& inOptions)
 {
 	double transformation[6] = {1,0,0,1,0,0};
 
@@ -1582,12 +1664,13 @@ void AbstractContentContext::DrawImage(double inX,double inY,const std::string& 
     cm(transformation[0],transformation[1],transformation[2],transformation[3],transformation[4],transformation[5]);
     Do(GetResourcesDictionary()->AddFormXObjectMapping(result.first));
     Q();
+	return GetCurrentStatusCode();
 
 }
 
-void AbstractContentContext::SetOpacity(double inAlpha) {
+EStatusCode AbstractContentContext::SetOpacity(double inAlpha) {
 	if(inAlpha == NO_OPACITY_VALUE) // special value allowing to fallback on the current graphic state opacity value. this allows a default behavior for high level text commands
-		return;
+		return GetCurrentStatusCode();
 
     // registering the images at pdfwriter to allow optimization on image writes
     ObjectIDTypeAndBool result = mDocumentContext->GetExtGStateRegistry().RegisterExtGStateForOpacity(inAlpha);
@@ -1597,4 +1680,17 @@ void AbstractContentContext::SetOpacity(double inAlpha) {
 		ScheduleObjectEndWriteTask(mDocumentContext->GetExtGStateRegistry().CreateExtGStateForOpacityWritingTask(result.first, inAlpha));
     }
 	gs(GetResourcesDictionary()->AddExtGStateMapping(result.first));
+	return GetCurrentStatusCode();
+}
+
+
+EStatusCode AbstractContentContext::GetCurrentStatusCode() {
+	return mCurrentStatusCode;
+}
+
+PDFHummus::EStatusCode AbstractContentContext::RenewStreamConnectAndStoreResult() {
+	EStatusCode status = RenewStreamConnection();
+	if(status != eSuccess)
+		mCurrentStatusCode = status;
+	return status;
 }

--- a/PDFWriter/AbstractContentContext.h
+++ b/PDFWriter/AbstractContentContext.h
@@ -191,98 +191,103 @@ public:
 	AbstractContentContext(PDFHummus::DocumentContext* inDocumentContext);
 	virtual ~AbstractContentContext(void);
 
+	// all of the drawing operators return StatusCode, in case writing goes wrong (right now it's about maxing out on PDF files size limit of 10gbs). instead of checking right after each one you can use
+	// GetCurrentStatusCode after a series of them, to find out if a problem occured while writing them. For the sake of convenience.
+	PDFHummus::EStatusCode GetCurrentStatusCode();
+
+
 	// High level methods
-	void DrawRectangle(double inLeft,double inBottom,double inWidth,double inHeight,const GraphicOptions& inOptions=GraphicOptions());
-	void DrawSquare(double inLeft,double inBottom,double inEdge,const GraphicOptions& inOptions=GraphicOptions());
-	void DrawCircle(double inCenterX,double inCenterY,double inRadius,const GraphicOptions& inOptions=GraphicOptions());
-	void DrawPath(const DoubleAndDoublePairList& inPathPoints,const GraphicOptions& inOptions=GraphicOptions());
-	void WriteText(double inX,double inY,const std::string& inText,const TextOptions& inOptions);
+	PDFHummus::EStatusCode DrawRectangle(double inLeft,double inBottom,double inWidth,double inHeight,const GraphicOptions& inOptions=GraphicOptions());
+	PDFHummus::EStatusCode DrawSquare(double inLeft,double inBottom,double inEdge,const GraphicOptions& inOptions=GraphicOptions());
+	PDFHummus::EStatusCode DrawCircle(double inCenterX,double inCenterY,double inRadius,const GraphicOptions& inOptions=GraphicOptions());
+	PDFHummus::EStatusCode DrawPath(const DoubleAndDoublePairList& inPathPoints,const GraphicOptions& inOptions=GraphicOptions());
+	PDFHummus::EStatusCode WriteText(double inX,double inY,const std::string& inText,const TextOptions& inOptions);
 	static unsigned long ColorValueForName(const std::string& inColorName);
-	void DrawImage(double inX,double inY,const std::string& inImagePath,const ImageOptions& inOptions=ImageOptions());
+	PDFHummus::EStatusCode DrawImage(double inX,double inY,const std::string& inImagePath,const ImageOptions& inOptions=ImageOptions());
 
 
 	// PDF Operators. For explanations on the meanings of each operator read Appendix A "Operator Summary" of the PDF Reference Manual (1.7)
 	
 	// path stroke/fill
-	void b();
-	void B();
-	void bStar();
-	void BStar();
-	void s();
-	void S();
-	void f();
-	void F();
-	void fStar();
-	void n();
+	PDFHummus::EStatusCode b();
+	PDFHummus::EStatusCode B();
+	PDFHummus::EStatusCode bStar();
+	PDFHummus::EStatusCode BStar();
+	PDFHummus::EStatusCode s();
+	PDFHummus::EStatusCode S();
+	PDFHummus::EStatusCode f();
+	PDFHummus::EStatusCode F();
+	PDFHummus::EStatusCode fStar();
+	PDFHummus::EStatusCode n();
 
 	// path construction
-	void m(double inX,double inY);
-	void l(double inX,double inY);
-	void c(	double inX1,double inY1, 
+	PDFHummus::EStatusCode m(double inX,double inY);
+	PDFHummus::EStatusCode l(double inX,double inY);
+	PDFHummus::EStatusCode c(	double inX1,double inY1, 
 			double inX2, double inY2, 
 			double inX3, double inY3);
-	void v(	double inX2,double inY2, 
+	PDFHummus::EStatusCode v(	double inX2,double inY2, 
 			double inX3, double inY3);
-	void y(	double inX1,double inY1, 
+	PDFHummus::EStatusCode y(	double inX1,double inY1, 
 			double inX3, double inY3);
-	void h();
-	void re(double inLeft,double inBottom, double inWidth,double inHeight);
+	PDFHummus::EStatusCode h();
+	PDFHummus::EStatusCode re(double inLeft,double inBottom, double inWidth,double inHeight);
 
 	// graphic state
-	void q();
+	PDFHummus::EStatusCode q();
 	PDFHummus::EStatusCode Q(); // Status code returned, in case there's inbalance in "q-Q"s
-	void cm(double inA, double inB, double inC, double inD, double inE, double inF);
-	void w(double inLineWidth);
-	void J(int inLineCapStyle);
-	void j(int inLineJoinStyle);
-	void M(double inMiterLimit);
-	void d(double* inDashArray, int inDashArrayLength, double inDashPhase);
-	void ri(const std::string& inRenderingIntentName);
-	void i(int inFlatness);
-	void gs(const std::string& inGraphicStateName);
+	PDFHummus::EStatusCode cm(double inA, double inB, double inC, double inD, double inE, double inF);
+	PDFHummus::EStatusCode w(double inLineWidth);
+	PDFHummus::EStatusCode J(int inLineCapStyle);
+	PDFHummus::EStatusCode j(int inLineJoinStyle);
+	PDFHummus::EStatusCode M(double inMiterLimit);
+	PDFHummus::EStatusCode d(double* inDashArray, int inDashArrayLength, double inDashPhase);
+	PDFHummus::EStatusCode ri(const std::string& inRenderingIntentName);
+	PDFHummus::EStatusCode i(int inFlatness);
+	PDFHummus::EStatusCode gs(const std::string& inGraphicStateName);
 
 	// color operators
-	void CS(const std::string& inColorSpaceName);
-	void cs(const std::string& inColorSpaceName);
-	void SC(double* inColorComponents, int inColorComponentsLength);
-	void SCN(double* inColorComponents, int inColorComponentsLength);
-	void SCN(double* inColorComponents, int inColorComponentsLength,const std::string& inPatternName);
-	void SCN(const std::string& inPatternName);
-	void sc(double* inColorComponents, int inColorComponentsLength);
-	void scn(double* inColorComponents, int inColorComponentsLength);
-	void scn(double* inColorComponents, int inColorComponentsLength,const std::string& inPatternName);
-	void scn(const std::string& inPatternName);
-	void G(double inGray);
-	void g(double inGray);
-	void RG(double inR,double inG,double inB);
-	void rg(double inR,double inG,double inB);
-	void K(double inC,double inM,double inY,double inK);
-	void k(double inC,double inM,double inY,double inK);
+	PDFHummus::EStatusCode CS(const std::string& inColorSpaceName);
+	PDFHummus::EStatusCode cs(const std::string& inColorSpaceName);
+	PDFHummus::EStatusCode SC(double* inColorComponents, int inColorComponentsLength);
+	PDFHummus::EStatusCode SCN(double* inColorComponents, int inColorComponentsLength);
+	PDFHummus::EStatusCode SCN(double* inColorComponents, int inColorComponentsLength,const std::string& inPatternName);
+	PDFHummus::EStatusCode SCN(const std::string& inPatternName);
+	PDFHummus::EStatusCode sc(double* inColorComponents, int inColorComponentsLength);
+	PDFHummus::EStatusCode scn(double* inColorComponents, int inColorComponentsLength);
+	PDFHummus::EStatusCode scn(double* inColorComponents, int inColorComponentsLength,const std::string& inPatternName);
+	PDFHummus::EStatusCode scn(const std::string& inPatternName);
+	PDFHummus::EStatusCode G(double inGray);
+	PDFHummus::EStatusCode g(double inGray);
+	PDFHummus::EStatusCode RG(double inR,double inG,double inB);
+	PDFHummus::EStatusCode rg(double inR,double inG,double inB);
+	PDFHummus::EStatusCode K(double inC,double inM,double inY,double inK);
+	PDFHummus::EStatusCode k(double inC,double inM,double inY,double inK);
 
 	// clip operators
-	void W();
-	void WStar();
+	PDFHummus::EStatusCode W();
+	PDFHummus::EStatusCode WStar();
 
 	// XObject usage
-	void Do(const std::string& inXObjectName);
+	PDFHummus::EStatusCode Do(const std::string& inXObjectName);
 
 	// Text state operators
-	void Tc(double inCharacterSpace);
-	void Tw(double inWordSpace);
-	void Tz(int inHorizontalScaling);
-	void TL(double inTextLeading);
-	void Tr(int inRenderingMode);
-	void Ts(double inFontRise);
+	PDFHummus::EStatusCode Tc(double inCharacterSpace);
+	PDFHummus::EStatusCode Tw(double inWordSpace);
+	PDFHummus::EStatusCode Tz(int inHorizontalScaling);
+	PDFHummus::EStatusCode TL(double inTextLeading);
+	PDFHummus::EStatusCode Tr(int inRenderingMode);
+	PDFHummus::EStatusCode Ts(double inFontRise);
 
 	// Text object operators
-	void BT();
-	void ET();
+	PDFHummus::EStatusCode BT();
+	PDFHummus::EStatusCode ET();
 
 	// Text positioning operators
-	void Td(double inTx, double inTy);
-	void TD(double inTx, double inTy);
-	void Tm(double inA, double inB, double inC, double inD, double inE, double inF);
-	void TStar();
+	PDFHummus::EStatusCode Td(double inTx, double inTy);
+	PDFHummus::EStatusCode TD(double inTx, double inTy);
+	PDFHummus::EStatusCode Tm(double inA, double inB, double inC, double inD, double inE, double inF);
+	PDFHummus::EStatusCode TStar();
 
 	//
 	// Text showing operators using the library handling of fonts with unicode text using UTF 16
@@ -335,42 +340,42 @@ public:
 	// font and text usage
 
 	// Low level setting of font. for the high level version, see below
-	void TfLow(const std::string& inFontName,double inFontSize); 
+	PDFHummus::EStatusCode TfLow(const std::string& inFontName,double inFontSize); 
 
 	// first version of Tj writes the string in literal string paranthesis, 
 	// second version of Tj writes the string in hex string angle brackets
-	void TjLow(const std::string& inText);
-	void TjHexLow(const std::string& inText); 
+	PDFHummus::EStatusCode TjLow(const std::string& inText);
+	PDFHummus::EStatusCode TjHexLow(const std::string& inText); 
 
-	void QuoteLow(const std::string& inText); // matches the operator '
-	void QuoteHexLow(const std::string& inText);
+	PDFHummus::EStatusCode QuoteLow(const std::string& inText); // matches the operator '
+	PDFHummus::EStatusCode QuoteHexLow(const std::string& inText);
 
-	void DoubleQuoteLow(double inWordSpacing, double inCharacterSpacing, const std::string& inText); // matches the operator "
-	void DoubleQuoteHexLow(double inWordSpacing, double inCharacterSpacing, const std::string& inText); 
+	PDFHummus::EStatusCode DoubleQuoteLow(double inWordSpacing, double inCharacterSpacing, const std::string& inText); // matches the operator "
+	PDFHummus::EStatusCode DoubleQuoteHexLow(double inWordSpacing, double inCharacterSpacing, const std::string& inText); 
 
 	// similar to the TJ PDF command, TJ() recieves an input an array of items which
 	// can be either a string or a double
-	void TJLow(const StringOrDoubleList& inStringsAndSpacing);
-	void TJHexLow(const StringOrDoubleList& inStringsAndSpacing);
+	PDFHummus::EStatusCode TJLow(const StringOrDoubleList& inStringsAndSpacing);
+	PDFHummus::EStatusCode TJHexLow(const StringOrDoubleList& inStringsAndSpacing);
 
     // introduce free code
-    void WriteFreeCode(const std::string& inFreeCode);
-    void WriteFreeCode(IByteReader* inFreeCodeSource);
+    PDFHummus::EStatusCode WriteFreeCode(const std::string& inFreeCode);
+    PDFHummus::EStatusCode WriteFreeCode(IByteReader* inFreeCodeSource);
 
     // Extensibility
     void AddContentContextListener(IContentContextListener* inExtender);
     void RemoveContentContextListener(IContentContextListener* inExtender);
 
 	// Simplified color setup
-	void SetupColor(const GraphicOptions& inOptions);
-	void SetupColor(const TextOptions& inOptions);
-	void SetupColor(EDrawingType inDrawingType,unsigned long inColorValue,EColorSpace inColorSpace, double inOpacity);
+	PDFHummus::EStatusCode SetupColor(const GraphicOptions& inOptions);
+	PDFHummus::EStatusCode SetupColor(const TextOptions& inOptions);
+	PDFHummus::EStatusCode SetupColor(EDrawingType inDrawingType,unsigned long inColorValue,EColorSpace inColorSpace, double inOpacity);
 
 	// Opacity. sets for both fill and stroke, for simplicity sake.
 	// Alpha value is 0 to 1, where 1 is opaque and 0 is fully transparent.
 	// 255.0 is a special value which skips setting an alpha value. can be used for calling always but with a default
 	// behavior that falls back on current graphic state
-	void SetOpacity(double inAlpha);
+	PDFHummus::EStatusCode SetOpacity(double inAlpha);
 
 	// accessors for internal objects, for extending content context capabilities outside of content context
 	PrimitiveObjectsWriter& GetPrimitiveWriter() {return mPrimitiveWriter;}
@@ -393,7 +398,13 @@ protected:
 
 private:
 	// Derived classes should optionally use this method if the stream needs updating (use calls to SetPDFStreamForWrite for this purpose)
-	virtual void RenewStreamConnection() {};
+	virtual PDFHummus::EStatusCode RenewStreamConnection() {return PDFHummus::eSuccess;};
+
+	PDFHummus::EStatusCode RenewStreamConnectAndStoreResult();
+
+	// This variable holds success until an operator writing fails.
+	// This way one can write a series of operators and then check if they all succeeded.
+	PDFHummus::EStatusCode mCurrentStatusCode;
 
 
 	PrimitiveObjectsWriter mPrimitiveWriter;
@@ -410,7 +421,7 @@ private:
 	PDFHummus::EStatusCode WriteTextCommandWithDirectGlyphSelection(const GlyphUnicodeMappingList& inText,ITextCommand* inTextCommand);
 
 
-	void FinishPath(const GraphicOptions& inOptions);
+	PDFHummus::EStatusCode FinishPath(const GraphicOptions& inOptions);
 
 	PDFHummus::EStatusCode EncodeWithCurrentFont(const std::string& inText,GlyphUnicodeMappingList& outGlyphsUnicodeMapping);
 };

--- a/PDFWriter/AbstractWrittenFont.cpp
+++ b/PDFWriter/AbstractWrittenFont.cpp
@@ -351,7 +351,11 @@ EStatusCode AbstractWrittenFont::WriteWrittenFontState(WrittenFontRepresentation
 {
 	ObjectIDTypeList objectIDs;
 
-	inStateWriter->StartNewIndirectObject(inObjectID);	
+	EStatusCode status = inStateWriter->StartNewIndirectObject(inObjectID);	
+	if(status != PDFHummus::eSuccess) {
+		TRACE_LOG1("AbstractWrittenFont::WriteWrittenFontState, failed to write object for object ID = %ld",inObjectID);
+		return status;
+	}
 	DictionaryContext* writtenFontObject = inStateWriter->StartDictionary();
 
 	writtenFontObject->WriteKey("Type");
@@ -383,18 +387,22 @@ EStatusCode AbstractWrittenFont::WriteWrittenFontState(WrittenFontRepresentation
 		ObjectIDTypeList::iterator itIDs = objectIDs.begin();
 
 		it = inRepresentation->mGlyphIDToEncodedChar.begin();
-		for(; it != inRepresentation->mGlyphIDToEncodedChar.end();++it,++itIDs)
-			WriteGlyphEncodingInfoState(inStateWriter,*itIDs,it->second);
+		for(; it != inRepresentation->mGlyphIDToEncodedChar.end() && (eSuccess == status);++it,++itIDs)
+			status = WriteGlyphEncodingInfoState(inStateWriter,*itIDs,it->second);
 	}
 
-	return PDFHummus::eSuccess;
+	return status;
 }
 
-void AbstractWrittenFont::WriteGlyphEncodingInfoState(ObjectsContext* inStateWriter,
+EStatusCode AbstractWrittenFont::WriteGlyphEncodingInfoState(ObjectsContext* inStateWriter,
 													  ObjectIDType inObjectID,
 													  const GlyphEncodingInfo& inGlyphEncodingInfo)
 {
-	inStateWriter->StartNewIndirectObject(inObjectID);	
+	EStatusCode status = inStateWriter->StartNewIndirectObject(inObjectID);	
+	if(status != PDFHummus::eSuccess) {
+		TRACE_LOG1("AbstractWrittenFont::WriteGlyphEncodingInfoState, failed to write object for object ID = %ld",inObjectID);
+		return status;
+	}
 	DictionaryContext* glyphEncodingInfoObject = inStateWriter->StartDictionary();
 
 	glyphEncodingInfoObject->WriteKey("Type");
@@ -414,6 +422,8 @@ void AbstractWrittenFont::WriteGlyphEncodingInfoState(ObjectsContext* inStateWri
 
 	inStateWriter->EndDictionary(glyphEncodingInfoObject);
 	inStateWriter->EndIndirectObject();
+
+	return status;
 	
 }
 

--- a/PDFWriter/AbstractWrittenFont.h
+++ b/PDFWriter/AbstractWrittenFont.h
@@ -85,7 +85,7 @@ private:
 
 
 	PDFHummus::EStatusCode WriteWrittenFontState(WrittenFontRepresentation* inRepresentation,ObjectsContext* inStateWriter,ObjectIDType inObjectID);
-	void WriteGlyphEncodingInfoState(ObjectsContext* inStateWriter,
+	PDFHummus::EStatusCode WriteGlyphEncodingInfoState(ObjectsContext* inStateWriter,
 									 ObjectIDType inObjectId,
 									 const GlyphEncodingInfo& inGlyphEncodingInfo);
 	void ReadWrittenFontState(PDFParser* inStateReader,PDFDictionary* inState,WrittenFontRepresentation* inRepresentation);

--- a/PDFWriter/CIDFontWriter.h
+++ b/PDFWriter/CIDFontWriter.h
@@ -60,7 +60,7 @@ private:
 
 	void WriteEncoding(DictionaryContext* inFontContext);
 	void CalculateCharacterEncodingArray();
-	void WriteToUnicodeMap(ObjectIDType inToUnicodeMap);
+	PDFHummus::EStatusCode WriteToUnicodeMap(ObjectIDType inToUnicodeMap);
 	void WriteGlyphEntry(IByteWriter* inWriter,unsigned short inEncodedCharacter,const ULongVector& inUnicodeValues);
 
 };

--- a/PDFWriter/DescendentFontWriter.h
+++ b/PDFWriter/DescendentFontWriter.h
@@ -74,7 +74,7 @@ private:
 
 	void WriteWidths(const UIntAndGlyphEncodingInfoVector& inEncodedGlyphs,
 						DictionaryContext* inFontContext);
-	void WriteCIDSystemInfo(ObjectIDType inCIDSystemInfoObjectID);
+	PDFHummus::EStatusCode WriteCIDSystemInfo(ObjectIDType inCIDSystemInfoObjectID);
 	void WriteWidthsItem(bool inAllWidthsSame,const FTPosList& inWidths,unsigned short inFirstCID, unsigned short inLastCID);
-	void WriteCIDSet(unsigned int cidSetMaxGlyph);
+	PDFHummus::EStatusCode WriteCIDSet(unsigned int cidSetMaxGlyph);
 };

--- a/PDFWriter/DocumentContext.h
+++ b/PDFWriter/DocumentContext.h
@@ -417,15 +417,15 @@ namespace PDFHummus
 		void WriteHeaderComment(EPDFVersion inPDFVersion);
 		void Write4BinaryBytes();
 		PDFHummus::EStatusCode WriteCatalogObjectOfNewPDF();
-    PDFHummus::EStatusCode WriteCatalogObject(const ObjectReference& inPageTreeRootObjectReference,IDocumentContextExtender* inModifiedFileCopyContext = NULL);
+    	PDFHummus::EStatusCode WriteCatalogObject(const ObjectReference& inPageTreeRootObjectReference,IDocumentContextExtender* inModifiedFileCopyContext = NULL);
 		PDFHummus::EStatusCode WriteTrailerDictionary();
         PDFHummus::EStatusCode WriteTrailerDictionaryValues(DictionaryContext* inDictionaryContext);
 		void WriteXrefReference(LongFilePositionType inXrefTablePosition);
 		void WriteFinalEOF();
-		void WriteInfoDictionary();
-		void WriteEncryptionDictionary();
-		void WritePagesTree();
-		int WritePageTree(PageTree* inPageTreeToWrite);
+		PDFHummus::EStatusCode WriteInfoDictionary();
+		PDFHummus::EStatusCode WriteEncryptionDictionary();
+		PDFHummus::EStatusCode  WritePagesTree();
+		PDFHummus::EStatusCode WritePageTree(PageTree* inPageTreeToWrite, int& outNodesCount);
 		std::string GenerateMD5IDForFile();
 		PDFHummus::EStatusCode WriteResourcesDictionary(ResourcesDictionary& inResourcesDictionary);
         PDFHummus::EStatusCode WriteResourceDictionary(ResourcesDictionary* inResourcesDictionary,
@@ -436,12 +436,12 @@ namespace PDFHummus
 		PDFHummus::EStatusCode WriteUsedFontsDefinitions();
 		EStatusCodeAndObjectIDType WriteAnnotationAndLinkForURL(const std::string& inURL,const PDFRectangle& inLinkClickArea);
 
-		void WriteTrailerState(ObjectsContext* inStateWriter,ObjectIDType inObjectID);
+		PDFHummus::EStatusCode WriteTrailerState(ObjectsContext* inStateWriter,ObjectIDType inObjectID);
         void WriteReferenceState(ObjectsContext* inStateWriter,
                                  const ObjectReference& inReference);
-		void WriteTrailerInfoState(ObjectsContext* inStateWriter,ObjectIDType inObjectID);
+		PDFHummus::EStatusCode WriteTrailerInfoState(ObjectsContext* inStateWriter,ObjectIDType inObjectID);
 		void WriteDateState(ObjectsContext* inStateWriter,const PDFDate& inDate);
-		void WriteCatalogInformationState(ObjectsContext* inStateWriter,ObjectIDType inObjectID);
+		PDFHummus::EStatusCode WriteCatalogInformationState(ObjectsContext* inStateWriter,ObjectIDType inObjectID);
 		void ReadTrailerState(PDFParser* inStateReader,PDFDictionary* inTrailerState);
         ObjectReference GetReferenceFromState(PDFDictionary* inDictionary);
 		void ReadTrailerInfoState(PDFParser* inStateReader,PDFDictionary* inTrailerInfoState);
@@ -449,7 +449,7 @@ namespace PDFHummus
 		void ReadCatalogInformationState(PDFParser* inStateReader,PDFDictionary* inCatalogInformationState);
 
 
-		void WritePageTreeState(ObjectsContext* inStateWriter,ObjectIDType inObjectID,PageTree* inPageTree);
+		PDFHummus::EStatusCode WritePageTreeState(ObjectsContext* inStateWriter,ObjectIDType inObjectID,PageTree* inPageTree);
 		void ReadPageTreeState(PDFParser* inStateReader,PDFDictionary* inPageTreeState,PageTree* inPageTree);
 
         ObjectReference GetOriginalDocumentPageTreeRoot(PDFParser* inModifiedFileParser);

--- a/PDFWriter/EncryptionHelper.cpp
+++ b/PDFWriter/EncryptionHelper.cpp
@@ -368,9 +368,11 @@ EStatusCode EncryptionHelper::Setup(const DecryptionHelper& inDecryptionSource)
 }
 
 
-PDFHummus::EStatusCode EncryptionHelper::WriteState(ObjectsContext* inStateWriter, ObjectIDType inObjectID)
+EStatusCode EncryptionHelper::WriteState(ObjectsContext* inStateWriter, ObjectIDType inObjectID)
 {
-	inStateWriter->StartNewIndirectObject(inObjectID);
+	EStatusCode status = inStateWriter->StartNewIndirectObject(inObjectID);
+	if(status != eSuccess)
+		return status;
 	DictionaryContext* encryptionObject = inStateWriter->StartDictionary();
 
 	encryptionObject->WriteKey("Type");
@@ -415,7 +417,7 @@ PDFHummus::EStatusCode EncryptionHelper::WriteState(ObjectsContext* inStateWrite
 	inStateWriter->EndDictionary(encryptionObject);
 	inStateWriter->EndIndirectObject();
 
-	return eSuccess;
+	return status;
 }
 
 PDFHummus::EStatusCode EncryptionHelper::ReadState(PDFParser* inStateReader, ObjectIDType inObjectID)

--- a/PDFWriter/ExtGStateRegistry.cpp
+++ b/PDFWriter/ExtGStateRegistry.cpp
@@ -38,7 +38,9 @@ public:
 
     virtual PDFHummus::EStatusCode Write(ObjectsContext* inObjectsContext,
                                          PDFHummus::DocumentContext* inDocumentContext) {
-        inObjectsContext->StartNewIndirectObject(mObjectID);
+        PDFHummus::EStatusCode status = inObjectsContext->StartNewIndirectObject(mObjectID);
+        if(status != PDFHummus::eSuccess)
+            return status;
         DictionaryContext* dict = inObjectsContext->StartDictionary();
         dict->WriteKey("Type");
         dict->WriteNameValue("ExtGState");
@@ -46,7 +48,7 @@ public:
         dict->WriteDoubleValue(mAlphaValue);
         dict->WriteKey("CA");
         dict->WriteDoubleValue(mAlphaValue);
-        EStatusCode status = inObjectsContext->EndDictionary(dict);
+        status = inObjectsContext->EndDictionary(dict);
         inObjectsContext->EndIndirectObject();
 
         return status;

--- a/PDFWriter/FontDescriptorWriter.cpp
+++ b/PDFWriter/FontDescriptorWriter.cpp
@@ -25,7 +25,7 @@
 #include "IFontDescriptorHelper.h"
 #include "DictionaryContext.h"
 
-
+using namespace PDFHummus;
 
 
 FontDescriptorWriter::FontDescriptorWriter(void)
@@ -67,7 +67,7 @@ static const char* scFontStretchLabels[eFontStretchMax] =
 	"UltraExpanded"
 };
 
-void FontDescriptorWriter::WriteFontDescriptor(	ObjectIDType inFontDescriptorObjectID,
+EStatusCode FontDescriptorWriter::WriteFontDescriptor(	ObjectIDType inFontDescriptorObjectID,
 												const std::string& inFontPostscriptName,
 												FreeTypeFaceWrapper* inFontInfo,
 												const UIntAndGlyphEncodingInfoVector& inEncodedGlyphs,
@@ -76,7 +76,10 @@ void FontDescriptorWriter::WriteFontDescriptor(	ObjectIDType inFontDescriptorObj
 {
 	DictionaryContext* fontDescriptorDictionary;
 
-	inObjectsContext->StartNewIndirectObject(inFontDescriptorObjectID);
+	EStatusCode status = inObjectsContext->StartNewIndirectObject(inFontDescriptorObjectID);
+	if(status != eSuccess) {
+		return status;
+	}
 	fontDescriptorDictionary = inObjectsContext->StartDictionary();
 	
 	// Type
@@ -153,6 +156,7 @@ void FontDescriptorWriter::WriteFontDescriptor(	ObjectIDType inFontDescriptorObj
 
 	inObjectsContext->EndDictionary(fontDescriptorDictionary);
 	inObjectsContext->EndIndirectObject();
+	return status;
 }
 
 unsigned int FontDescriptorWriter::CalculateFlags(	FreeTypeFaceWrapper* inFontInfo,

--- a/PDFWriter/FontDescriptorWriter.h
+++ b/PDFWriter/FontDescriptorWriter.h
@@ -20,6 +20,7 @@
 */
 #pragma once
 
+#include "EStatusCode.h"
 #include "ObjectsBasicTypes.h"
 #include "WrittenFontRepresentation.h"
 
@@ -42,7 +43,7 @@ public:
 	FontDescriptorWriter(void);
 	~FontDescriptorWriter(void);
 
-	void WriteFontDescriptor(	ObjectIDType inFontDescriptorObjectID,
+	PDFHummus::EStatusCode WriteFontDescriptor(	ObjectIDType inFontDescriptorObjectID,
 								const std::string& inFontPostscriptName,
 								FreeTypeFaceWrapper* inFontInfo,
 								const UIntAndGlyphEncodingInfoVector& inEncodedGlyphs,

--- a/PDFWriter/IndirectObjectsReferenceRegistry.cpp
+++ b/PDFWriter/IndirectObjectsReferenceRegistry.cpp
@@ -176,7 +176,9 @@ EStatusCode IndirectObjectsReferenceRegistry::WriteState(ObjectsContext* inState
 {
 	ObjectIDTypeList objects;
 
-	inStateWriter->StartNewIndirectObject(inObjectID);
+	EStatusCode status = inStateWriter->StartNewIndirectObject(inObjectID);
+	if(status != eSuccess)
+		return status;
 	
 	DictionaryContext* myDictionary = inStateWriter->StartDictionary();
 	
@@ -203,9 +205,11 @@ EStatusCode IndirectObjectsReferenceRegistry::WriteState(ObjectsContext* inState
 
 	it = mObjectsWritesRegistry.begin();
 
-	for(; it != mObjectsWritesRegistry.end(); ++it,++itIDs)
+	for(; (it != mObjectsWritesRegistry.end()) && (eSuccess == status); ++it,++itIDs)
 	{
-		inStateWriter->StartNewIndirectObject(*itIDs);
+		status = inStateWriter->StartNewIndirectObject(*itIDs);
+		if(status != eSuccess)
+			break;
 
 		DictionaryContext* registryDictionary = inStateWriter->StartDictionary();
 		
@@ -235,7 +239,7 @@ EStatusCode IndirectObjectsReferenceRegistry::WriteState(ObjectsContext* inState
 		inStateWriter->EndIndirectObject();
 	}
 
-	return PDFHummus::eSuccess;
+	return status;
 }
 
 EStatusCode IndirectObjectsReferenceRegistry::ReadState(PDFParser* inStateReader,ObjectIDType inObjectID)

--- a/PDFWriter/JPEGImageHandler.cpp
+++ b/PDFWriter/JPEGImageHandler.cpp
@@ -132,7 +132,12 @@ PDFImageXObject* JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation(
 			break;
 		}
 
-		mObjectsContext->StartNewIndirectObject(inImageXObjectID);
+		status = mObjectsContext->StartNewIndirectObject(inImageXObjectID);
+		if(status != PDFHummus::eSuccess)
+		{
+			TRACE_LOG1("JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation. Unexpected Error, unable to start image xobject for object ID %ld",inImageXObjectID);
+			break;
+		}
 		DictionaryContext* imageContext = mObjectsContext->StartDictionary();
 
 		// type
@@ -219,8 +224,13 @@ PDFImageXObject* JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation(
 			break;
 		}
 
-		mObjectsContext->EndPDFStream(imageStream);
+		status = mObjectsContext->EndPDFStream(imageStream);
 		delete imageStream;
+		if(status != PDFHummus::eSuccess)
+		{
+			TRACE_LOG("JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation. Unexpected Error, failed to finalize image stream");
+			break;
+		}
 
 		imageXObject = new PDFImageXObject(inImageXObjectID,1 == inJPGImageInformation.ColorComponentsCount ? KProcsetImageB:KProcsetImageC);
 	}while(false);
@@ -369,6 +379,11 @@ PDFFormXObject* JPEGImageHandler::CreateImageFormXObjectFromImageXObject(PDFImag
 		DoubleAndDoublePair dimensions = GetImageDimensions(inJPGImageInformation);
 
 		formXObject = mDocumentContext->StartFormXObject(PDFRectangle(0,0,dimensions.first,dimensions.second),inFormXObjectID);
+		if(!formXObject)
+		{
+			TRACE_LOG("JPEGImageHandler::CreateImageFormXObjectFromImageXObject. Unexpected Error, could not start form XObject for image");
+			break;
+		}
 		XObjectContentContext* xobjectContentContext = formXObject->GetContentContext();
 
 		xobjectContentContext->q();

--- a/PDFWriter/ObjectsContext.h
+++ b/PDFWriter/ObjectsContext.h
@@ -103,14 +103,14 @@ public:
 	void EndArray(ETokenSeparator inSeparate = eTokenSeparatorNone);
 
 	// Indirect objects writing
-	// override that allocate a new object ID and returns it
+	// override that allocate a new object ID and returns it. Error return is marked by a 0 object ID
 	ObjectIDType StartNewIndirectObject();
 	// override for objects that already have been allocated in advance, and have an object ID
-	void StartNewIndirectObject(ObjectIDType inObjectID);
+	PDFHummus::EStatusCode StartNewIndirectObject(ObjectIDType inObjectID);
 	void EndIndirectObject();
 
     // for modified files scenarios, modify an existing object
-    void StartModifiedIndirectObject(ObjectIDType inObjectID);
+    PDFHummus::EStatusCode StartModifiedIndirectObject(ObjectIDType inObjectID);
 
 	// Sets whether streams created by the objects context will be compressed (with flate) or not
 	void SetCompressStreams(bool inCompressStreams);
@@ -122,7 +122,7 @@ public:
 	PDFStream* StartPDFStream(DictionaryContext* inStreamDictionary=NULL,bool inForceDirectExtentObject = false);
 	// same as StartPDFStream but forces the stream to create an unfiltered stream
 	PDFStream* StartUnfilteredPDFStream(DictionaryContext* inStreamDictionary=NULL);
-	void EndPDFStream(PDFStream* inStream);
+	PDFHummus::EStatusCode EndPDFStream(PDFStream* inStream);
 
 	// Extensibility
 	void SetObjectsContextExtender(IObjectsContextExtender* inExtender);
@@ -150,7 +150,7 @@ private:
 	DictionaryContextList mDictionaryStack;
 
 	void WritePDFStreamEndWithoutExtent();
-	void WritePDFStreamExtent(PDFStream* inStream);
+	PDFHummus::EStatusCode WritePDFStreamExtent(PDFStream* inStream);
     void WriteXrefNumber(IByteWriter* inStream,LongFilePositionType inElement, size_t inElementSize);
 	bool IsEncrypting();
 	std::string MaybeEncryptString(const std::string& inString);

--- a/PDFWriter/PDFCosDict.h
+++ b/PDFWriter/PDFCosDict.h
@@ -31,6 +31,7 @@
 */
 
 #pragma once
+#include "EStatusCode.h"
 #include "PDFWriter.h"
 #include "DictionaryContext.h"
 
@@ -47,8 +48,10 @@ public:
       m_DocumentContext(parentDoc.GetObjectsContext()),
       m_DidEnd(false)
     {
-        if(newID)
-            m_DocumentContext.StartNewIndirectObject(m_ObjID = newID);
+        if(newID) {
+            if(m_DocumentContext.StartNewIndirectObject(newID) != PDFHummus::eSuccess)
+                m_ObjID = 0;
+        }
         else
            m_ObjID              = m_DocumentContext.StartNewIndirectObject();
 	    m_DictonaryContext      = m_DocumentContext.StartDictionary();

--- a/PDFWriter/PDFUsedFont.cpp
+++ b/PDFWriter/PDFUsedFont.cpp
@@ -127,7 +127,9 @@ EStatusCode PDFUsedFont::WriteFontDefinition()
 
 EStatusCode PDFUsedFont::WriteState(ObjectsContext* inStateWriter,ObjectIDType inObjectID)
 {
-	inStateWriter->StartNewIndirectObject(inObjectID);
+	EStatusCode status = inStateWriter->StartNewIndirectObject(inObjectID);
+	if(status != eSuccess)
+		return status;
 	DictionaryContext* pdfUsedFontObject = inStateWriter->StartDictionary();
 
 	pdfUsedFontObject->WriteKey("Type");
@@ -149,7 +151,7 @@ EStatusCode PDFUsedFont::WriteState(ObjectsContext* inStateWriter,ObjectIDType i
 	if(mWrittenFont)
 		mWrittenFont->WriteState(inStateWriter,writtenFontObject);
 
-	return PDFHummus::eSuccess;
+	return status;
 }
 
 EStatusCode PDFUsedFont::ReadState(PDFParser* inStateReader,ObjectIDType inObjectID)

--- a/PDFWriter/PDFWriter.cpp
+++ b/PDFWriter/PDFWriter.cpp
@@ -370,6 +370,12 @@ EStatusCode PDFWriter::Shutdown(const std::string& inStateFilePath)
 		}
 
 		ObjectIDType rootObjectID = writer.GetObjectsWriter()->StartNewIndirectObject();
+		if(0 == rootObjectID)
+		{
+			TRACE_LOG("PDFWriter::Shutdown, cant start root object writing");
+			status = eFailure;
+			break;
+		}
 		DictionaryContext* pdfWriterDictionary = writer.GetObjectsWriter()->StartDictionary();
 
 		pdfWriterDictionary->WriteKey("Type");

--- a/PDFWriter/PageContentContext.h
+++ b/PDFWriter/PageContentContext.h
@@ -35,11 +35,11 @@ public:
 	// Finish writing a current stream, if exists and flush to the main PDF stream
 	PDFHummus::EStatusCode FinalizeCurrentStream();
 
-	// Extensibility method, retrieves the current content stream for writing. if one does not exist - creates it.
+	// Extensibility method, retrieves the current content stream for writing. if one does not exist - creates it. (will return NULL if failed to create)
 	PDFStream* GetCurrentPageContentStream();
 
 	// Extensibility method, forces creation of a new stream, if one does not exist now.
-	void StartAStreamIfRequired();
+	PDFHummus::EStatusCode StartAStreamIfRequired();
 
 	// Extensibility method, get the page to which this content is associated
 	PDFPage* GetAssociatedPage();
@@ -50,11 +50,11 @@ private:
 	PDFStream* mCurrentStream;
 
 	PDFHummus::EStatusCode FinalizeStreamWriteAndRelease();
-	void StartContentStreamDefinition();
+	PDFHummus::EStatusCode StartContentStreamDefinition();
 
 	// AbstractContentContext implementation
 	virtual ResourcesDictionary* GetResourcesDictionary();
-	virtual void RenewStreamConnection();
+	virtual PDFHummus::EStatusCode RenewStreamConnection();
 	virtual void ScheduleImageWrite(const std::string& inImagePath,unsigned long inImageIndex,ObjectIDType inObjectID, const PDFParsingOptions& inParsingOptions);
 	virtual void ScheduleObjectEndWriteTask(IObjectEndWritingTask* inObjectEndWritingTask);
 };

--- a/PDFWriter/PrimitiveObjectsWriter.cpp
+++ b/PDFWriter/PrimitiveObjectsWriter.cpp
@@ -39,6 +39,8 @@ PrimitiveObjectsWriter::~PrimitiveObjectsWriter(void)
 static const IOBasicTypes::Byte scSpace[] = {' '};
 void PrimitiveObjectsWriter::WriteTokenSeparator(ETokenSeparator inSeparate)
 {
+	if(!mStreamForWriting)
+		return;
 	if(eTokenSeparatorSpace == inSeparate)
 		mStreamForWriting->Write(scSpace,1);
 	else if(eTokenSeparatorEndLine == inSeparate)
@@ -48,11 +50,15 @@ void PrimitiveObjectsWriter::WriteTokenSeparator(ETokenSeparator inSeparate)
 static const IOBasicTypes::Byte scNewLine[2] = {'\r','\n'};
 void PrimitiveObjectsWriter::EndLine()
 {
+	if(!mStreamForWriting)
+		return;
 	mStreamForWriting->Write(scNewLine,2);
 }
 
 void PrimitiveObjectsWriter::WriteKeyword(const std::string& inKeyword)
 {
+	if(!mStreamForWriting)
+		return;
 	mStreamForWriting->Write((const IOBasicTypes::Byte *)inKeyword.c_str(),inKeyword.size());
 	EndLine();
 }
@@ -66,6 +72,8 @@ from the pdf reference:
 This syntax is required to represent any of the delimiter or white-space characters or the number sign character itself; 
 it is recommended but not required for characters whose codes are outside the range 33 (!) to 126 (~).
 */
+	if(!mStreamForWriting)
+		return;
 
 	mStreamForWriting->Write(scSlash,1);
 
@@ -92,6 +100,8 @@ it is recommended but not required for characters whose codes are outside the ra
 
 void PrimitiveObjectsWriter::WriteInteger(long long inIntegerToken,ETokenSeparator inSeparate)
 {
+	if(!mStreamForWriting)
+		return;
 	char buffer[512];
 
 	SAFE_SPRINTF_1(buffer,512,"%lld",inIntegerToken);
@@ -104,6 +114,8 @@ static const IOBasicTypes::Byte scRightParanthesis[1] = {')'};
 
 void PrimitiveObjectsWriter::WriteUnsafeLiteralString(const std::string& inString,ETokenSeparator inSeparate)
 {
+	if(!mStreamForWriting)
+		return;
 	mStreamForWriting->Write(scLeftParanthesis,1);
 	mStreamForWriting->Write((const IOBasicTypes::Byte *)inString.c_str(),inString.size());
 	mStreamForWriting->Write(scRightParanthesis,1);
@@ -112,6 +124,8 @@ void PrimitiveObjectsWriter::WriteUnsafeLiteralString(const std::string& inStrin
 
 void PrimitiveObjectsWriter::WriteLiteralString(const std::string& inString,ETokenSeparator inSeparate)
 {
+	if(!mStreamForWriting)
+		return;
 	mStreamForWriting->Write(scLeftParanthesis,1);
 	// doing some string conversion, so that charachters are written as safe ones.
 	IOBasicTypes::Byte buffer[5];
@@ -143,6 +157,8 @@ void PrimitiveObjectsWriter::WriteLiteralString(const std::string& inString,ETok
 
 void PrimitiveObjectsWriter::WriteDouble(double inDoubleToken,ETokenSeparator inSeparate)
 {
+	if(!mStreamForWriting)
+		return;
 	// make sure we get proper decimal point writing
 	std::stringstream s;
 	// use classic locale for no worries writing
@@ -185,6 +201,8 @@ static const IOBasicTypes::Byte scFalse[5] = {'f','a','l','s','e'};
 
 void PrimitiveObjectsWriter::WriteBoolean(bool inBoolean,ETokenSeparator inSeparate)
 {
+	if(!mStreamForWriting)
+		return;
 	if(inBoolean)
 		mStreamForWriting->Write(scTrue,4);
 	else
@@ -195,6 +213,8 @@ void PrimitiveObjectsWriter::WriteBoolean(bool inBoolean,ETokenSeparator inSepar
 static const IOBasicTypes::Byte scNull[4] = {'n','u','l','l'};
 void PrimitiveObjectsWriter::WriteNull(ETokenSeparator inSeparate)
 {
+	if(!mStreamForWriting)
+		return;
 	mStreamForWriting->Write(scNull,4);	
 	WriteTokenSeparator(inSeparate);
 }
@@ -208,12 +228,16 @@ void PrimitiveObjectsWriter::SetStreamForWriting(IByteWriter* inStreamForWriting
 static const IOBasicTypes::Byte scOpenBracketSpace[2] = {'[',' '};
 void PrimitiveObjectsWriter::StartArray()
 {
+	if(!mStreamForWriting)
+		return;
 	mStreamForWriting->Write(scOpenBracketSpace,2);
 }
 
 static const IOBasicTypes::Byte scCloseBracket[1] = {']'};
 void PrimitiveObjectsWriter::EndArray(ETokenSeparator inSeparate)
 {
+	if(!mStreamForWriting)
+		return;
 	mStreamForWriting->Write(scCloseBracket,1);
 	WriteTokenSeparator(inSeparate);
 }
@@ -222,6 +246,8 @@ static const IOBasicTypes::Byte scLeftAngle[1] = {'<'};
 static const IOBasicTypes::Byte scRightAngle[1] = {'>'};
 void PrimitiveObjectsWriter::WriteHexString(const std::string& inString,ETokenSeparator inSeparate)
 {
+	if(!mStreamForWriting)
+		return;
 	mStreamForWriting->Write(scLeftAngle,1);
 	IOBasicTypes::Byte buffer[3];
 	std::string::const_iterator it = inString.begin();
@@ -238,6 +264,8 @@ void PrimitiveObjectsWriter::WriteHexString(const std::string& inString,ETokenSe
 
 void PrimitiveObjectsWriter::WriteEncodedHexString(const std::string& inString, ETokenSeparator inSeparate)
 {
+	if(!mStreamForWriting)
+		return;
 	// string is already encoded, so no need to sprintf
 	mStreamForWriting->Write(scLeftAngle, 1);
 	std::string::const_iterator it = inString.begin();

--- a/PDFWriter/TrueTypeEmbeddedFontWriter.cpp
+++ b/PDFWriter/TrueTypeEmbeddedFontWriter.cpp
@@ -53,6 +53,7 @@ EStatusCode TrueTypeEmbeddedFontWriter::WriteEmbeddedFont(
 	MyStringBuf rawFontProgram;
 	bool notEmbedded;
 	EStatusCode status;
+	PDFStream* pdfStream = NULL;
 
 	do
 	{
@@ -72,6 +73,12 @@ EStatusCode TrueTypeEmbeddedFontWriter::WriteEmbeddedFont(
 		}
 
 		outEmbeddedFontObjectID = inObjectsContext->StartNewIndirectObject();
+		if(outEmbeddedFontObjectID == 0)
+		{
+			TRACE_LOG("TrueTypeEmbeddedFontWriter::WriteEmbeddedFont, failed to start embedded font object");
+			status = PDFHummus::eFailure;
+			break;
+		}
 		
 		DictionaryContext* fontProgramDictionaryContext = inObjectsContext->StartDictionary();
 
@@ -80,7 +87,7 @@ EStatusCode TrueTypeEmbeddedFontWriter::WriteEmbeddedFont(
 		fontProgramDictionaryContext->WriteKey(scLength1);
 		fontProgramDictionaryContext->WriteIntegerValue(rawFontProgram.GetCurrentWritePosition());
 		rawFontProgram.pubseekoff(0,std::ios_base::beg);
-		PDFStream* pdfStream = inObjectsContext->StartPDFStream(fontProgramDictionaryContext);
+		pdfStream = inObjectsContext->StartPDFStream(fontProgramDictionaryContext);
 
 
 		// now copy the created font program to the output stream
@@ -94,10 +101,10 @@ EStatusCode TrueTypeEmbeddedFontWriter::WriteEmbeddedFont(
 		}
 
 
-		inObjectsContext->EndPDFStream(pdfStream);
-		delete pdfStream;
+		status = inObjectsContext->EndPDFStream(pdfStream);
 	}while(false);
 
+	delete pdfStream;
 	return status;
 }
 

--- a/PDFWriter/Type1ToCFFEmbeddedFontWriter.cpp
+++ b/PDFWriter/Type1ToCFFEmbeddedFontWriter.cpp
@@ -148,6 +148,7 @@ EStatusCode Type1ToCFFEmbeddedFontWriter::WriteEmbeddedFont(
 		// as oppose to true type, the reason for using a memory stream here is mainly peformance - i don't want to start
 		// setting file pointers and move in a file stream
 	EStatusCode status;
+	PDFStream* pdfStream = NULL;
 
 	do
 	{
@@ -167,6 +168,12 @@ EStatusCode Type1ToCFFEmbeddedFontWriter::WriteEmbeddedFont(
 		}
 
 		outEmbeddedFontObjectID = inObjectsContext->StartNewIndirectObject();
+		if(outEmbeddedFontObjectID == 0)
+		{
+			TRACE_LOG("Type1ToCFFEmbeddedFontWriter::WriteEmbeddedFont, failed to start new indirect object for embedded font");
+			status = PDFHummus::eFailure;
+			break;
+		}
 		
 		DictionaryContext* fontProgramDictionaryContext = inObjectsContext->StartDictionary();
 
@@ -174,7 +181,7 @@ EStatusCode Type1ToCFFEmbeddedFontWriter::WriteEmbeddedFont(
 
 		fontProgramDictionaryContext->WriteKey(scSubtype);
 		fontProgramDictionaryContext->WriteNameValue(inFontFile3SubType);
-		PDFStream* pdfStream = inObjectsContext->StartPDFStream(fontProgramDictionaryContext);
+		pdfStream = inObjectsContext->StartPDFStream(fontProgramDictionaryContext);
 
 
 		// now copy the created font program to the output stream
@@ -188,10 +195,10 @@ EStatusCode Type1ToCFFEmbeddedFontWriter::WriteEmbeddedFont(
 		}
 
 
-		inObjectsContext->EndPDFStream(pdfStream);
-		delete pdfStream;
+		status = inObjectsContext->EndPDFStream(pdfStream);
 	}while(false);
 
+	delete pdfStream;
 	return status;		
 
 }

--- a/PDFWriter/UsedFontsRepository.cpp
+++ b/PDFWriter/UsedFontsRepository.cpp
@@ -133,7 +133,9 @@ EStatusCode UsedFontsRepository::WriteState(ObjectsContext* inStateWriter,Object
 	EStatusCode status = PDFHummus::eSuccess;
 	ObjectIDTypeList usedFontsObjects;
 
-	inStateWriter->StartNewIndirectObject(inObjectID);
+	status = inStateWriter->StartNewIndirectObject(inObjectID);
+	if(status != eSuccess)
+		return status;
 	DictionaryContext* usedFontsRepositoryObject = inStateWriter->StartDictionary();
 
 	usedFontsRepositoryObject->WriteKey("Type");

--- a/PDFWriter/WrittenFontCFF.cpp
+++ b/PDFWriter/WrittenFontCFF.cpp
@@ -241,7 +241,10 @@ bool WrittenFontCFF::HasEnoughSpaceForGlyphs(const GlyphUnicodeMappingListList& 
 
 EStatusCode WrittenFontCFF::WriteState(ObjectsContext* inStateWriter,ObjectIDType inObjectID)
 {
-	inStateWriter->StartNewIndirectObject(inObjectID);
+	EStatusCode status = inStateWriter->StartNewIndirectObject(inObjectID);
+	
+	if(status != PDFHummus::eSuccess)
+		return status;
 
 	DictionaryContext* writtenFontDictionary = inStateWriter->StartDictionary();
 
@@ -278,7 +281,7 @@ EStatusCode WrittenFontCFF::WriteState(ObjectsContext* inStateWriter,ObjectIDTyp
 	writtenFontDictionary->WriteKey("mIsCID");
 	writtenFontDictionary->WriteBooleanValue(mIsCID);
 
-	EStatusCode status = AbstractWrittenFont::WriteStateInDictionary(inStateWriter,writtenFontDictionary);
+	status = AbstractWrittenFont::WriteStateInDictionary(inStateWriter,writtenFontDictionary);
 	if(PDFHummus::eSuccess == status)
 	{
 		inStateWriter->EndDictionary(writtenFontDictionary);

--- a/PDFWriter/WrittenFontTrueType.cpp
+++ b/PDFWriter/WrittenFontTrueType.cpp
@@ -227,14 +227,16 @@ bool WrittenFontTrueType::AddToANSIRepresentation(	const GlyphUnicodeMappingList
 
 EStatusCode WrittenFontTrueType::WriteState(ObjectsContext* inStateWriter,ObjectIDType inObjectID)
 {
-	inStateWriter->StartNewIndirectObject(inObjectID);
+	EStatusCode status = inStateWriter->StartNewIndirectObject(inObjectID);
+	if(status != PDFHummus::eSuccess)
+		return status;
 
 	DictionaryContext* writtenFontDictionary = inStateWriter->StartDictionary();
 
 	writtenFontDictionary->WriteKey("Type");
 	writtenFontDictionary->WriteNameValue("WrittenFontTrueType");
 
-	EStatusCode status = AbstractWrittenFont::WriteStateInDictionary(inStateWriter,writtenFontDictionary);
+	status = AbstractWrittenFont::WriteStateInDictionary(inStateWriter,writtenFontDictionary);
 	if(PDFHummus::eSuccess == status)
 	{
 		inStateWriter->EndDictionary(writtenFontDictionary);

--- a/PDFWriterTesting/AppendAndReplaceURLAnnotations.cpp
+++ b/PDFWriterTesting/AppendAndReplaceURLAnnotations.cpp
@@ -61,6 +61,9 @@ EStatusCodeAndObjectIDType ReplaceAnnotation(ObjectsContext& objectsContext, PDF
 	ObjectIDTypeList referencedObjects;
 	ObjectIDType newAnnotationRef = objectsContext.StartNewIndirectObject();
 
+	if(newAnnotationRef == 0)
+		return EStatusCodeAndObjectIDType(eFailure,0);
+
 	do {
 
 		DictionaryContext* newAnnotationDicitonary = objectsContext.StartDictionary();
@@ -177,7 +180,11 @@ EStatusCode EmbedPagesInPDFAndReplaceUrl(PDFWriter* inTargetWriter, const string
 				// depending on which got replaced
 				ObjectIDType annotsRef;
 
-				annotsRef = objectsContext.StartNewIndirectObject();					
+				annotsRef = objectsContext.StartNewIndirectObject();	
+				if(annotsRef == 0) {
+					status = eFailure;
+					break;
+				}
 				objectsContext.StartArray();
 
 				ObjectIDTypeList referencedObjects;

--- a/PDFWriterTesting/AppendWithAnnotations.cpp
+++ b/PDFWriterTesting/AppendWithAnnotations.cpp
@@ -58,7 +58,11 @@ EStatusCode EmbedPagesInPDF(PDFWriter* inTargetWriter, const string& inSourcePDF
 					// it refers to (indirect annotation objects...normally)
 					ObjectsContext& objectsContext = inTargetWriter->GetObjectsContext();
 
-					annotsRef = objectsContext.StartNewIndirectObject();					
+					annotsRef = objectsContext.StartNewIndirectObject();	
+					if(annotsRef == 0) {
+						status = eFailure;
+						break;
+					}
 					EStatusCodeAndObjectIDTypeList result = copyingContext->CopyDirectObjectWithDeepCopy(annotsObject.GetPtr());
 
 					status = result.first;

--- a/PDFWriterTesting/CopyingAndMergingEmptyPages.cpp
+++ b/PDFWriterTesting/CopyingAndMergingEmptyPages.cpp
@@ -280,6 +280,11 @@ static EStatusCode MergeEmptyPageToForm(char* argv[], const string& inEmptyFileN
         
         // create form for two pages.
         PDFFormXObject* newFormXObject = pdfWriter.StartFormXObject(PDFRectangle(0,0,297.5,842));
+		if(!newFormXObject)
+		{
+			status = PDFHummus::eFailure;
+			break;
+		}
         
 		XObjectContentContext* xobjectContentContext = newFormXObject->GetContentContext();
         

--- a/PDFWriterTesting/DCTDecodeFilterTest.cpp
+++ b/PDFWriterTesting/DCTDecodeFilterTest.cpp
@@ -210,7 +210,12 @@ static EStatusCode ModifyImageObject(PDFWriter* inWriter,ObjectIDType inImageObj
         RefCountPtr<PDFDictionary> imageDictionary(imageStream->QueryStreamDictionary());
         
         // strt object for modified image
-        inWriter->GetObjectsContext().StartModifiedIndirectObject(inImageObject);
+        status = inWriter->GetObjectsContext().StartModifiedIndirectObject(inImageObject);
+        if(status != eSuccess)
+        {
+            cout<<"failed to start modified image object\n";
+            break;
+        }
         
         DictionaryContext* newImageDictionary = inWriter->GetObjectsContext().StartDictionary();
         
@@ -252,7 +257,8 @@ static EStatusCode ModifyImageObject(PDFWriter* inWriter,ObjectIDType inImageObj
         status = traits.CopyToOutputStream(sourceImage);
         
         // finalize stream
-        inWriter->GetObjectsContext().EndPDFStream(newImageStream);
+        if(status != eFailure)
+            status = inWriter->GetObjectsContext().EndPDFStream(newImageStream);
         delete newImageStream;
 		delete sourceImage;
 

--- a/PDFWriterTesting/FormXObjectTest.cpp
+++ b/PDFWriterTesting/FormXObjectTest.cpp
@@ -73,6 +73,12 @@ int FormXObjectTest(int argc, char* argv[])
 
 		// define an xobject form to draw a 200X100 points red rectangle
 		PDFFormXObject* xobjectForm = pdfWriter.StartFormXObject(PDFRectangle(0,0,200,100));
+		if(!xobjectForm)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"failed to create form xobject\n";
+			break;
+		}
 		ObjectIDType formObjectID = xobjectForm->GetObjectID();
 
 		XObjectContentContext* xobjectContentContext = xobjectForm->GetContentContext();

--- a/PDFWriterTesting/ImagesAndFormsForwardReferenceTest.cpp
+++ b/PDFWriterTesting/ImagesAndFormsForwardReferenceTest.cpp
@@ -148,6 +148,12 @@ int ImagesAndFormsForwardReferenceTest(int argc, char* argv[])
 
 		// define an xobject form to draw a 200X100 points red rectangle
 		PDFFormXObject* xobjectForm = pdfWriter.StartFormXObject(PDFRectangle(0,0,200,100),simpleFormXObjectID);
+		if(!xobjectForm)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"failed to create form xobject\n";
+			break;
+		}
 
 		XObjectContentContext* xobjectContentContext = xobjectForm->GetContentContext();
 		xobjectContentContext->q();

--- a/PDFWriterTesting/MergeToPDFForm.cpp
+++ b/PDFWriterTesting/MergeToPDFForm.cpp
@@ -59,6 +59,11 @@ int MergeToPDFForm(int argc, char* argv[])
         
         // create form for two pages.
         PDFFormXObject* newFormXObject = pdfWriter.StartFormXObject(PDFRectangle(0,0,297.5,842));
+        if(!newFormXObject)
+        {
+            status = PDFHummus::eFailure;
+            break;
+        }
         
 		XObjectContentContext* xobjectContentContext = newFormXObject->GetContentContext();
         

--- a/PDFWriterTesting/ModifyingExistingFileContent.cpp
+++ b/PDFWriterTesting/ModifyingExistingFileContent.cpp
@@ -59,7 +59,12 @@ static EStatusCode TestPageSizeModification(PDFWriter* inPDFWriter)
         
         MapIterator<PDFNameToPDFObjectMap>  thirdPageObjectIt = thirdPageObject->GetIterator();
         
-        inPDFWriter->GetObjectsContext().StartModifiedIndirectObject(thirdPageID);
+        status = inPDFWriter->GetObjectsContext().StartModifiedIndirectObject(thirdPageID);
+        if(status != eSuccess)
+        {
+            cout<<"failed to start modified page object\n";
+            break;
+        }
         DictionaryContext* modifiedPageObject = inPDFWriter->GetObjectsContext().StartDictionary();
         
         while(thirdPageObjectIt.MoveNext())
@@ -174,7 +179,12 @@ static EStatusCode TestAddingComments(PDFWriter* inPDFWriter)
         
         MapIterator<PDFNameToPDFObjectMap>  fourthPageObjectIt = fourthPageObject->GetIterator();
         
-        inPDFWriter->GetObjectsContext().StartModifiedIndirectObject(fourthPageID);
+        status = inPDFWriter->GetObjectsContext().StartModifiedIndirectObject(fourthPageID);
+        if(status != eSuccess)
+        {
+            cout<<"failed to start modified page object\n";
+            break;
+        }
         DictionaryContext* modifiedPageObject = inPDFWriter->GetObjectsContext().StartDictionary();
         
         while(fourthPageObjectIt.MoveNext())

--- a/PDFWriterTesting/PDFCommentWriter.cpp
+++ b/PDFWriterTesting/PDFCommentWriter.cpp
@@ -68,6 +68,12 @@ EStatusCodeAndObjectIDType PDFCommentWriter::WriteCommentsTree(PDFComment* inCom
 
 		// Start new InDirect object for annotation dictionary
 		result.second = objectsContext.StartNewIndirectObject();
+		if(result.second == 0)
+		{
+			result.first = eFailure;
+			TRACE_LOG("PDFCommentWriter::WriteCommentsTree, Exception in starting comment dictionary");
+			break;
+		}
 		
 		DictionaryContext* dictionaryContext = objectsContext.StartDictionary();
 

--- a/PDFWriterTesting/ShutDownRestartTest.cpp
+++ b/PDFWriterTesting/ShutDownRestartTest.cpp
@@ -172,6 +172,12 @@ int ShutDownRestartTest(int argc, char* argv[])
 
 			// define an xobject form to draw a 200X100 points red rectangle
 			PDFFormXObject* xobjectForm = pdfWriterB.StartFormXObject(PDFRectangle(0,0,200,100));
+			if(!xobjectForm)
+			{
+				status = PDFHummus::eFailure;
+				cout<<"failed to create form xobject\n";
+				break;
+			}
 			ObjectIDType formObjectID = xobjectForm->GetObjectID();
 
 			XObjectContentContext* xobjectContentContext = xobjectForm->GetContentContext();

--- a/PDFWriterTesting/WatermarkTest.cpp
+++ b/PDFWriterTesting/WatermarkTest.cpp
@@ -52,6 +52,12 @@ int WatermarkTest(int argc, char* argv[])
 
         ObjectsContext& objCtx = pdfWriter.GetObjectsContext();
         ObjectIDType gsID = objCtx.StartNewIndirectObject();
+        if(gsID == 0)
+        {
+            status = PDFHummus::eFailure;
+            cout << "failed to start extgstate object\n";
+            break;
+        }
         DictionaryContext* dict = objCtx.StartDictionary();
         dict->WriteKey("type");
         dict->WriteNameValue("ExtGState");


### PR DESCRIPTION
The library current PDF output is limited to ~10gbs.
This is due to a limitation of PDF when writing regular xrefs. 10 bytes is what's used to represent position and so anything larger than what can be represented by 10 digits is simply out of bounds. Seems like i always had a check if the object written already exceeds this position on object start but never bothered with followup on such failures with higher level usages. There's a recent issue attempting to write very large PDF files (https://github.com/galkahana/PDF-Writer/issues/289), and there's bad artifacts given this neglected failure.

PDF1.5 and higher provide a method to write xrefs as xref streams...and more important - set the length of the position descriptors. so you can set it to more than 10bytes if you need to create larger files. See towards the end about plans to support this.

Now i knew this would be a terrible one to fix, given it's such a basic and low level functionality in the library, which directly affects things like starting a new object in either fashion. Still. what's needs fixing will be fixed.

Most of the methods were able to properly propagate status without breaking API. i sometimes had to convert a void function to return status...but other than that (which doesnt in itself break existing usages..though maybe it'll be good to start consulting the result) things seem ok.

One area where this change effects the convenience of the API is the content context. It's really nice to be able to write output without having to check status and this kinda ruins it.
So, to make things simple still I coded stuff so that you can write multiple commands and it'll just work, and when done you can then check the status of the context and through that learn if there's a failure or not. So...not each time...but rather after a sequence of commands. Use AbstractContentContext::GetCurrentStatusCode() to get the current status. it can only go from eSuccess to eFailure, so once it does no point in continuing. 

Do note still that will all these options to check status things are the same. It is only that if you managed to exceed 10gbs or so than the new behavior will properly propagate the inability to represent positions of that size. You probably are not doing that now if the files do not come out corrupted. The only difference is that instead of getting an error on PDFWriter::EndPDF() you'll get it earlier, at the point where the library notices that it exceeded what can be represented by Xref.


While it's nice to get an early warning it'd be nice to still be able to create very large file (well at least till we get to long long which is how file sizes are represented here). Im thinking of taking care of this by providing 1.5 style xref streams. Been dealing with those when added file modifications years ago. i just need to provide a method to write them also on regular files, and provide the option to choose them (and the bytesize). I'll think positively about doing that is about what im willing to say at this point ;).