### PR TITLE
fix: wasnt responding to report of correctly parsed photoshop tag in jpeg header parsing

### DIFF
--- a/PDFWriter/JPEGImageParser.cpp
+++ b/PDFWriter/JPEGImageParser.cpp
@@ -108,14 +108,17 @@ EStatusCode JPEGImageParser::Parse(IByteReaderWithPosition* inImageStream,JPEGIm
 						SkipTag();
 					break;
 				case scAPP13TagID:
-                    if(PhotoshopMarkerNotFound)
-                    {
-                        // photoshop tags may be corrupt, so internal method will return if the 
-                        // photoshop tag is OK. otherwise skip it, and wait for the next one...parhaps will be better
-                        status = ReadPhotoshopData(outImageInformation,PhotoshopMarkerNotFound);
-                    }
-                    else
-                        status = SkipTag();
+                	if(PhotoshopMarkerNotFound)
+					{
+						// photoshop tags may be corrupt, so internal method will return if the 
+						// photoshop tag is OK. otherwise skip it, and wait for the next one...parhaps will be better
+						bool photoshopDataOK = false;
+						status = ReadPhotoshopData(outImageInformation,photoshopDataOK);
+						if(PDFHummus::eSuccess == status && photoshopDataOK)
+							PhotoshopMarkerNotFound = false;
+					}
+					else
+						status = SkipTag();
 					break;				
 				case scAPP1TagID:
 					if(ExifMarkerNotFound)
@@ -280,7 +283,7 @@ EStatusCode JPEGImageParser::SkipStream(unsigned long inSkip, unsigned long& ref
 	return PDFHummus::eSuccess;
 }
 
-EStatusCode JPEGImageParser::ReadPhotoshopData(JPEGImageInformation& outImageInformation, bool outPhotoshopDataOK)
+EStatusCode JPEGImageParser::ReadPhotoshopData(JPEGImageInformation& outImageInformation, bool& outPhotoshopDataOK)
 {
 	// code below uses a two level status where the primary is in charge of read error
 	// and the secondary is in charge of realizing whether the data is correct. 

--- a/PDFWriter/JPEGImageParser.h
+++ b/PDFWriter/JPEGImageParser.h
@@ -68,7 +68,7 @@ private:
 	void SkipStream(unsigned long inSkip);
 	PDFHummus::EStatusCode SkipStream(unsigned long inSkip, unsigned long& refReadLimit);
 	PDFHummus::EStatusCode ReadJFIFData(JPEGImageInformation& outImageInformation);
-	PDFHummus::EStatusCode ReadPhotoshopData(JPEGImageInformation& outImageInformation,bool outPhotoshopDataOK);
+	PDFHummus::EStatusCode ReadPhotoshopData(JPEGImageInformation& outImageInformation,bool& outPhotoshopDataOK);
 	PDFHummus::EStatusCode ReadExifData(JPEGImageInformation& outImageInformation);
 	PDFHummus::EStatusCode GetResolutionFromExif(	JPEGImageInformation& outImageInformation,
 									   unsigned long inXResolutionOffset,


### PR DESCRIPTION
ReadPhotoshopData was supposed to report of parsing succeeded.
didn't do that (by value, not by ref) so parsing tags can't early exit...shame.
now it does. 
note that it's not just that the out params wasnt provided by ref, but also that the outparam should actually be inverse of PhotoshopMarkerNotFound. so correction has additional logic to verify the result is good before allowing to skip it later