### PR TITLE
refactor: replace ByteList type from std::list to std::basic_string

### DIFF
--- a/PDFWriter/ByteList.cpp
+++ b/PDFWriter/ByteList.cpp
@@ -3,50 +3,23 @@
 using namespace IOBasicTypes;
 
 ByteList stringToByteList(const std::string& inString) {
-	ByteList buffer;
-	std::string::const_iterator it = inString.begin();
-
-	for (; it != inString.end(); ++it)
-		buffer.push_back((Byte)*it);
-
-	return buffer;
+	return ByteList(reinterpret_cast<const Byte *>(inString.data()), inString.size());
 }
 
+// are substr, append and concat really needed?
 ByteList substr(const ByteList& inList, IOBasicTypes::LongBufferSizeType inStart, IOBasicTypes::LongBufferSizeType inLength) {
-	ByteList buffer;
-	ByteList::const_iterator it = inList.begin();
-
-	for (IOBasicTypes::LongBufferSizeType i = 0; i < inStart && it != inList.end(); ++i, ++it);
-
-	for (IOBasicTypes::LongBufferSizeType i = 0; i < inLength && it != inList.end(); ++i, ++it)
-		buffer.push_back((Byte)*it);
-
-	return buffer;
+	return inList.substr(inStart, inLength);
 }
 
 void append(ByteList& ioTargetList, const ByteList& inSource) {
-	ByteList::const_iterator it = inSource.begin();
-
-	for (; it != inSource.end(); ++it)
-		ioTargetList.push_back(*it);
+	ioTargetList.append(inSource);
 }
 
 ByteList concat(const ByteList& inA, const ByteList& inB) {
-	ByteList buffer;
-
-	append(buffer, inA);
-	append(buffer, inB);
-
-	return buffer;
+	return inA + inB;
 }
 
 
 std::string ByteListToString(const ByteList& inByteList) {
-	std::string buffer;
-	ByteList::const_iterator it = inByteList.begin();
-
-	for (; it != inByteList.end(); ++it)
-		buffer.push_back((char)*it);
-
-	return buffer;
+	return std::string(reinterpret_cast<const char *>(inByteList.data()), inByteList.size());
 }

--- a/PDFWriter/ByteList.h
+++ b/PDFWriter/ByteList.h
@@ -2,10 +2,9 @@
 
 #include "IOBasicTypes.h"
 
-#include <list>
 #include <string>
 
-typedef std::list<IOBasicTypes::Byte> ByteList;
+typedef std::basic_string<IOBasicTypes::Byte> ByteList;
 
 
 ByteList stringToByteList(const std::string& inString);

--- a/PDFWriter/InputAESDecodeStream.h
+++ b/PDFWriter/InputAESDecodeStream.h
@@ -24,9 +24,9 @@
 #include "IByteReader.h"
 #include "aescpp.h"
 
-#include <list>
+#include <string>
 
-typedef std::list<IOBasicTypes::Byte> ByteList;
+typedef std::basic_string<IOBasicTypes::Byte> ByteList;
 
 class InputAESDecodeStream : public IByteReader
 {

--- a/PDFWriter/InputRC4XcodeStream.h
+++ b/PDFWriter/InputRC4XcodeStream.h
@@ -22,9 +22,9 @@
 #include "IByteReader.h"
 #include "RC4.h"
 
-#include <list>
+#include <string>
 
-typedef std::list<IOBasicTypes::Byte> ByteList;
+typedef std::basic_string<IOBasicTypes::Byte> ByteList;
 
 class InputRC4XcodeStream : public IByteReader
 {

--- a/PDFWriter/MD5Generator.h
+++ b/PDFWriter/MD5Generator.h
@@ -67,11 +67,10 @@
 
 #include "EStatusCode.h"
 #include "IOBasicTypes.h"
-#include <list>
 #include <string>
 
 
-typedef std::list<IOBasicTypes::Byte> ByteList;
+typedef std::basic_string<IOBasicTypes::Byte> ByteList;
 
 class MD5Generator
 {

--- a/PDFWriter/OutputAESEncodeStream.h
+++ b/PDFWriter/OutputAESEncodeStream.h
@@ -22,9 +22,9 @@ limitations under the License.
 #include "IByteWriterWithPosition.h"
 #include "aescpp.h"
 
-#include <list>
+#include <string>
 
-typedef std::list<IOBasicTypes::Byte> ByteList;
+typedef std::basic_string<IOBasicTypes::Byte> ByteList;
 
 
 class OutputAESEncodeStream : public IByteWriterWithPosition

--- a/PDFWriter/OutputRC4XcodeStream.h
+++ b/PDFWriter/OutputRC4XcodeStream.h
@@ -22,9 +22,9 @@ limitations under the License.
 #include "IByteWriterWithPosition.h"
 #include "RC4.h"
 
-#include <list>
+#include <string>
 
-typedef std::list<IOBasicTypes::Byte> ByteList;
+typedef std::basic_string<IOBasicTypes::Byte> ByteList;
 
 
 class OutputRC4XcodeStream : public IByteWriterWithPosition

--- a/PDFWriter/RC4.h
+++ b/PDFWriter/RC4.h
@@ -21,9 +21,9 @@ limitations under the License.
 #pragma once
 
 #include "IOBasicTypes.h"
-#include <list>
+#include <string>
 
-typedef std::list<IOBasicTypes::Byte> ByteList;
+typedef std::basic_string<IOBasicTypes::Byte> ByteList;
 
 class RC4
 {


### PR DESCRIPTION
It is really inefficient to have std::list<IOBasicTypes::Byte> has huge overhead as each single Byte would be
struct Node {
  Node* prev;    // 8 B
  Node* next;    // 8 B
  byte  value;   // 1 B
  // padding/alignment → ~24 B total
};
then there is cache unfriendly traversal, allocation cost...

Alternatives could be std::vector<IOBasicTypes::Byte> or std::deque<byte>, but std::basic_string seems a better fit as it already has substr, append, and similar operations.

After this change, maybe ByteList isn't the best name anymore, but I went for minimal changes