### PR TITLE
bug: embedding an external PDF inverted its width and height

### DIFF
--- a/PDFWriter/DocumentContext.cpp
+++ b/PDFWriter/DocumentContext.cpp
@@ -3136,8 +3136,8 @@ DoubleAndDoublePair DocumentContext::GetImageDimensions(
 
 				PDFPageInput helper(&pdfParser,pdfParser.ParsePage(inImageIndex));
 
-				imageWidth = helper.GetMediaBox().GetHeight();
-				imageHeight = helper.GetMediaBox().GetWidth();
+				imageWidth = helper.GetMediaBox().GetWidth();
+				imageHeight = helper.GetMediaBox().GetHeight();
 
 				break;
 			}


### PR DESCRIPTION
As a result, when using the embedded PDF's GetImageDimensions() to create a new page from it, the [new page was landscape](https://tmp.outters.eu/cv.misrotatedembed.pdf) when [the original was portrait](https://tmp.outters.eu/gui/cv.pdf.parchemin.pdf), **truncating its top part**

I found it while trying to generate my curriculum vitae after updating PDF-Writer from a very old version to 4.7.0, getting this unexpected result. Bissecting through each release between 4.1 and 4.7.0 duly recompiled, until finding the difference of output between 4.5.11 and 4.5.12, which lead me to [the diff with _right_ lines 2922 and 2923 but _wrong_ lines 3005 and 3006](https://github.com/galkahana/PDF-Writer/compare/v4.5.11...v4.5.12#diff-6083d687ce7a1c2fd3faed0d3e3fb95eae290cc8914610bd1c812b8fe85d64f6R2922-R3006):
```diff
-      imageWidth = helper.GetMediaBox().UpperRightX - helper.GetMediaBox().LowerLeftX;
-      imageHeight = helper.GetMediaBox().UpperRightY - helper.GetMediaBox().LowerLeftY;
+      imageWidth = helper.GetMediaBox().GetWidth(); // ← ✅ Here Width = GetWidth()
+      imageHeight = helper.GetMediaBox().GetHeight();
       […]
-				imageWidth = helper.GetMediaBox().UpperRightX - helper.GetMediaBox().LowerLeftX;
-				imageHeight = helper.GetMediaBox().UpperRightY - helper.GetMediaBox().LowerLeftY;
+				imageWidth = helper.GetMediaBox().GetHeight(); // ← ❌ Here Width = GetHeight()
+				imageHeight = helper.GetMediaBox().GetWidth();
```