### PR TITLE
bug: file pointing to non existant object fails to copy, should just mark as non existant

### DIFF
--- a/PDFWriter/PDFDocumentHandler.cpp
+++ b/PDFWriter/PDFDocumentHandler.cpp
@@ -599,19 +599,25 @@ EStatusCode PDFDocumentHandler::CopyInDirectObject(ObjectIDType inSourceObjectID
 	RefCountPtr<PDFObject> sourceObject = mParser->ParseNewObject(inSourceObjectID);
 	if(!sourceObject)
 	{
+		// if the object did not parse, check if it does not have an xref entry or is marked for deletion. in either of those
+		// cases it means we have a reference to a non existant object, which is _valid_ in PDF and just means it's a null.
+		// in all those cases, create a deleted object reference, so we can keep the xref table sequential.
 		XrefEntryInput* xrefEntry = mParser->GetXrefEntry(inSourceObjectID);
-		if ((xrefEntry != NULL) && (xrefEntry->mType == eXrefEntryDelete)) {
-			// if the object is deleted, replace with a deleted object
+		if (
+			(xrefEntry == NULL) || // index exceeds xref entry size
+			(xrefEntry != NULL) && (
+				xrefEntry->mType == eXrefEntryDelete // object is marked as deleted (free object)
+				|| xrefEntry->mType == eXrefEntryUndefined // object is internally marked as undefined which means we got holes in the source xref tables ranges
+			))  {
 			status = mObjectsContext->GetInDirectObjectsRegistry().DeleteObject(inTargetObjectID);
 			if (status != PDFHummus::eSuccess) {
-				TRACE_LOG1("PDFDocumentHandler::CopyInDirectObject, failed mark object as deleted. %ld", inTargetObjectID);
+				TRACE_LOG2("PDFDocumentHandler::CopyInDirectObject, failed mark source object %ld object as deleted object with target ID %ld", inSourceObjectID, inTargetObjectID);
 				return status;
 			}
 			return status;
-		}
-		else {
-			// fail
-			TRACE_LOG1("PDFDocumentHandler::CopyInDirectObject, object not found. %ld", inSourceObjectID);
+		} else {
+			// fail, couldn't parse an object that has a valid xref entry
+			TRACE_LOG1("PDFDocumentHandler::CopyInDirectObject, cannot parse source object %ld", inSourceObjectID);
 			return PDFHummus::eFailure;
 		}
 	}


### PR DESCRIPTION
copying fails if source object reference points to a nonexistent object.  however...that's actually valid. to keep the output xref consecutive...so the next guy got easier job to parse....just mark those cases as deleted as well.

this should allow copying content of PDFs with pointers to null.

this corrects item number 2 in https://github.com/galkahana/PDF-Writer/issues/329