### PR TITLE
fix: add bounds check for LZW decoder sequence buffer

### DIFF
--- a/PDFWriter/InputLZWDecodeStream.cpp
+++ b/PDFWriter/InputLZWDecodeStream.cpp
@@ -23,7 +23,6 @@
 #include "Trace.h"
 #include "zlib.h"
 
-
 InputLZWDecodeStream::InputLZWDecodeStream(int early)
 {
 	mSourceStream = NULL;
@@ -114,7 +113,7 @@ bool InputLZWDecodeStream::ProcessNextCode()
 		if(!mCurrentlyEncoding)
 			break;		
 
-		if (nextCode >= 4097) 
+		if (nextCode >= LZW_MAX_CODE) 
 		{
 			//error(getPos(), "Bad LZW stream - expected clear-table code");
 			ClearTable();
@@ -130,7 +129,7 @@ bool InputLZWDecodeStream::ProcessNextCode()
 		else if (code < nextCode) 
 		{
 			seqLength = table[code].length;
-			if (seqLength >= 4097)
+			if (seqLength >= LZW_MAX_CODE)
 			{
 				TRACE_LOG("InputLZWDecodeStream::ProcessNextCode, sequence length exceeds seqBuf bounds");
 				mCurrentlyEncoding = false;
@@ -144,7 +143,7 @@ bool InputLZWDecodeStream::ProcessNextCode()
 		}
 		else if (code == nextCode) 
 		{
-			if (seqLength >= 4097)
+			if (seqLength >= LZW_MAX_CODE)
 			{
 				TRACE_LOG("InputLZWDecodeStream::ProcessNextCode, sequence length exceeds seqBuf bounds");
 				mCurrentlyEncoding = false;

--- a/PDFWriter/InputLZWDecodeStream.cpp
+++ b/PDFWriter/InputLZWDecodeStream.cpp
@@ -130,6 +130,12 @@ bool InputLZWDecodeStream::ProcessNextCode()
 		else if (code < nextCode) 
 		{
 			seqLength = table[code].length;
+			if (seqLength >= 4097)
+			{
+				TRACE_LOG("InputLZWDecodeStream::ProcessNextCode, sequence length exceeds seqBuf bounds");
+				mCurrentlyEncoding = false;
+				break;
+			}
 			for (i = seqLength - 1, j = code; i > 0; --i) {
 				seqBuf[i] = table[j].tail;
 				j = table[j].head;
@@ -138,6 +144,12 @@ bool InputLZWDecodeStream::ProcessNextCode()
 		}
 		else if (code == nextCode) 
 		{
+			if (seqLength >= 4097)
+			{
+				TRACE_LOG("InputLZWDecodeStream::ProcessNextCode, sequence length exceeds seqBuf bounds");
+				mCurrentlyEncoding = false;
+				break;
+			}
 			seqBuf[seqLength] = newChar;
 			++seqLength;
 		}

--- a/PDFWriter/InputLZWDecodeStream.cpp
+++ b/PDFWriter/InputLZWDecodeStream.cpp
@@ -113,7 +113,7 @@ bool InputLZWDecodeStream::ProcessNextCode()
 		if(!mCurrentlyEncoding)
 			break;		
 
-		if (nextCode >= LZW_MAX_CODE) 
+		if (nextCode >= LZW_TABLE_SIZE) 
 		{
 			//error(getPos(), "Bad LZW stream - expected clear-table code");
 			ClearTable();
@@ -129,7 +129,7 @@ bool InputLZWDecodeStream::ProcessNextCode()
 		else if (code < nextCode) 
 		{
 			seqLength = table[code].length;
-			if (seqLength >= LZW_MAX_CODE)
+			if (seqLength > LZW_TABLE_SIZE)
 			{
 				TRACE_LOG("InputLZWDecodeStream::ProcessNextCode, sequence length exceeds seqBuf bounds");
 				mCurrentlyEncoding = false;
@@ -143,7 +143,7 @@ bool InputLZWDecodeStream::ProcessNextCode()
 		}
 		else if (code == nextCode) 
 		{
-			if (seqLength >= LZW_MAX_CODE)
+			if (seqLength >= LZW_TABLE_SIZE)
 			{
 				TRACE_LOG("InputLZWDecodeStream::ProcessNextCode, sequence length exceeds seqBuf bounds");
 				mCurrentlyEncoding = false;

--- a/PDFWriter/InputLZWDecodeStream.h
+++ b/PDFWriter/InputLZWDecodeStream.h
@@ -23,6 +23,9 @@
 #include "EStatusCode.h"
 #include "IByteReader.h"
 
+#define LZW_MAX_CODE 4097
+
+
 class InputLZWDecodeStream : public IByteReader
 {
 public:
@@ -57,12 +60,12 @@ private:
 		int length;
 		int head;
 		IOBasicTypes::Byte tail;
-	} table[4097];
+	} table[LZW_MAX_CODE];
 	int nextCode;			// next code to be used
 	int nextBits;			// number of bits in next code word
 	int prevCode;			// previous code used in stream
 	int newChar;			// next char to be added to table
-	IOBasicTypes::Byte		seqBuf[4097];		// buffer for current sequence
+	IOBasicTypes::Byte		seqBuf[LZW_MAX_CODE];		// buffer for current sequence
 	int seqLength;		// length of current sequence
 	int seqIndex;			// index into current sequence
 	bool first;			// first code after a table clear

--- a/PDFWriter/InputLZWDecodeStream.h
+++ b/PDFWriter/InputLZWDecodeStream.h
@@ -23,7 +23,7 @@
 #include "EStatusCode.h"
 #include "IByteReader.h"
 
-#define LZW_MAX_CODE 4097
+#define LZW_TABLE_SIZE 4097
 
 
 class InputLZWDecodeStream : public IByteReader
@@ -60,12 +60,12 @@ private:
 		int length;
 		int head;
 		IOBasicTypes::Byte tail;
-	} table[LZW_MAX_CODE];
+	} table[LZW_TABLE_SIZE];
 	int nextCode;			// next code to be used
 	int nextBits;			// number of bits in next code word
 	int prevCode;			// previous code used in stream
 	int newChar;			// next char to be added to table
-	IOBasicTypes::Byte		seqBuf[LZW_MAX_CODE];		// buffer for current sequence
+	IOBasicTypes::Byte		seqBuf[LZW_TABLE_SIZE];		// buffer for current sequence
 	int seqLength;		// length of current sequence
 	int seqIndex;			// index into current sequence
 	bool first;			// first code after a table clear


### PR DESCRIPTION
## Severity: 7.5 HIGH

## Summary
- Fix heap buffer overflow vulnerability in LZW decoder's `ProcessNextCode()` method in `InputLZWDecodeStream.cpp`

## Description
The `seqBuf` array in the LZW decoder is 4097 bytes, but there was no bounds checking before writing to it. In two code paths within `ProcessNextCode()`:

1. **`code < nextCode` branch**: `seqLength` is set from `table[code].length` which could exceed 4097 if the table is corrupted by a malicious LZW stream.
2. **`code == nextCode` branch**: `seqLength` is incremented and used as an index into `seqBuf` without checking it remains within bounds.

A crafted LZW stream could exploit either path to write beyond the `seqBuf` buffer, causing heap overflow.

## Fix
Added `if (seqLength >= 4097)` bounds checks in both branches. When the limit is exceeded, encoding is stopped gracefully with a TRACE_LOG diagnostic message, following the existing error handling pattern in the function.

## Test plan
- [ ] Verify existing tests pass with `ctest --test-dir . -C Release`
- [ ] Verify that LZW-compressed PDF streams still decode correctly
- [ ] Verify that malformed LZW streams with excessive sequence lengths are handled gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)