### PR TITLE
feat: allow asking for using xref streams, which opens the option to build very large files

### DIFF
--- a/PDFWriter/DocumentContext.h
+++ b/PDFWriter/DocumentContext.h
@@ -119,6 +119,7 @@ namespace PDFHummus
 		void SetObjectsContext(ObjectsContext* inObjectsContext);
 		void SetOutputFileInformation(OutputFile* inOutputFile);
 		void SetEmbedFonts(bool inEmbedFonts);
+		void SetWriteXrefAsXrefStream(bool inWriteXrefAsXrefStream);
 		PDFHummus::EStatusCode	WriteHeader(EPDFVersion inPDFVersion);
 		PDFHummus::EStatusCode	FinalizeNewPDF();
         PDFHummus::EStatusCode	FinalizeModifiedPDF(PDFParser* inModifiedFileParser,EPDFVersion inModifiedPDFVersion);
@@ -413,6 +414,7 @@ namespace PDFHummus
 	    StringAndULongPairToHummusImageInformationMap mImagesInformation;
 		EncryptionHelper mEncryptionHelper;
 		ExtGStateRegistry mExtGStateRegistry;
+		bool mWriteXrefAsXrefStream;
 
 		void WriteHeaderComment(EPDFVersion inPDFVersion);
 		void Write4BinaryBytes();
@@ -461,5 +463,6 @@ namespace PDFHummus
 		bool RequiresXrefStream(PDFParser* inModifiedFileParser);
         PDFHummus::EStatusCode WriteXrefStream(LongFilePositionType& outXrefPosition);
 		HummusImageInformation& GetImageInformationStructFor(const std::string& inImageFile,unsigned long inImageIndex);
+		void SetupXrefMaxWritePositionValidation();
 	};
 }

--- a/PDFWriter/IndirectObjectsReferenceRegistry.cpp
+++ b/PDFWriter/IndirectObjectsReferenceRegistry.cpp
@@ -37,6 +37,7 @@ using namespace PDFHummus;
 IndirectObjectsReferenceRegistry::IndirectObjectsReferenceRegistry(void)
 {
     SetupInitialFreeObject();
+	SetShouldValidateMaxWritePositionForXref(true);
 }
 
 void IndirectObjectsReferenceRegistry::SetupInitialFreeObject()
@@ -49,6 +50,11 @@ void IndirectObjectsReferenceRegistry::SetupInitialFreeObject()
     singleFreeObjectInformation.mGenerationNumber = 65535;
     singleFreeObjectInformation.mWritePosition = 0;
 	mObjectsWritesRegistry.push_back(singleFreeObjectInformation);
+}
+
+void IndirectObjectsReferenceRegistry::SetShouldValidateMaxWritePositionForXref(bool inShouldValidate)
+{
+	mShouldValidateMaxWritePositionForXref = inShouldValidate;
 }
 
 IndirectObjectsReferenceRegistry::~IndirectObjectsReferenceRegistry(void)
@@ -70,6 +76,20 @@ ObjectIDType IndirectObjectsReferenceRegistry::AllocateNewObjectID()
 	return newObjectID;
 }
 
+EStatusCode IndirectObjectsReferenceRegistry::MaybeValidateMaxWritePositionForXref(LongFilePositionType inWritePosition)
+{
+	if(!mShouldValidateMaxWritePositionForXref)
+		return PDFHummus::eSuccess;
+
+	if(inWritePosition > 9999999999LL) // if write position is larger than what can be represented by 10 digits, xref write will fail
+	{
+		TRACE_LOG1("IndirectObjectsReferenceRegistry::MaybeValidateMaxWritePositionForXref, Write position out of bounds. Trying to write an object at position that cannot be represented in Xref = %lld. probably means file got too long",inWritePosition);
+		return PDFHummus::eFailure;
+	}
+
+	return PDFHummus::eSuccess;	
+}
+
 
 EStatusCode IndirectObjectsReferenceRegistry::MarkObjectAsWritten(ObjectIDType inObjectID,LongFilePositionType inWritePosition)
 {
@@ -86,9 +106,8 @@ EStatusCode IndirectObjectsReferenceRegistry::MarkObjectAsWritten(ObjectIDType i
 		return PDFHummus::eFailure; // trying to mark as written an object that was already marked as such in the past. probably a mistake [till we have revisions]
 	}
 
-	if(inWritePosition > 9999999999LL) // if write position is larger than what can be represented by 10 digits, xref write will fail
+	if(MaybeValidateMaxWritePositionForXref(inWritePosition) != PDFHummus::eSuccess) // if write position is larger than what can be represented by 10 digits, xref write will fail
 	{
-		TRACE_LOG1("IndirectObjectsReferenceRegistry::MarkObjectAsWritten, Write position out of bounds. Trying to write an object at position that cannot be represented in Xref = %lld. probably means file got too long",inWritePosition);
 		return PDFHummus::eFailure;
 	}
 
@@ -155,12 +174,10 @@ PDFHummus::EStatusCode IndirectObjectsReferenceRegistry::MarkObjectAsUpdated(Obj
 		return PDFHummus::eFailure; 
 	}
 
-	if(inNewWritePosition > 9999999999LL) // if write position is larger than what can be represented by 10 digits, xref write will fail
+	if(MaybeValidateMaxWritePositionForXref(inNewWritePosition) != PDFHummus::eSuccess) // if write position is larger than what can be represented by 10 digits, xref write will fail
 	{
-		TRACE_LOG1("IndirectObjectsReferenceRegistry::MarkObjectAsUpdated, Write position out of bounds. Trying to write an object at position that cannot be represented in Xref = %lld. probably means file got too long",inNewWritePosition);
 		return PDFHummus::eFailure;
-	}
-
+	}	
     
     mObjectsWritesRegistry[inObjectID].mIsDirty = true;
     mObjectsWritesRegistry[inObjectID].mWritePosition = inNewWritePosition;

--- a/PDFWriter/IndirectObjectsReferenceRegistry.h
+++ b/PDFWriter/IndirectObjectsReferenceRegistry.h
@@ -89,12 +89,16 @@ public:
 	void Reset();
  
     void SetupXrefFromModifiedFile(PDFParser* inModifiedFileParser);
+
+	void SetShouldValidateMaxWritePositionForXref(bool inShouldValidateMaxWritePositionForXref);
     
 private:
 	ObjectWriteInformationVector mObjectsWritesRegistry;
+	bool mShouldValidateMaxWritePositionForXref;
     
     void SetupInitialFreeObject();
     void AppendExistingItem(ObjectWriteInformation::EObjectReferenceType inObjectReferenceType,
                             unsigned long inGenerationNumber,
                             LongFilePositionType inWritePosition);
+	PDFHummus::EStatusCode MaybeValidateMaxWritePositionForXref(LongFilePositionType inWritePosition);
 };

--- a/PDFWriter/PDFWriter.h
+++ b/PDFWriter/PDFWriter.h
@@ -59,10 +59,16 @@ struct PDFCreationSettings
 	bool CompressStreams;
 	bool EmbedFonts;
 	EncryptionOptions DocumentEncryptionOptions;
+	bool WriteXrefAsXrefStream;
 
-	PDFCreationSettings(bool inCompressStreams, bool inEmbedFonts,EncryptionOptions inDocumentEncryptionOptions = EncryptionOptions::DefaultEncryptionOptions()):DocumentEncryptionOptions(inDocumentEncryptionOptions){
+	PDFCreationSettings(
+		bool inCompressStreams, 
+		bool inEmbedFonts,
+		EncryptionOptions inDocumentEncryptionOptions = EncryptionOptions::DefaultEncryptionOptions(), 
+		bool inWriteXrefAsXrefStream = false):DocumentEncryptionOptions(inDocumentEncryptionOptions){
 		CompressStreams = inCompressStreams;
 		EmbedFonts = inEmbedFonts;
+		WriteXrefAsXrefStream = inWriteXrefAsXrefStream;
 	}
 
 };

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -76,6 +76,7 @@ create_test_sourcelist (Tests
   UppercaseSequanceTest.cpp
   WatermarkTest.cpp
   WatermarkWithContextOpacityTest.cpp
+  XrefStreamsTest.cpp
 )
 
 # add the testing executable

--- a/PDFWriterTesting/XrefStreamsTest.cpp
+++ b/PDFWriterTesting/XrefStreamsTest.cpp
@@ -1,0 +1,134 @@
+/*
+   Source File : TestMeasurementsTest.cpp
+
+
+   Copyright 2011 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   
+*/
+#include "PDFWriter.h"
+#include "PDFPage.h"
+#include "PageContentContext.h"
+#include "PDFUsedFont.h"
+
+#include <iostream>
+
+#include "testing/TestIO.h"
+
+using namespace PDFHummus;
+
+
+int XrefStreamsTest(int argc, char* argv[])
+{
+	EStatusCode status = eSuccess;
+	PDFWriter pdfWriter;
+
+	do
+	{
+		status = pdfWriter.StartPDF(BuildRelativeOutputPath(argv,"XrefStreamsTest.pdf"),
+                                    ePDFVersion15,
+                                    LogConfiguration(true,true,BuildRelativeOutputPath(argv,"XrefStreamsTest.log")),
+									PDFCreationSettings(true,true,EncryptionOptions::DefaultEncryptionOptions(), true));
+												
+		if(status != eSuccess)
+		{
+			cout<<"Failed to start file\n";
+			break;
+		}
+
+		PDFPage* page = new PDFPage();
+		page->SetMediaBox(PDFRectangle(0,0,595,842));
+		
+		PageContentContext* cxt = pdfWriter.StartPageContentContext(page);
+
+		AbstractContentContext::TextOptions textOptions(pdfWriter.GetFontForFile(
+																			BuildRelativeInputPath(
+                                                                            argv,
+                                                                            "fonts/arial.ttf")),
+																			14,
+																			AbstractContentContext::eGray,
+																			0);
+		AbstractContentContext::GraphicOptions pathFillOptions(AbstractContentContext::eFill,
+																AbstractContentContext::eCMYK,
+																0xFF000000);
+		AbstractContentContext::GraphicOptions pathStrokeOptions(AbstractContentContext::eStroke,
+																AbstractContentContext::eRGB,
+																AbstractContentContext::ColorValueForName("DarkMagenta"),
+																4);
+
+		DoubleAndDoublePairList pathPoints;
+
+		// draw path
+		pathPoints.push_back(DoubleAndDoublePair(75,640));
+		pathPoints.push_back(DoubleAndDoublePair(149,800));
+		pathPoints.push_back(DoubleAndDoublePair(225,640));
+		cxt->DrawPath(pathPoints,pathFillOptions);
+		pathPoints.clear();
+		pathPoints.push_back(DoubleAndDoublePair(75,540));
+		pathPoints.push_back(DoubleAndDoublePair(110,440));
+		pathPoints.push_back(DoubleAndDoublePair(149,540));
+		pathPoints.push_back(DoubleAndDoublePair(188,440));
+		pathPoints.push_back(DoubleAndDoublePair(223,540));
+		cxt->DrawPath(pathPoints,pathStrokeOptions);
+
+		// draw square
+		cxt->DrawSquare(375,640,120,pathFillOptions);
+		cxt->DrawSquare(375,440,120,pathStrokeOptions);
+
+		// draw rectangle
+		cxt->DrawRectangle(375,220,50,160,pathFillOptions);
+		cxt->DrawRectangle(375,10,50,160,pathStrokeOptions);
+
+		// draw circle
+		cxt->DrawCircle(149,300,80,pathFillOptions);
+		cxt->DrawCircle(149,90,80,pathStrokeOptions);
+
+		// wrote text (writing labels for each of the shapes)
+		cxt->WriteText(10,820,"File With Xref Stremas",textOptions);
+		cxt->WriteText(75,805,"Paths",textOptions);
+		cxt->WriteText(375,805,"Squares",textOptions);
+		cxt->WriteText(375,400,"Rectangles",textOptions);
+		cxt->WriteText(75,400,"Circles",textOptions);
+
+		status = pdfWriter.EndPageContentContext(cxt);
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to end content context\n";
+			break;
+		}
+
+		status = pdfWriter.WritePageAndRelease(page);
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to write page\n";
+			break;
+		}
+
+
+		status = pdfWriter.EndPDF();
+		if(status != eSuccess)
+		{
+			status = PDFHummus::eFailure;
+			cout<<"Failed to end pdf\n";
+			break;
+		}
+
+	}while(false);
+
+
+	return status == eSuccess ? 0:1;
+}


### PR DESCRIPTION
Enable using Xref streams for regular PDF files (and not just modified files, as it was). To do this provide StartPDF/StartPDFForStream with PDFCreationSettings which inWriteXrefAsXrefStream is true. You should also aim for PDFVersion of 1.5 or higher (the last one is more for the sake of readers as xref streams are a 1.5 feature (or higher).

See XrefStreamsTest.cpp for an example.

What this allows is to lift the limit of 10gbs for file size imposed by regular xrefs that use 10 decimal digits to describe file offset. You can now use the full long long kind of size (~8 EBs or ~8K TBs).  