### PR TITLE
fix: include <stdint.h> for SIZE_MAX to fix Ubuntu build

### DIFF
--- a/PDFWriter/InputPredictorTIFFSubStream.cpp
+++ b/PDFWriter/InputPredictorTIFFSubStream.cpp
@@ -20,7 +20,7 @@
 */
 #include "InputPredictorTIFFSubStream.h"
 #include "Trace.h"
-#include <stddef.h>
+#include <stdint.h>
 
 using namespace IOBasicTypes;
 


### PR DESCRIPTION
## Summary
- Fixes Ubuntu CI build failure introduced by PR #337
- `SIZE_MAX` is defined in `<stdint.h>`, not `<stddef.h>`. On macOS it works via transitive includes but GCC on Ubuntu is stricter.

## Test plan
- CI should pass on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)