### PR TITLE
fix: guard against cycle and max depth in PDFDocumentHandler Parent walk

### DIFF
--- a/PDFWriter/PDFDocumentHandler.cpp
+++ b/PDFWriter/PDFDocumentHandler.cpp
@@ -34,6 +34,7 @@
 #include "InputFlateDecodeStream.h"
 #include "ObjectsContext.h"
 #include "PDFIndirectObjectReference.h"
+#include "PDFParsingPath.h"
 #include "PDFBoolean.h"
 #include "PDFSymbol.h"
 #include "DictionaryContext.h"
@@ -2505,21 +2506,64 @@ void PDFDocumentHandler::RegisterFormRelatedObjects(PDFFormXObject* inFormXObjec
     mDocumentContext->RegisterFormEndWritingTask(inFormXObject,new ObjectsCopyingTask(this,inObjectsToWrite));
 }
 
-PDFObject* PDFDocumentHandler::FindPageResources(PDFParser* inParser, PDFDictionary* inDictionary) {
+static const std::string scParent = "Parent";
+static const int scMaxInheritedLookupDepth = 100;
+
+PDFObject* PDFDocumentHandler::FindPageResources(PDFParser* inParser, PDFDictionary* inDictionary,
+                                                 PDFParsingPath* ioParsingPath, int inCurrentDepth) {
+	if(!inDictionary)
+		return NULL;
+
+	if(inCurrentDepth >= scMaxInheritedLookupDepth)
+	{
+		TRACE_LOG1("PDFDocumentHandler::FindPageResources, reached maximum inherited lookup depth of %d while searching for Resources",
+			scMaxInheritedLookupDepth);
+		return NULL;
+	}
+
 	if(inDictionary->Exists("Resources")) {
 		return inParser->QueryDictionaryObject(inDictionary, "Resources");
 	}
-	else {
-		PDFObjectCastPtr<PDFDictionary> parentDict(
-			inDictionary->Exists("Parent") ? 
-				inParser->QueryDictionaryObject(inDictionary, "Parent"): 
-				NULL);
-		if(!parentDict) {
+
+	if(inDictionary->Exists(scParent))
+	{
+		// Get parent as direct object first to detect indirect references
+		RefCountPtr<PDFObject> parentDirect(inDictionary->QueryDirectObject(scParent));
+		if(!parentDirect)
 			return NULL;
+
+		// Extract parent ID if it's an indirect reference
+		ObjectIDType parentID = 0;
+		bool isIndirectRef = (parentDirect->GetType() == PDFObject::ePDFObjectIndirectObjectReference);
+		if(isIndirectRef)
+		{
+			parentID = ((PDFIndirectObjectReference*)parentDirect.GetPtr())->mObjectID;
+			if(ioParsingPath->EnterObject(parentID) != PDFHummus::eSuccess)
+			{
+				TRACE_LOG1("PDFDocumentHandler::FindPageResources, cycle detected in Parent chain at object %lu while searching for Resources",
+					parentID);
+				return NULL;
+			}
 		}
-		else {
-			return FindPageResources(inParser,parentDict.GetPtr());
+
+		PDFObjectCastPtr<PDFDictionary> parent(inParser->QueryDictionaryObject(inDictionary, scParent));
+
+		PDFObject* result = NULL;
+		if(!!parent)
+		{
+			result = FindPageResources(inParser, parent.GetPtr(), ioParsingPath, inCurrentDepth + 1);
 		}
-		
-	}	
+
+		if(isIndirectRef)
+			ioParsingPath->ExitObject(parentID);
+
+		return result;
+	}
+
+	return NULL;
+}
+
+PDFObject* PDFDocumentHandler::FindPageResources(PDFParser* inParser, PDFDictionary* inDictionary) {
+	PDFParsingPath parsingPath;
+	return FindPageResources(inParser, inDictionary, &parsingPath, 0);
 }

--- a/PDFWriter/PDFDocumentHandler.h
+++ b/PDFWriter/PDFDocumentHandler.h
@@ -48,6 +48,7 @@ class IPDFParserExtender;
 class ICategoryServicesCommand;
 class PDFIndirectObjectReference;
 class PDFObject;
+class PDFParsingPath;
 
 
 namespace PDFHummus
@@ -324,6 +325,8 @@ private:
                                                            PDFDictionary* inSourcePage,
                                                            const StringToStringMap& inMappedResourcesNames);
 	PDFObject* FindPageResources(PDFParser* inParser, PDFDictionary* inDictionary);
+	PDFObject* FindPageResources(PDFParser* inParser, PDFDictionary* inDictionary,
+	                             PDFParsingPath* ioParsingPath, int inCurrentDepth);
 
 
 };


### PR DESCRIPTION
## Summary

Fixes V-016 from the Phase 1.5 consumer-layer audit: `PDFDocumentHandler::FindPageResources` walked the `/Parent` chain looking for inherited `/Resources` without cycle detection or depth limit. A page dictionary whose `/Parent` points back to itself (or any cycle in the parent chain) caused infinite recursion → stack overflow, the same failure mode as #345 / PR #346 in `PDFPageInput` and PR #347 in `PDFModifiedPage`.

This helper is reached from the page-copy / form-XObject-from-page / page-merge paths (`AppendPDFPagesFromPDF`, `CreatePDFFormXObjectsFromPDF`, `MergePDFPagesToPage`), so any consumer that copies, embeds, or merges a page from a malformed source PDF could hit it.

**Severity:** Medium (stack overflow / DoS on malicious or malformed input)

## Fix

Mirrors the #346 / #347 approach:
- Introduces a private overload taking a `PDFParsingPath` plus a depth counter
- Public method becomes a thin wrapper that creates the path and calls the overload at depth 0
- Reuses `scMaxInheritedLookupDepth = 100` to match prior fixes
- `PDFParsingPath::EnterObject` rejects already-visited indirect references, breaking cycles
- Direct (non-reference) `/Parent` is still traversed but contributes only to the depth bound

## Test plan
- [x] Full test suite passes (82/82) — `ctest -C Release`
- [x] Pattern verified against PR #346 (`PDFPageInput`) and PR #347 (`PDFModifiedPage`) reference fixes
- [ ] Regression test using marcoffee's reproducer adapted for `AppendPDFPagesFromPDF` will be added in the deferred Phase 1 / 1.5 regression-test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)