### PR TITLE
Add Development Guidelines section to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,15 @@ Install these extensions:
 cd build && cpack .
 ```
 
+### Development Guidelines
+For detailed development guidelines, coding standards, and contribution patterns, see [CLAUDE.md](./CLAUDE.md). This document contains:
+- Project coding standards and conventions
+- Build commands and configuration options
+- Error handling patterns and best practices
+- Testing guidelines and organizational structure
+
+This documentation is also optimized for AI-assisted development with Claude Code.
+
 ## Additional Build Instructions
 
 **iOS**: See [build guide](http://pdfhummus.com/post/45501609236/how-to-build-iphone-apps-that-use-pdfhummus)


### PR DESCRIPTION
## Summary
- Added a new "Development Guidelines" subsection under the Development section in README.md
- References CLAUDE.md for detailed coding standards, build commands, error handling patterns, and testing guidelines
- Helps contributors understand project conventions and supports AI-assisted development

## Test plan
- [x] Verify README.md renders correctly with new section
- [x] Confirm CLAUDE.md link works properly
- [x] Check that section placement is logical within README structure

🤖 Generated with [Claude Code](https://claude.ai/code)