### PR TITLE
fix: guard against cycle and max depth in PDFModifiedPage Parent walk

### DIFF
--- a/PDFWriter/PDFModifiedPage.cpp
+++ b/PDFWriter/PDFModifiedPage.cpp
@@ -35,6 +35,7 @@
 #include "BoxingBase.h"
 #include "PDFStream.h"
 #include "PDFObject.h"
+#include "PDFParsingPath.h"
 #include "Trace.h"
 
 #include <string>
@@ -125,23 +126,66 @@ vector<string> PDFModifiedPage::WriteNewResourcesDictionary(ObjectsContext& inOb
 	return formResourcesNames;	
 }
 
-PDFObject* PDFModifiedPage::findInheritedResources(PDFParser* inParser,PDFDictionary* inDictionary) {
+static const std::string scParent = "Parent";
+static const int scMaxInheritedLookupDepth = 100;
+
+PDFObject* PDFModifiedPage::findInheritedResources(PDFParser* inParser,PDFDictionary* inDictionary,
+                                                   PDFParsingPath* ioParsingPath,int inCurrentDepth) {
+	if(!inDictionary)
+		return NULL;
+
+	if(inCurrentDepth >= scMaxInheritedLookupDepth)
+	{
+		TRACE_LOG1("PDFModifiedPage::findInheritedResources, reached maximum inherited lookup depth of %d while searching for Resources",
+			scMaxInheritedLookupDepth);
+		return NULL;
+	}
+
 	if(inDictionary->Exists("Resources")) {
 		return inParser->QueryDictionaryObject(inDictionary, "Resources");
 	}
-	else {
-		PDFObjectCastPtr<PDFDictionary> parentDict(
-			inDictionary->Exists("Parent") ? 
-				inParser->QueryDictionaryObject(inDictionary, "Parent"): 
-				NULL);
-		if(!parentDict) {
+
+	if(inDictionary->Exists(scParent))
+	{
+		// Get parent as direct object first to detect indirect references
+		RefCountPtr<PDFObject> parentDirect(inDictionary->QueryDirectObject(scParent));
+		if(!parentDirect)
 			return NULL;
+
+		// Extract parent ID if it's an indirect reference
+		ObjectIDType parentID = 0;
+		bool isIndirectRef = (parentDirect->GetType() == PDFObject::ePDFObjectIndirectObjectReference);
+		if(isIndirectRef)
+		{
+			parentID = ((PDFIndirectObjectReference*)parentDirect.GetPtr())->mObjectID;
+			if(ioParsingPath->EnterObject(parentID) != PDFHummus::eSuccess)
+			{
+				TRACE_LOG1("PDFModifiedPage::findInheritedResources, cycle detected in Parent chain at object %lu while searching for Resources",
+					parentID);
+				return NULL;
+			}
 		}
-		else {
-			return findInheritedResources(inParser,parentDict.GetPtr());
+
+		PDFObjectCastPtr<PDFDictionary> parent(inParser->QueryDictionaryObject(inDictionary, scParent));
+
+		PDFObject* result = NULL;
+		if(!!parent)
+		{
+			result = findInheritedResources(inParser, parent.GetPtr(), ioParsingPath, inCurrentDepth + 1);
 		}
-		
+
+		if(isIndirectRef)
+			ioParsingPath->ExitObject(parentID);
+
+		return result;
 	}
+
+	return NULL;
+}
+
+PDFObject* PDFModifiedPage::findInheritedResources(PDFParser* inParser,PDFDictionary* inDictionary) {
+	PDFParsingPath parsingPath;
+	return findInheritedResources(inParser, inDictionary, &parsingPath, 0);
 }
 
 PDFHummus::EStatusCode PDFModifiedPage::WritePage()

--- a/PDFWriter/PDFModifiedPage.h
+++ b/PDFWriter/PDFModifiedPage.h
@@ -33,6 +33,7 @@ class ObjectsContext;
 class ResourcesDictionary;
 class PDFParser;
 class PDFObject;
+class PDFParsingPath;
 
 typedef std::vector<PDFFormXObject*> PDFFormXObjectVector;
 
@@ -70,6 +71,8 @@ private:
 	unsigned char GetDifferentChar(unsigned char);
 	std::vector<std::string> WriteNewResourcesDictionary(ObjectsContext& inObjectContext);
 	PDFObject* findInheritedResources(PDFParser* inParser,PDFDictionary* inDictionary);
+	PDFObject* findInheritedResources(PDFParser* inParser,PDFDictionary* inDictionary,
+	                                  PDFParsingPath* ioParsingPath,int inCurrentDepth);
 
 };
 


### PR DESCRIPTION
## Summary

Sibling fix to #346, in `PDFModifiedPage::findInheritedResources`.

Problem: `PDFModifiedPage::findInheritedResources` walked the `/Parent` chain of a page dictionary looking for inherited `/Resources`, with no cycle detection and no depth limit. A page whose `/Parent` references itself (or any cycle in the parent chain) causes infinite recursion → stack overflow — the same crash class as #345.

The pre-existing implementation:

```cpp
PDFObject* PDFModifiedPage::findInheritedResources(PDFParser* inParser, PDFDictionary* inDictionary) {
    if(inDictionary->Exists("Resources")) {
        return inParser->QueryDictionaryObject(inDictionary, "Resources");
    }
    else {
        PDFObjectCastPtr<PDFDictionary> parentDict(
            inDictionary->Exists("Parent") ?
                inParser->QueryDictionaryObject(inDictionary, "Parent"):
                NULL);
        if(!parentDict) return NULL;
        return findInheritedResources(inParser, parentDict.GetPtr());
    }
}
```

is structurally identical to the `PDFPageInput::QueryInheritedValue` shape that #346 just fixed, and has the same bug. The reproducer from #345 crashes through this path when the affected page is processed via `PDFWriter::ModifyPDF` (which calls `WritePage` → `findInheritedResources` for pages without a direct `/Resources` entry).

## Fix

Mirrors the #346 approach exactly:
- Adds an internal overload `findInheritedResources(parser, dict, ioParsingPath, depth)`.
- Public method becomes a 3-line wrapper that creates a fresh `PDFParsingPath` and calls the overload at depth 0.
- Internal overload:
  - depth-limit check against `scMaxInheritedLookupDepth = 100` (same constant used in #346),
  - resolves `/Parent` as a direct object first; if it's an indirect reference, calls `ioParsingPath->EnterObject(parentID)` and returns `NULL` on cycle detection (with a `TRACE_LOG`),
  - resolves the parent dictionary, recurses with `depth+1`, then `ExitObject` if it had entered.

Constants `scParent` and `scMaxInheritedLookupDepth` are file-local (matching #346) — not yet factored into a shared helper. A follow-up refactor PR can collapse the three near-identical helpers (`PDFPageInput::QueryInheritedValue`, `PDFDocumentHandler::FindPageResources`, this one) into a single utility once each fix has landed; keeping this PR focused on the bug.

## Test plan

- [x] `cmake --build . --config Release` clean
- [x] `ctest -C Release` — 82/82 pass, no regressions
- [ ] Regression test (crafted PDF with self-referential `/Parent` driven through `ModifyPDF`) deferred to the planned regression-test PR alongside the other Phase 1 fuzz fixtures, matching the project's existing pattern where #346 also did not bundle a test

🤖 Generated with [Claude Code](https://claude.com/claude-code)