### PR TITLE
feat: guard against max depth and cycle in reading parent

### DIFF
--- a/PDFWriter/PDFPageInput.cpp
+++ b/PDFWriter/PDFPageInput.cpp
@@ -25,6 +25,9 @@
 #include "Trace.h"
 #include "PDFName.h"
 #include "ParsedPrimitiveHelper.h"
+#include "PDFIndirectObjectReference.h"
+
+#include <set>
 
 using namespace PDFHummus;
 
@@ -151,21 +154,65 @@ PDFRectangle PDFPageInput::GetArtBox()
 
 
 static const std::string scParent = "Parent";
-PDFObject* PDFPageInput::QueryInheritedValue(PDFDictionary* inDictionary,const std::string& inName)
+static const int scMaxInheritedLookupDepth = 100;
+
+PDFObject* PDFPageInput::QueryInheritedValue(PDFDictionary* inDictionary, const std::string& inName,
+                                              std::set<ObjectIDType>* ioVisitedParentIDs, int inCurrentDepth)
 {
+	if(!inDictionary)
+		return NULL;
+
+	// Check depth limit
+	if(inCurrentDepth >= scMaxInheritedLookupDepth)
+	{
+		TRACE_LOG2("PDFPageInput::QueryInheritedValue, reached maximum inherited lookup depth of %d while searching for %s",
+			scMaxInheritedLookupDepth, inName.substr(0, 100).c_str());
+		return NULL;
+	}
+
+	// Check if key exists in current dictionary
 	if(inDictionary->Exists(inName))
 	{
-		return mParser->QueryDictionaryObject(inDictionary,inName);
+		return mParser->QueryDictionaryObject(inDictionary, inName);
 	}
-	else if(inDictionary->Exists(scParent))
+
+	// Check for Parent and recurse
+	if(inDictionary->Exists(scParent))
 	{
-		PDFObjectCastPtr<PDFDictionary> parent(mParser->QueryDictionaryObject(inDictionary,scParent));
+		// Get parent as direct object first to detect indirect references
+		RefCountPtr<PDFObject> parentDirect(inDictionary->QueryDirectObject(scParent));
+		if(!parentDirect)
+			return NULL;
+
+		// If parent is an indirect reference, check for cycles
+		if(parentDirect->GetType() == PDFObject::ePDFObjectIndirectObjectReference)
+		{
+			ObjectIDType parentID = ((PDFIndirectObjectReference*)parentDirect.GetPtr())->mObjectID;
+			if(ioVisitedParentIDs->find(parentID) != ioVisitedParentIDs->end())
+			{
+				TRACE_LOG2("PDFPageInput::QueryInheritedValue, cycle detected in Parent chain at object %ld while searching for %s",
+					parentID, inName.substr(0, 100).c_str());
+				return NULL;
+			}
+			ioVisitedParentIDs->insert(parentID);
+		}
+
+		// Now resolve the parent dictionary
+		PDFObjectCastPtr<PDFDictionary> parent(mParser->QueryDictionaryObject(inDictionary, scParent));
 		if(!parent)
 			return NULL;
-		return QueryInheritedValue(parent.GetPtr(),inName);
+
+		// Recurse into parent
+		return QueryInheritedValue(parent.GetPtr(), inName, ioVisitedParentIDs, inCurrentDepth + 1);
 	}
-	else
-		return NULL;
+
+	return NULL;
+}
+
+PDFObject* PDFPageInput::QueryInheritedValue(PDFDictionary* inDictionary, const std::string& inName)
+{
+	std::set<ObjectIDType> visitedParentIDs;
+	return QueryInheritedValue(inDictionary, inName, &visitedParentIDs, 0);
 }
 
 EStatusCode PDFPageInput::SetPDFRectangleFromPDFArray(PDFArray* inPDFArray,PDFRectangle& outPDFRectangle)

--- a/PDFWriter/PDFPageInput.cpp
+++ b/PDFWriter/PDFPageInput.cpp
@@ -26,8 +26,7 @@
 #include "PDFName.h"
 #include "ParsedPrimitiveHelper.h"
 #include "PDFIndirectObjectReference.h"
-
-#include <set>
+#include "PDFParsingPath.h"
 
 using namespace PDFHummus;
 
@@ -157,7 +156,7 @@ static const std::string scParent = "Parent";
 static const int scMaxInheritedLookupDepth = 100;
 
 PDFObject* PDFPageInput::QueryInheritedValue(PDFDictionary* inDictionary, const std::string& inName,
-                                              std::set<ObjectIDType>* ioVisitedParentIDs, int inCurrentDepth)
+                                              PDFParsingPath* ioParsingPath, int inCurrentDepth)
 {
 	if(!inDictionary)
 		return NULL;
@@ -184,26 +183,35 @@ PDFObject* PDFPageInput::QueryInheritedValue(PDFDictionary* inDictionary, const 
 		if(!parentDirect)
 			return NULL;
 
-		// If parent is an indirect reference, check for cycles
-		if(parentDirect->GetType() == PDFObject::ePDFObjectIndirectObjectReference)
+		// Extract parent ID if it's an indirect reference
+		ObjectIDType parentID = 0;
+		bool isIndirectRef = (parentDirect->GetType() == PDFObject::ePDFObjectIndirectObjectReference);
+		if(isIndirectRef)
 		{
-			ObjectIDType parentID = ((PDFIndirectObjectReference*)parentDirect.GetPtr())->mObjectID;
-			if(ioVisitedParentIDs->find(parentID) != ioVisitedParentIDs->end())
+			parentID = ((PDFIndirectObjectReference*)parentDirect.GetPtr())->mObjectID;
+			if(ioParsingPath->EnterObject(parentID) != PDFHummus::eSuccess)
 			{
 				TRACE_LOG2("PDFPageInput::QueryInheritedValue, cycle detected in Parent chain at object %ld while searching for %s",
 					parentID, inName.substr(0, 100).c_str());
 				return NULL;
 			}
-			ioVisitedParentIDs->insert(parentID);
 		}
 
 		// Now resolve the parent dictionary
 		PDFObjectCastPtr<PDFDictionary> parent(mParser->QueryDictionaryObject(inDictionary, scParent));
-		if(!parent)
-			return NULL;
-
-		// Recurse into parent
-		return QueryInheritedValue(parent.GetPtr(), inName, ioVisitedParentIDs, inCurrentDepth + 1);
+		
+		// Recurse into parent if it exists
+		PDFObject* result = NULL;
+		if(!!parent)
+		{
+			result = QueryInheritedValue(parent.GetPtr(), inName, ioParsingPath, inCurrentDepth + 1);
+		}
+		
+		// Exit the indirect reference if we entered it
+		if(isIndirectRef)
+			ioParsingPath->ExitObject(parentID);
+		
+		return result;
 	}
 
 	return NULL;
@@ -211,8 +219,8 @@ PDFObject* PDFPageInput::QueryInheritedValue(PDFDictionary* inDictionary, const 
 
 PDFObject* PDFPageInput::QueryInheritedValue(PDFDictionary* inDictionary, const std::string& inName)
 {
-	std::set<ObjectIDType> visitedParentIDs;
-	return QueryInheritedValue(inDictionary, inName, &visitedParentIDs, 0);
+	PDFParsingPath parsingPath;
+	return QueryInheritedValue(inDictionary, inName, &parsingPath, 0);
 }
 
 EStatusCode PDFPageInput::SetPDFRectangleFromPDFArray(PDFArray* inPDFArray,PDFRectangle& outPDFRectangle)

--- a/PDFWriter/PDFPageInput.cpp
+++ b/PDFWriter/PDFPageInput.cpp
@@ -191,7 +191,7 @@ PDFObject* PDFPageInput::QueryInheritedValue(PDFDictionary* inDictionary, const 
 			parentID = ((PDFIndirectObjectReference*)parentDirect.GetPtr())->mObjectID;
 			if(ioParsingPath->EnterObject(parentID) != PDFHummus::eSuccess)
 			{
-				TRACE_LOG2("PDFPageInput::QueryInheritedValue, cycle detected in Parent chain at object %ld while searching for %s",
+				TRACE_LOG2("PDFPageInput::QueryInheritedValue, cycle detected in Parent chain at object %lu while searching for %s",
 					parentID, inName.substr(0, 100).c_str());
 				return NULL;
 			}

--- a/PDFWriter/PDFPageInput.h
+++ b/PDFWriter/PDFPageInput.h
@@ -35,9 +35,9 @@
 #include "PDFDictionary.h"
 #include "EStatusCode.h"
 #include "ObjectsBasicTypes.h"
+#include "PDFParsingPath.h"
 
 #include <string>
-#include <set>
 
 
 
@@ -74,7 +74,7 @@ private:
     
 	PDFObject* QueryInheritedValue(PDFDictionary* inDictionary,const std::string& inName);
 	PDFObject* QueryInheritedValue(PDFDictionary* inDictionary,const std::string& inName,
-	                               std::set<ObjectIDType>* ioVisitedParentIDs,int inCurrentDepth);
+	                               PDFParsingPath* ioParsingPath,int inCurrentDepth);
     PDFHummus::EStatusCode SetPDFRectangleFromPDFArray(PDFArray* inPDFArray,PDFRectangle& outPDFRectangle);
     
     void AssertPageObjectValid();

--- a/PDFWriter/PDFPageInput.h
+++ b/PDFWriter/PDFPageInput.h
@@ -35,7 +35,6 @@
 #include "PDFDictionary.h"
 #include "EStatusCode.h"
 #include "ObjectsBasicTypes.h"
-#include "PDFParsingPath.h"
 
 #include <string>
 
@@ -44,6 +43,7 @@
 class PDFObject;
 class PDFParser;
 class PDFArray;
+class PDFParsingPath;
 
 class PDFPageInput
 {

--- a/PDFWriter/PDFPageInput.h
+++ b/PDFWriter/PDFPageInput.h
@@ -34,8 +34,10 @@
 #include "PDFObjectCast.h"
 #include "PDFDictionary.h"
 #include "EStatusCode.h"
+#include "ObjectsBasicTypes.h"
 
 #include <string>
+#include <set>
 
 
 
@@ -71,6 +73,8 @@ private:
     PDFObjectCastPtr<PDFDictionary> mPageObject;
     
 	PDFObject* QueryInheritedValue(PDFDictionary* inDictionary,const std::string& inName);
+	PDFObject* QueryInheritedValue(PDFDictionary* inDictionary,const std::string& inName,
+	                               std::set<ObjectIDType>* ioVisitedParentIDs,int inCurrentDepth);
     PDFHummus::EStatusCode SetPDFRectangleFromPDFArray(PDFArray* inPDFArray,PDFRectangle& outPDFRectangle);
     
     void AssertPageObjectValid();


### PR DESCRIPTION
this should deal with #345 and also add a depth limit, similar to the one in PDFObjectParser, so we match.