### PR TITLE
refactor: consolidate /Parent inheritance walks onto a single guarded helper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # exclude tests from exported git archives
 PDFWriterTesting export-ignore
+
+# PDF test materials are binary; never apply line-ending translation,
+# otherwise Windows checkout corrupts the precise byte offsets baked
+# into xref tables.
+*.pdf binary

--- a/PDFWriter/PDFDocumentHandler.cpp
+++ b/PDFWriter/PDFDocumentHandler.cpp
@@ -34,7 +34,6 @@
 #include "InputFlateDecodeStream.h"
 #include "ObjectsContext.h"
 #include "PDFIndirectObjectReference.h"
-#include "PDFParsingPath.h"
 #include "PDFBoolean.h"
 #include "PDFSymbol.h"
 #include "DictionaryContext.h"
@@ -2506,64 +2505,6 @@ void PDFDocumentHandler::RegisterFormRelatedObjects(PDFFormXObject* inFormXObjec
     mDocumentContext->RegisterFormEndWritingTask(inFormXObject,new ObjectsCopyingTask(this,inObjectsToWrite));
 }
 
-static const std::string scParent = "Parent";
-static const int scMaxInheritedLookupDepth = 100;
-
-PDFObject* PDFDocumentHandler::FindPageResources(PDFParser* inParser, PDFDictionary* inDictionary,
-                                                 PDFParsingPath* ioParsingPath, int inCurrentDepth) {
-	if(!inDictionary)
-		return NULL;
-
-	if(inCurrentDepth >= scMaxInheritedLookupDepth)
-	{
-		TRACE_LOG1("PDFDocumentHandler::FindPageResources, reached maximum inherited lookup depth of %d while searching for Resources",
-			scMaxInheritedLookupDepth);
-		return NULL;
-	}
-
-	if(inDictionary->Exists("Resources")) {
-		return inParser->QueryDictionaryObject(inDictionary, "Resources");
-	}
-
-	if(inDictionary->Exists(scParent))
-	{
-		// Get parent as direct object first to detect indirect references
-		RefCountPtr<PDFObject> parentDirect(inDictionary->QueryDirectObject(scParent));
-		if(!parentDirect)
-			return NULL;
-
-		// Extract parent ID if it's an indirect reference
-		ObjectIDType parentID = 0;
-		bool isIndirectRef = (parentDirect->GetType() == PDFObject::ePDFObjectIndirectObjectReference);
-		if(isIndirectRef)
-		{
-			parentID = ((PDFIndirectObjectReference*)parentDirect.GetPtr())->mObjectID;
-			if(ioParsingPath->EnterObject(parentID) != PDFHummus::eSuccess)
-			{
-				TRACE_LOG1("PDFDocumentHandler::FindPageResources, cycle detected in Parent chain at object %lu while searching for Resources",
-					parentID);
-				return NULL;
-			}
-		}
-
-		PDFObjectCastPtr<PDFDictionary> parent(inParser->QueryDictionaryObject(inDictionary, scParent));
-
-		PDFObject* result = NULL;
-		if(!!parent)
-		{
-			result = FindPageResources(inParser, parent.GetPtr(), ioParsingPath, inCurrentDepth + 1);
-		}
-
-		if(isIndirectRef)
-			ioParsingPath->ExitObject(parentID);
-
-		return result;
-	}
-
-	return NULL;
-}
-
 PDFObject* PDFDocumentHandler::FindPageResources(PDFParser* inParser, PDFDictionary* inDictionary) {
-	PDFParsingPath parsingPath;
-	return FindPageResources(inParser, inDictionary, &parsingPath, 0);
+	return inParser->QueryInheritedDictionaryEntry(inDictionary, "Resources");
 }

--- a/PDFWriter/PDFDocumentHandler.h
+++ b/PDFWriter/PDFDocumentHandler.h
@@ -48,7 +48,6 @@ class IPDFParserExtender;
 class ICategoryServicesCommand;
 class PDFIndirectObjectReference;
 class PDFObject;
-class PDFParsingPath;
 
 
 namespace PDFHummus
@@ -325,8 +324,6 @@ private:
                                                            PDFDictionary* inSourcePage,
                                                            const StringToStringMap& inMappedResourcesNames);
 	PDFObject* FindPageResources(PDFParser* inParser, PDFDictionary* inDictionary);
-	PDFObject* FindPageResources(PDFParser* inParser, PDFDictionary* inDictionary,
-	                             PDFParsingPath* ioParsingPath, int inCurrentDepth);
 
 
 };

--- a/PDFWriter/PDFModifiedPage.cpp
+++ b/PDFWriter/PDFModifiedPage.cpp
@@ -35,7 +35,6 @@
 #include "BoxingBase.h"
 #include "PDFStream.h"
 #include "PDFObject.h"
-#include "PDFParsingPath.h"
 #include "Trace.h"
 
 #include <string>
@@ -126,66 +125,8 @@ vector<string> PDFModifiedPage::WriteNewResourcesDictionary(ObjectsContext& inOb
 	return formResourcesNames;	
 }
 
-static const std::string scParent = "Parent";
-static const int scMaxInheritedLookupDepth = 100;
-
-PDFObject* PDFModifiedPage::findInheritedResources(PDFParser* inParser,PDFDictionary* inDictionary,
-                                                   PDFParsingPath* ioParsingPath,int inCurrentDepth) {
-	if(!inDictionary)
-		return NULL;
-
-	if(inCurrentDepth >= scMaxInheritedLookupDepth)
-	{
-		TRACE_LOG1("PDFModifiedPage::findInheritedResources, reached maximum inherited lookup depth of %d while searching for Resources",
-			scMaxInheritedLookupDepth);
-		return NULL;
-	}
-
-	if(inDictionary->Exists("Resources")) {
-		return inParser->QueryDictionaryObject(inDictionary, "Resources");
-	}
-
-	if(inDictionary->Exists(scParent))
-	{
-		// Get parent as direct object first to detect indirect references
-		RefCountPtr<PDFObject> parentDirect(inDictionary->QueryDirectObject(scParent));
-		if(!parentDirect)
-			return NULL;
-
-		// Extract parent ID if it's an indirect reference
-		ObjectIDType parentID = 0;
-		bool isIndirectRef = (parentDirect->GetType() == PDFObject::ePDFObjectIndirectObjectReference);
-		if(isIndirectRef)
-		{
-			parentID = ((PDFIndirectObjectReference*)parentDirect.GetPtr())->mObjectID;
-			if(ioParsingPath->EnterObject(parentID) != PDFHummus::eSuccess)
-			{
-				TRACE_LOG1("PDFModifiedPage::findInheritedResources, cycle detected in Parent chain at object %lu while searching for Resources",
-					parentID);
-				return NULL;
-			}
-		}
-
-		PDFObjectCastPtr<PDFDictionary> parent(inParser->QueryDictionaryObject(inDictionary, scParent));
-
-		PDFObject* result = NULL;
-		if(!!parent)
-		{
-			result = findInheritedResources(inParser, parent.GetPtr(), ioParsingPath, inCurrentDepth + 1);
-		}
-
-		if(isIndirectRef)
-			ioParsingPath->ExitObject(parentID);
-
-		return result;
-	}
-
-	return NULL;
-}
-
 PDFObject* PDFModifiedPage::findInheritedResources(PDFParser* inParser,PDFDictionary* inDictionary) {
-	PDFParsingPath parsingPath;
-	return findInheritedResources(inParser, inDictionary, &parsingPath, 0);
+	return inParser->QueryInheritedDictionaryEntry(inDictionary, "Resources");
 }
 
 PDFHummus::EStatusCode PDFModifiedPage::WritePage()

--- a/PDFWriter/PDFModifiedPage.h
+++ b/PDFWriter/PDFModifiedPage.h
@@ -33,7 +33,6 @@ class ObjectsContext;
 class ResourcesDictionary;
 class PDFParser;
 class PDFObject;
-class PDFParsingPath;
 
 typedef std::vector<PDFFormXObject*> PDFFormXObjectVector;
 
@@ -71,8 +70,6 @@ private:
 	unsigned char GetDifferentChar(unsigned char);
 	std::vector<std::string> WriteNewResourcesDictionary(ObjectsContext& inObjectContext);
 	PDFObject* findInheritedResources(PDFParser* inParser,PDFDictionary* inDictionary);
-	PDFObject* findInheritedResources(PDFParser* inParser,PDFDictionary* inDictionary,
-	                                  PDFParsingPath* ioParsingPath,int inCurrentDepth);
 
 };
 

--- a/PDFWriter/PDFPageInput.cpp
+++ b/PDFWriter/PDFPageInput.cpp
@@ -25,8 +25,6 @@
 #include "Trace.h"
 #include "PDFName.h"
 #include "ParsedPrimitiveHelper.h"
-#include "PDFIndirectObjectReference.h"
-#include "PDFParsingPath.h"
 
 using namespace PDFHummus;
 
@@ -152,75 +150,9 @@ PDFRectangle PDFPageInput::GetArtBox()
 }
 
 
-static const std::string scParent = "Parent";
-static const int scMaxInheritedLookupDepth = 100;
-
-PDFObject* PDFPageInput::QueryInheritedValue(PDFDictionary* inDictionary, const std::string& inName,
-                                              PDFParsingPath* ioParsingPath, int inCurrentDepth)
-{
-	if(!inDictionary)
-		return NULL;
-
-	// Check depth limit
-	if(inCurrentDepth >= scMaxInheritedLookupDepth)
-	{
-		TRACE_LOG2("PDFPageInput::QueryInheritedValue, reached maximum inherited lookup depth of %d while searching for %s",
-			scMaxInheritedLookupDepth, inName.substr(0, 100).c_str());
-		return NULL;
-	}
-
-	// Check if key exists in current dictionary
-	if(inDictionary->Exists(inName))
-	{
-		return mParser->QueryDictionaryObject(inDictionary, inName);
-	}
-
-	// Check for Parent and recurse
-	if(inDictionary->Exists(scParent))
-	{
-		// Get parent as direct object first to detect indirect references
-		RefCountPtr<PDFObject> parentDirect(inDictionary->QueryDirectObject(scParent));
-		if(!parentDirect)
-			return NULL;
-
-		// Extract parent ID if it's an indirect reference
-		ObjectIDType parentID = 0;
-		bool isIndirectRef = (parentDirect->GetType() == PDFObject::ePDFObjectIndirectObjectReference);
-		if(isIndirectRef)
-		{
-			parentID = ((PDFIndirectObjectReference*)parentDirect.GetPtr())->mObjectID;
-			if(ioParsingPath->EnterObject(parentID) != PDFHummus::eSuccess)
-			{
-				TRACE_LOG2("PDFPageInput::QueryInheritedValue, cycle detected in Parent chain at object %lu while searching for %s",
-					parentID, inName.substr(0, 100).c_str());
-				return NULL;
-			}
-		}
-
-		// Now resolve the parent dictionary
-		PDFObjectCastPtr<PDFDictionary> parent(mParser->QueryDictionaryObject(inDictionary, scParent));
-		
-		// Recurse into parent if it exists
-		PDFObject* result = NULL;
-		if(!!parent)
-		{
-			result = QueryInheritedValue(parent.GetPtr(), inName, ioParsingPath, inCurrentDepth + 1);
-		}
-		
-		// Exit the indirect reference if we entered it
-		if(isIndirectRef)
-			ioParsingPath->ExitObject(parentID);
-		
-		return result;
-	}
-
-	return NULL;
-}
-
 PDFObject* PDFPageInput::QueryInheritedValue(PDFDictionary* inDictionary, const std::string& inName)
 {
-	PDFParsingPath parsingPath;
-	return QueryInheritedValue(inDictionary, inName, &parsingPath, 0);
+	return mParser->QueryInheritedDictionaryEntry(inDictionary, inName);
 }
 
 EStatusCode PDFPageInput::SetPDFRectangleFromPDFArray(PDFArray* inPDFArray,PDFRectangle& outPDFRectangle)

--- a/PDFWriter/PDFPageInput.h
+++ b/PDFWriter/PDFPageInput.h
@@ -43,7 +43,6 @@
 class PDFObject;
 class PDFParser;
 class PDFArray;
-class PDFParsingPath;
 
 class PDFPageInput
 {
@@ -73,8 +72,6 @@ private:
     PDFObjectCastPtr<PDFDictionary> mPageObject;
     
 	PDFObject* QueryInheritedValue(PDFDictionary* inDictionary,const std::string& inName);
-	PDFObject* QueryInheritedValue(PDFDictionary* inDictionary,const std::string& inName,
-	                               PDFParsingPath* ioParsingPath,int inCurrentDepth);
     PDFHummus::EStatusCode SetPDFRectangleFromPDFArray(PDFArray* inPDFArray,PDFRectangle& outPDFRectangle);
     
     void AssertPageObjectValid();

--- a/PDFWriter/PDFParser.cpp
+++ b/PDFWriter/PDFParser.cpp
@@ -1126,6 +1126,71 @@ PDFObject* PDFParser::QueryDictionaryObject(PDFDictionary* inDictionary,const st
 	}
 }
 
+static const std::string scParent = "Parent";
+static const int scMaxInheritedLookupDepth = 100;
+
+PDFObject* PDFParser::QueryInheritedDictionaryEntry(PDFDictionary* inDictionary,const std::string& inName,
+                                                    PDFParsingPath* ioParsingPath,int inCurrentDepth)
+{
+	if(!inDictionary)
+		return NULL;
+
+	if(inCurrentDepth >= scMaxInheritedLookupDepth)
+	{
+		TRACE_LOG2("PDFParser::QueryInheritedDictionaryEntry, reached maximum inherited lookup depth of %d while searching for %s",
+			scMaxInheritedLookupDepth, inName.substr(0, 100).c_str());
+		return NULL;
+	}
+
+	if(inDictionary->Exists(inName))
+	{
+		return QueryDictionaryObject(inDictionary, inName);
+	}
+
+	if(inDictionary->Exists(scParent))
+	{
+		// Get parent as direct object first to detect indirect references
+		RefCountPtr<PDFObject> parentDirect(inDictionary->QueryDirectObject(scParent));
+		if(!parentDirect)
+			return NULL;
+
+		// Extract parent ID if it's an indirect reference
+		ObjectIDType parentID = 0;
+		bool isIndirectRef = (parentDirect->GetType() == PDFObject::ePDFObjectIndirectObjectReference);
+		if(isIndirectRef)
+		{
+			parentID = ((PDFIndirectObjectReference*)parentDirect.GetPtr())->mObjectID;
+			if(ioParsingPath->EnterObject(parentID) != PDFHummus::eSuccess)
+			{
+				TRACE_LOG2("PDFParser::QueryInheritedDictionaryEntry, cycle detected in Parent chain at object %lu while searching for %s",
+					parentID, inName.substr(0, 100).c_str());
+				return NULL;
+			}
+		}
+
+		PDFObjectCastPtr<PDFDictionary> parent(QueryDictionaryObject(inDictionary, scParent));
+
+		PDFObject* result = NULL;
+		if(!!parent)
+		{
+			result = QueryInheritedDictionaryEntry(parent.GetPtr(), inName, ioParsingPath, inCurrentDepth + 1);
+		}
+
+		if(isIndirectRef)
+			ioParsingPath->ExitObject(parentID);
+
+		return result;
+	}
+
+	return NULL;
+}
+
+PDFObject* PDFParser::QueryInheritedDictionaryEntry(PDFDictionary* inDictionary,const std::string& inName)
+{
+	PDFParsingPath parsingPath;
+	return QueryInheritedDictionaryEntry(inDictionary, inName, &parsingPath, 0);
+}
+
 PDFObject* PDFParser::QueryArrayObject(PDFArray* inArray,unsigned long inIndex)
 {
 	RefCountPtr<PDFObject> anObject(inArray->QueryObject(inIndex));

--- a/PDFWriter/PDFParser.h
+++ b/PDFWriter/PDFParser.h
@@ -43,6 +43,7 @@ class PDFStreamInput;
 class PDFDictionary;
 class PDFName;
 class IPDFParserExtender;
+class PDFParsingPath;
 
 typedef std::pair<PDFHummus::EStatusCode,IByteReader*> EStatusCodeAndIByteReader;
 
@@ -112,6 +113,11 @@ public:
 	// Query a dictinary object, if indirect, go and fetch the indirect object and return it instead
 	// [if you want the direct dictionary value, use PDFDictionary::QueryDirectObject [will AddRef automatically]
 	PDFObject* QueryDictionaryObject(PDFDictionary* inDictionary,const std::string& inName);
+
+	// Walk the /Parent chain looking for an inherited entry by name.
+	// Returns the first matching entry (resolved via QueryDictionaryObject), or NULL if none found.
+	// Guards against /Parent chain cycles and bounds the recursion depth, so it is safe on malformed input.
+	PDFObject* QueryInheritedDictionaryEntry(PDFDictionary* inDictionary,const std::string& inName);
 	
 	// Query an array object, if indirect, go and fetch the indirect object and return it instead
 	// [if you want the direct array value, use the PDFArray direct access to the vector [and use AddRef, cause it won't]
@@ -174,6 +180,9 @@ public:
     IByteReaderWithPosition* GetParserStream();
     
 private:
+	PDFObject* QueryInheritedDictionaryEntry(PDFDictionary* inDictionary,const std::string& inName,
+	                                         PDFParsingPath* ioParsingPath,int inCurrentDepth);
+
 	PDFObjectParser mObjectParser;
 	DecryptionHelper mDecryptionHelper;
 	InputOffsetStream mStream;

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -45,6 +45,7 @@ create_test_sourcelist (Tests
   OutputFileStreamTest.cpp
   PageModifierTest.cpp
   PageOrderModification.cpp
+  ParentCycleSanity.cpp
   ParsePDFWithOwner.cpp
   ParsingBadXref.cpp
   ParsingFaulty.cpp

--- a/PDFWriterTesting/Materials/ParentCycle.pdf
+++ b/PDFWriterTesting/Materials/ParentCycle.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 3 0 R /MediaBox [0 0 612 792] >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+186
+%%EOF

--- a/PDFWriterTesting/ParentCycleSanity.cpp
+++ b/PDFWriterTesting/ParentCycleSanity.cpp
@@ -1,0 +1,114 @@
+/*
+   Source File : ParentCycleSanity.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression test for the /Parent cycle / unbounded recursion issues fixed in
+   PRs #346, #347, #348 and refactored onto PDFParser::QueryInheritedDictionaryEntry.
+
+   ParentCycle.pdf contains a single page whose /Parent points back to itself
+   and which has no /Resources. Walking the parent chain looking for inherited
+   /Resources used to recurse forever -> stack overflow. With the fix in place
+   each consumer-layer caller must return (success or eFailure) without
+   crashing the process.
+*/
+#include "PDFParser.h"
+#include "PDFPageInput.h"
+#include "PDFModifiedPage.h"
+#include "PDFWriter.h"
+#include "PDFEmbedParameterTypes.h"
+#include "InputFile.h"
+#include "EStatusCode.h"
+#include "Trace.h"
+
+#include "testing/TestIO.h"
+
+#include <iostream>
+
+using namespace std;
+using namespace PDFHummus;
+
+static EStatusCode exercisePageInputPath(const string& inSourcePath) {
+	PDFParser parser;
+	InputFile pdfFile;
+	if(pdfFile.OpenFile(inSourcePath) != eSuccess)
+		return eFailure;
+	if(parser.StartPDFParsing(pdfFile.GetInputStream()) != eSuccess)
+		return eFailure;
+
+	PDFPageInput pageInput(&parser, parser.ParsePage(0));
+	// These call QueryInheritedValue which walks /Parent. With the cycle
+	// guard the call returns; without it the process stack-overflows.
+	pageInput.GetMediaBox();
+	pageInput.GetCropBox();
+	pageInput.GetRotate();
+	return eSuccess;
+}
+
+static EStatusCode exerciseModifiedPagePath(const string& inSourcePath, const string& inOutputPath) {
+	PDFWriter writer;
+	if(writer.ModifyPDF(inSourcePath, ePDFVersion14, inOutputPath) != eSuccess)
+		return eFailure;
+
+	PDFModifiedPage modifiedPage(&writer, 0);
+	// StartContentContext -> findInheritedResources walks the /Parent chain.
+	// May legitimately fail to start a context if the page has no resources;
+	// we only require that it does not crash.
+	modifiedPage.StartContentContext();
+	modifiedPage.EndContentContext();
+	modifiedPage.WritePage();
+
+	writer.EndPDF();
+	return eSuccess;
+}
+
+static EStatusCode exerciseDocumentHandlerPath(const string& inSourcePath, const string& inOutputPath) {
+	PDFWriter writer;
+	if(writer.StartPDF(inOutputPath, ePDFVersion14) != eSuccess)
+		return eFailure;
+
+	// AppendPDFPagesFromPDF -> FindPageResources walks the /Parent chain.
+	// The append may itself fail because of the malformed source; the
+	// regression check is just that we return.
+	writer.AppendPDFPagesFromPDF(inSourcePath, PDFPageRange());
+
+	writer.EndPDF();
+	return eSuccess;
+}
+
+int ParentCycleSanity(int argc, char* argv[]) {
+	Trace::DefaultTrace().SetLogSettings(BuildRelativeOutputPath(argv, "ParentCycleSanityLog.txt"), true, true);
+
+	const string sourcePath = BuildRelativeInputPath(argv, "ParentCycle.pdf");
+
+	if(exercisePageInputPath(sourcePath) != eSuccess) {
+		cout << "ParentCycleSanity: PDFPageInput path failed" << endl;
+		return 1;
+	}
+
+	if(exerciseModifiedPagePath(sourcePath, BuildRelativeOutputPath(argv, "ParentCycle_Modified.pdf")) != eSuccess) {
+		cout << "ParentCycleSanity: PDFModifiedPage path failed" << endl;
+		return 1;
+	}
+
+	if(exerciseDocumentHandlerPath(sourcePath, BuildRelativeOutputPath(argv, "ParentCycle_Appended.pdf")) != eSuccess) {
+		cout << "ParentCycleSanity: PDFDocumentHandler path failed" << endl;
+		return 1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Summary

The deferred follow-up flagged in `FINDINGS.md` after PRs #346, #347, and #348. Those three PRs each added the same cycle + max-depth guard to a near-identical `/Parent`-chain walk in three different consumer-layer helpers:

- `PDFPageInput::QueryInheritedValue`
- `PDFModifiedPage::findInheritedResources`
- `PDFDocumentHandler::FindPageResources`

This PR introduces a single guarded helper on the parser itself and collapses the three callers to thin wrappers, so future consumer-layer code that needs inherited-entry lookup can reuse it instead of re-implementing the walk and re-introducing the bug.

## Refactor

New API on `PDFParser`:

```cpp
// Walk the /Parent chain looking for an inherited entry by name.
// Returns the first matching entry (resolved via QueryDictionaryObject),
// or NULL if none found. Guards against /Parent chain cycles and bounds
// the recursion depth, so it is safe on malformed input.
PDFObject* QueryInheritedDictionaryEntry(PDFDictionary* inDictionary, const std::string& inName);
```

Internal guarded overload uses `PDFParsingPath` for cycle detection and a depth limit of 100, matching the prior per-site fixes.

The three callers become one-liners:
- `PDFPageInput::QueryInheritedValue(d, n)` -> `mParser->QueryInheritedDictionaryEntry(d, n)`
- `PDFModifiedPage::findInheritedResources(p, d)` -> `p->QueryInheritedDictionaryEntry(d, "Resources")`
- `PDFDocumentHandler::FindPageResources(p, d)` -> `p->QueryInheritedDictionaryEntry(d, "Resources")`

Net diff: -120 lines of duplicated, error-prone code.

## Regression test

Adds `ParentCycleSanity` test + `ParentCycle.pdf` regression input. The PDF contains a single page whose `/Parent` points back to itself and which has no `/Resources`. The test exercises all three consumer-layer entry points:

1. `PDFPageInput::GetCropBox` / `GetMediaBox` / `GetRotate` (PDFPageInput path)
2. `PDFWriter::ModifyPDF` + `PDFModifiedPage` (PDFModifiedPage path)
3. `PDFWriter::AppendPDFPagesFromPDF` (PDFDocumentHandler path)

Pre-fix each path stack-overflowed. Post-fix the cycle guard fires on object 3 (verified in trace log) and each call returns cleanly. Closes the regression-test gap Copilot flagged on #348.

## Test plan
- [x] Full test suite passes (83/83) - `ctest -C Release`
- [x] `ParentCycleSanity` trace log confirms `cycle detected in Parent chain at object 3` is hit (i.e. the bug is actually triggered)
- [x] No behavior change for existing fuzz / parsing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)