### PR TITLE
bug: when parsing stream with filters array and decoded params the incorrect variable was used to determine the filter name

### DIFF
--- a/PDFWriter/PDFParser.cpp
+++ b/PDFWriter/PDFParser.cpp
@@ -1938,7 +1938,7 @@ IByteReader* PDFParser::CreateInputStreamReader(PDFStreamInput* inStream)
 				{
 					PDFObjectCastPtr<PDFDictionary> decodeParamsItem(QueryArrayObject(decodeParams.GetPtr(),i));
 
-					createStatus = CreateFilterForStream(result,(PDFName*)filterObject.GetPtr(), !decodeParamsItem ? NULL: decodeParamsItem.GetPtr(), inStream);
+					createStatus = CreateFilterForStream(result,filterObjectItem.GetPtr(), !decodeParamsItem ? NULL: decodeParamsItem.GetPtr(), inStream);
 				}
 
 				if(createStatus.first != eSuccess)


### PR DESCRIPTION
this causes the crash in https://github.com/galkahana/PDF-Writer/issues/318.
a _very_ old line using `filterObect` which is the array object, instead of the `filterObjectItem` which is the filter name.
and the signs that something is wrong were there. i guess it wasn't compiling which is why i put casting...instead of noticing something is wrong.

anyways. correction should fix the issue.