### PR TITLE
fix: initialize mKey to NULL in AES decode default constructor

### DIFF
--- a/PDFWriter/InputAESDecodeStream.cpp
+++ b/PDFWriter/InputAESDecodeStream.cpp
@@ -28,6 +28,7 @@ using namespace IOBasicTypes;
 InputAESDecodeStream::InputAESDecodeStream()
 {
 	mSourceStream = NULL;
+	mKey = NULL;
 }
 
 


### PR DESCRIPTION
## Summary
- **Severity**: 5.3 MEDIUM (CWE-824: Access of Uninitialized Pointer)
- Initialize `mKey` to `NULL` in the `InputAESDecodeStream` default constructor to prevent undefined behavior in the destructor

## Problem
The default constructor of `InputAESDecodeStream` only initialized `mSourceStream` but left `mKey` uninitialized. The destructor unconditionally checks `if (mKey)` before calling `delete[] mKey`. When `mKey` holds an indeterminate value (garbage pointer), this check is undefined behavior and could evaluate to true, causing `delete[]` on a garbage address -- resulting in a crash or heap corruption.

## Fix
Add `mKey = NULL;` to the default constructor in `PDFWriter/InputAESDecodeStream.cpp`. This ensures the destructor's `if (mKey)` check is well-defined and the `delete[]` is safely skipped when the parameterized constructor was never called.

## Test plan
- [x] Verified the fix is a minimal, single-line addition consistent with C99-compatible coding style
- [ ] Build and run existing test suite (`ctest --test-dir . -C Release`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)