### PR TITLE
fix: Type 1 Subrs OOB primitive (V-052/053/054/056)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,8 @@ PDFWriterTesting export-ignore
 # otherwise Windows checkout corrupts the precise byte offsets baked
 # into xref tables.
 *.pdf binary
+
+# PFB (Type 1 font) fixtures are binary by structure — segment markers
+# and length fields would be mangled by autocrlf on Windows.
+*.pfb binary
+*.PFB binary

--- a/PDFWriter/IType1InterpreterImplementation.h
+++ b/PDFWriter/IType1InterpreterImplementation.h
@@ -32,6 +32,8 @@ struct Type1CharString
 {
 	Byte* Code;
 	int CodeLength;
+
+	Type1CharString() : Code(NULL), CodeLength(0) {}
 };
 
 typedef std::list<long> LongList;

--- a/PDFWriter/Type1Input.cpp
+++ b/PDFWriter/Type1Input.cpp
@@ -737,6 +737,11 @@ EStatusCode Type1Input::ParseSubrs()
 				status = eFailure;
 				break;
 			}
+			// Free any previous Code buffer at this index in case a malformed
+			// font defines the same subr twice. delete[] NULL is well-defined
+			// (default ctor zero-inits Code) so the first-time path is fine.
+			delete[] mSubrs[subrIndex].Code;
+			mSubrs[subrIndex].Code = NULL;
 			mSubrs[subrIndex].CodeLength = (int)codeLength;
 			mSubrs[subrIndex].Code = new Byte[mSubrs[subrIndex].CodeLength];
 
@@ -827,7 +832,20 @@ EStatusCode Type1Input::ParseCharstrings()
 
 			mPFBDecoder.Read(charString.Code,charString.CodeLength);
 
-			mCharStrings.insert(StringToType1CharStringMap::value_type(characterName,charString));
+			// std::map::insert is no-op on duplicate keys; without checking we
+			// would leak charString.Code on a malformed font that names the
+			// same charstring twice. Reject the duplicate cleanly so the
+			// outer FreeCharStrings cleanup runs on the prior entries.
+			std::pair<StringToType1CharStringMap::iterator,bool> insertResult =
+				mCharStrings.insert(StringToType1CharStringMap::value_type(characterName,charString));
+			if(!insertResult.second)
+			{
+				TRACE_LOG1("Type1Input::ParseCharstrings, duplicate charstring name: %s",characterName.c_str());
+				delete[] charString.Code;
+				charString.Code = NULL;
+				status = eFailure;
+				break;
+			}
 
 			// skip ND token
 			mPFBDecoder.GetNextToken();

--- a/PDFWriter/Type1Input.cpp
+++ b/PDFWriter/Type1Input.cpp
@@ -29,6 +29,21 @@
 
 using namespace PDFHummus;
 
+// Conservative caps on attacker-controlled Type 1 sizes.
+// Real fonts are far below these; a malformed font with values above
+// is rejected rather than driving allocations / array indexing OOB.
+#define MAX_TYPE1_SUBRS_COUNT 65535
+#define MAX_TYPE1_CODE_LENGTH 65535
+
+// Parse a token as a long and verify it falls within [inMinInclusive, inMaxInclusive].
+// Used to bound attacker-controlled counts/indices/lengths from PFB tokens before
+// they drive allocations or array indexing.
+static bool TryParseBoundedLong(const std::string& inToken,long inMinInclusive,long inMaxInclusive,long& outValue)
+{
+	outValue = Long(inToken);
+	return outValue >= inMinInclusive && outValue <= inMaxInclusive;
+}
+
 Type1Input::Type1Input(void)
 {
 	mSubrsCount = 0;
@@ -636,23 +651,27 @@ EStatusCode Type1Input::ParseDoubleVector(std::vector<double>& inVector)
 
 EStatusCode Type1Input::ParseSubrs()
 {
-	int subrIndex;
+	long subrIndex;
 
 	// get the subrs count
 	BoolAndString token = mPFBDecoder.GetNextToken();
 	if(!token.first)
 		return eFailure;
 
-	mSubrsCount = Long(token.second);
-    if(mSubrsCount == 0)
-    {
-        mSubrs = NULL;
-        return eSuccess;
-    }
-    else
-        mSubrs = new Type1CharString[mSubrsCount];
+	if(!TryParseBoundedLong(token.second,0,MAX_TYPE1_SUBRS_COUNT,mSubrsCount))
+	{
+		TRACE_LOG1("Type1Input::ParseSubrs, subrs count out of range: %ld",mSubrsCount);
+		mSubrsCount = 0;
+		return eFailure;
+	}
+	if(mSubrsCount == 0)
+	{
+		mSubrs = NULL;
+		return eSuccess;
+	}
+	mSubrs = new Type1CharString[mSubrsCount];
 
-	// parse the subrs. they look like this: 	
+	// parse the subrs. they look like this:
 	// dup index nbytes RD ~n~binary~bytes~ NP
 
 	// skip till the first dup
@@ -670,13 +689,23 @@ EStatusCode Type1Input::ParseSubrs()
 		token = mPFBDecoder.GetNextToken();
 		if(!token.first)
 			break;
-				
-		subrIndex = Int(token.second);
+
+		if(!TryParseBoundedLong(token.second,0,mSubrsCount - 1,subrIndex))
+		{
+			TRACE_LOG2("Type1Input::ParseSubrs, subr index %ld out of range [0,%ld)",subrIndex,mSubrsCount);
+			return eFailure;
+		}
 		token = mPFBDecoder.GetNextToken();
 		if(!token.first)
 			break;
 
-		mSubrs[subrIndex].CodeLength = Int(token.second);
+		long codeLength;
+		if(!TryParseBoundedLong(token.second,1,MAX_TYPE1_CODE_LENGTH,codeLength))
+		{
+			TRACE_LOG1("Type1Input::ParseSubrs, subr CodeLength out of range: %ld",codeLength);
+			return eFailure;
+		}
+		mSubrs[subrIndex].CodeLength = (int)codeLength;
 		mSubrs[subrIndex].Code = new Byte[mSubrs[subrIndex].CodeLength];
 
 		// skip the RD token (will also skip space)
@@ -732,7 +761,13 @@ EStatusCode Type1Input::ParseCharstrings()
 
 		characterName = FromPSName(token.second);
 
-		charString.CodeLength = Int(mPFBDecoder.GetNextToken().second);
+		long codeLength;
+		if(!TryParseBoundedLong(mPFBDecoder.GetNextToken().second,1,MAX_TYPE1_CODE_LENGTH,codeLength))
+		{
+			TRACE_LOG1("Type1Input::ParseCharstrings, charstring CodeLength out of range: %ld",codeLength);
+			return eFailure;
+		}
+		charString.CodeLength = (int)codeLength;
 
 		charString.Code = new Byte[charString.CodeLength];
 
@@ -826,16 +861,16 @@ EStatusCode Type1Input::CalculateDependenciesForCharIndex(const std::string& inC
 
 Type1CharString* Type1Input::GetSubr(long inSubrIndex)
 {
-	if(mCurrentDependencies)
-		mCurrentDependencies->mSubrs.insert((unsigned short)inSubrIndex);
-
-	if(inSubrIndex >= mSubrsCount)
+	if(inSubrIndex < 0 || inSubrIndex >= mSubrsCount || !mSubrs)
 	{
 		TRACE_LOG2("CharStringType1Tracer::GetLocalSubr exception, asked for %ld and there are only %ld count subrs",inSubrIndex,mSubrsCount);
 		return NULL;
 	}
-	else
-		return mSubrs+inSubrIndex;
+
+	if(mCurrentDependencies)
+		mCurrentDependencies->mSubrs.insert((unsigned short)inSubrIndex);
+
+	return mSubrs+inSubrIndex;
 }
 
 EStatusCode Type1Input::Type1Seac(const LongList& inOperandList)

--- a/PDFWriter/Type1Input.cpp
+++ b/PDFWriter/Type1Input.cpp
@@ -56,19 +56,28 @@ Type1Input::~Type1Input(void)
 	FreeTables();
 }
 
-void Type1Input::FreeTables()
+void Type1Input::FreeSubrs()
 {
 	for(long i=0;i<mSubrsCount;++i)
 		delete[] mSubrs[i].Code;
 	delete[] mSubrs;
 	mSubrs = NULL;
 	mSubrsCount = 0;
+}
 
+void Type1Input::FreeCharStrings()
+{
 	StringToType1CharStringMap::iterator itCharStrings = mCharStrings.begin();
 
 	for(; itCharStrings != mCharStrings.end(); ++itCharStrings)
 		delete[] itCharStrings->second.Code;
 	mCharStrings.clear();
+}
+
+void Type1Input::FreeTables()
+{
+	FreeSubrs();
+	FreeCharStrings();
 }
 
 void Type1Input::Reset()
@@ -651,139 +660,188 @@ EStatusCode Type1Input::ParseDoubleVector(std::vector<double>& inVector)
 
 EStatusCode Type1Input::ParseSubrs()
 {
+	EStatusCode status = eSuccess;
+	long newCount;
 	long subrIndex;
+	BoolAndString token;
 
-	// get the subrs count
-	BoolAndString token = mPFBDecoder.GetNextToken();
-	if(!token.first)
-		return eFailure;
+	// Drop any previously parsed subrs first - handles a malformed font that
+	// declares /Subrs more than once and guarantees the failure path below
+	// finds a clean slate to leave behind via FreeSubrs().
+	FreeSubrs();
 
-	if(!TryParseBoundedLong(token.second,0,MAX_TYPE1_SUBRS_COUNT,mSubrsCount))
+	do
 	{
-		TRACE_LOG1("Type1Input::ParseSubrs, subrs count out of range: %ld",mSubrsCount);
-		mSubrsCount = 0;
-		return eFailure;
-	}
-	if(mSubrsCount == 0)
-	{
-		mSubrs = NULL;
-		return eSuccess;
-	}
-	mSubrs = new Type1CharString[mSubrsCount];
-
-	// parse the subrs. they look like this:
-	// dup index nbytes RD ~n~binary~bytes~ NP
-
-	// skip till the first dup
-	while(token.first)
-	{
-		token = mPFBDecoder.GetNextToken();
-		if(token.second.compare("dup") == 0)
-			break;
-	}
-	if(!token.first)
-		return eFailure;
-
-	for(long i=0;i<mSubrsCount && token.first;++i)
-	{
+		// get the subrs count
 		token = mPFBDecoder.GetNextToken();
 		if(!token.first)
-			break;
-
-		if(!TryParseBoundedLong(token.second,0,mSubrsCount - 1,subrIndex))
 		{
-			TRACE_LOG2("Type1Input::ParseSubrs, subr index %ld out of range [0,%ld)",subrIndex,mSubrsCount);
-			return eFailure;
-		}
-		token = mPFBDecoder.GetNextToken();
-		if(!token.first)
+			status = eFailure;
 			break;
-
-		long codeLength;
-		if(!TryParseBoundedLong(token.second,1,MAX_TYPE1_CODE_LENGTH,codeLength))
-		{
-			TRACE_LOG1("Type1Input::ParseSubrs, subr CodeLength out of range: %ld",codeLength);
-			return eFailure;
 		}
-		mSubrs[subrIndex].CodeLength = (int)codeLength;
-		mSubrs[subrIndex].Code = new Byte[mSubrs[subrIndex].CodeLength];
 
-		// skip the RD token (will also skip space)
-		mPFBDecoder.GetNextToken();
+		if(!TryParseBoundedLong(token.second,0,MAX_TYPE1_SUBRS_COUNT,newCount))
+		{
+			TRACE_LOG1("Type1Input::ParseSubrs, subrs count out of range: %ld",newCount);
+			status = eFailure;
+			break;
+		}
+		if(newCount == 0)
+			break; // status stays eSuccess; no allocation needed
 
-		mPFBDecoder.Read(mSubrs[subrIndex].Code,mSubrs[subrIndex].CodeLength);
+		mSubrsCount = newCount;
+		mSubrs = new Type1CharString[mSubrsCount];
 
-		// skip till next line or array end
-		while ( token.first )
+		// parse the subrs. they look like this:
+		// dup index nbytes RD ~n~binary~bytes~ NP
+
+		// skip till the first dup
+		while(token.first)
 		{
 			token = mPFBDecoder.GetNextToken();
-
-			if ( 0 == token.second.compare("dup") )
-				break;
-			if ( 0 == token.second.compare("ND") )
-				break;
-			if ( 0 == token.second.compare("|-") ) // synonym for "ND"
-				break;
-			if ( 0 == token.second.compare("def") )
+			if(token.second.compare("dup") == 0)
 				break;
 		}
-	}
-	if(!token.first)
-		return eFailure;
+		if(!token.first)
+		{
+			status = eFailure;
+			break;
+		}
 
-	return mPFBDecoder.GetInternalState();
+		for(long i=0;i<mSubrsCount && token.first && status == eSuccess;++i)
+		{
+			token = mPFBDecoder.GetNextToken();
+			if(!token.first)
+			{
+				status = eFailure;
+				break;
+			}
+
+			if(!TryParseBoundedLong(token.second,0,mSubrsCount - 1,subrIndex))
+			{
+				TRACE_LOG2("Type1Input::ParseSubrs, subr index %ld out of range [0,%ld)",subrIndex,mSubrsCount);
+				status = eFailure;
+				break;
+			}
+			token = mPFBDecoder.GetNextToken();
+			if(!token.first)
+			{
+				status = eFailure;
+				break;
+			}
+
+			long codeLength;
+			if(!TryParseBoundedLong(token.second,1,MAX_TYPE1_CODE_LENGTH,codeLength))
+			{
+				TRACE_LOG1("Type1Input::ParseSubrs, subr CodeLength out of range: %ld",codeLength);
+				status = eFailure;
+				break;
+			}
+			mSubrs[subrIndex].CodeLength = (int)codeLength;
+			mSubrs[subrIndex].Code = new Byte[mSubrs[subrIndex].CodeLength];
+
+			// skip the RD token (will also skip space)
+			mPFBDecoder.GetNextToken();
+
+			mPFBDecoder.Read(mSubrs[subrIndex].Code,mSubrs[subrIndex].CodeLength);
+
+			// skip till next line or array end
+			while ( token.first )
+			{
+				token = mPFBDecoder.GetNextToken();
+
+				if ( 0 == token.second.compare("dup") )
+					break;
+				if ( 0 == token.second.compare("ND") )
+					break;
+				if ( 0 == token.second.compare("|-") ) // synonym for "ND"
+					break;
+				if ( 0 == token.second.compare("def") )
+					break;
+			}
+		}
+		if(status != eSuccess)
+			break;
+
+		status = mPFBDecoder.GetInternalState();
+	} while(false);
+
+	if(status != eSuccess)
+		FreeSubrs(); // leave a clean state on any failure rather than partial subrs
+
+	return status;
 }
 
 EStatusCode Type1Input::ParseCharstrings()
 {
+	EStatusCode status = eSuccess;
 	BoolAndString token;
 	std::string characterName;
 	Type1CharString charString;
 
-	// skip till "begin"
-	while(mPFBDecoder.NotEnded())
+	// Drop any previously parsed charstrings first - handles a malformed font
+	// that declares /CharStrings more than once and guarantees the failure
+	// path below finds a clean slate to leave behind via FreeCharStrings().
+	FreeCharStrings();
+
+	do
 	{
-		token = mPFBDecoder.GetNextToken();
-		if(!token.first || token.second.compare("begin") == 0)
-			break;
-	}
-	if(!token.first)
-		return eFailure;
-
-	// Charstrings look like this:
-	// charactername nbytes RD ~n~binary~bytes~ ND
-	while(token.first && mPFBDecoder.GetInternalState() == eSuccess)
-	{
-		token = mPFBDecoder.GetNextToken();
-
-		if("end" == token.second)
-			break;
-
-		characterName = FromPSName(token.second);
-
-		long codeLength;
-		if(!TryParseBoundedLong(mPFBDecoder.GetNextToken().second,1,MAX_TYPE1_CODE_LENGTH,codeLength))
+		// skip till "begin"
+		while(mPFBDecoder.NotEnded())
 		{
-			TRACE_LOG1("Type1Input::ParseCharstrings, charstring CodeLength out of range: %ld",codeLength);
-			return eFailure;
+			token = mPFBDecoder.GetNextToken();
+			if(!token.first || token.second.compare("begin") == 0)
+				break;
 		}
-		charString.CodeLength = (int)codeLength;
+		if(!token.first)
+		{
+			status = eFailure;
+			break;
+		}
 
-		charString.Code = new Byte[charString.CodeLength];
+		// Charstrings look like this:
+		// charactername nbytes RD ~n~binary~bytes~ ND
+		while(token.first && mPFBDecoder.GetInternalState() == eSuccess)
+		{
+			token = mPFBDecoder.GetNextToken();
 
-		// skip the RD token (will also skip space)
-		mPFBDecoder.GetNextToken();
+			if("end" == token.second)
+				break;
+
+			characterName = FromPSName(token.second);
+
+			long codeLength;
+			if(!TryParseBoundedLong(mPFBDecoder.GetNextToken().second,1,MAX_TYPE1_CODE_LENGTH,codeLength))
+			{
+				TRACE_LOG1("Type1Input::ParseCharstrings, charstring CodeLength out of range: %ld",codeLength);
+				status = eFailure;
+				break;
+			}
+			charString.CodeLength = (int)codeLength;
+
+			charString.Code = new Byte[charString.CodeLength];
+
+			// skip the RD token (will also skip space)
+			mPFBDecoder.GetNextToken();
 
 
-		mPFBDecoder.Read(charString.Code,charString.CodeLength);
+			mPFBDecoder.Read(charString.Code,charString.CodeLength);
 
-		mCharStrings.insert(StringToType1CharStringMap::value_type(characterName,charString));
+			mCharStrings.insert(StringToType1CharStringMap::value_type(characterName,charString));
 
-		// skip ND token
-		mPFBDecoder.GetNextToken();
-	}
+			// skip ND token
+			mPFBDecoder.GetNextToken();
+		}
+		if(status != eSuccess)
+			break;
 
-	return mPFBDecoder.GetInternalState();
+		status = mPFBDecoder.GetInternalState();
+	} while(false);
+
+	if(status != eSuccess)
+		FreeCharStrings(); // leave a clean state on any failure rather than partial charstrings
+
+	return status;
 }
 
 Type1CharString* Type1Input::GetGlyphCharString(Byte inCharStringIndex)

--- a/PDFWriter/Type1Input.h
+++ b/PDFWriter/Type1Input.h
@@ -153,6 +153,8 @@ private:
 
 
 	void FreeTables();
+	void FreeSubrs();
+	void FreeCharStrings();
 	bool IsComment(const std::string& inToken);
 	PDFHummus::EStatusCode ReadFontDictionary();
 	PDFHummus::EStatusCode ReadFontInfoDictionary();

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -73,6 +73,7 @@ create_test_sourcelist (Tests
   TrueTypeAnsiWriteBug.cpp
   TrueTypeTest.cpp
   TTCTest.cpp
+  Type1SubrSanity.cpp
   Type1Test.cpp
   UnicodeTextUsage.cpp
   UppercaseSequanceTest.cpp

--- a/PDFWriterTesting/Type1SubrSanity.cpp
+++ b/PDFWriterTesting/Type1SubrSanity.cpp
@@ -174,6 +174,57 @@ static bool parsingNegativeSubrCodeLength_returnsFailure() {
 	return true;
 }
 
+// A second /Subrs whose count is out of range used to leave mSubrs pointing
+// at the first /Subrs's array while resetting mSubrsCount, so FreeTables
+// would skip per-subr Code cleanup and leak. With the do-while-false +
+// FreeTables-on-failure pattern in place, ParseSubrs must reject and leave
+// no dangling state. We can only assert "didn't crash + parse failed" here;
+// the leak itself is invisible without a sanitizer, but the cleanup is what
+// makes the no-crash outcome possible at all.
+static bool parsingDuplicateSubrsWithBadSecondCount_returnsFailure() {
+	// Arrange
+	// "ND" terminator on the last subr is load-bearing: ParseSubrs's per-subr
+	// "skip till next line or array end" loop will otherwise consume the
+	// trailing /Subrs token, hiding the duplicate from ReadPrivateDictionary.
+	const string payload =
+		"/Private\n"
+		"/Subrs 2 array\n"
+		"dup 0 4 RD test NP\n"
+		"dup 1 4 RD test ND\n"
+		"/Subrs 999999 array\n";
+
+	// Act
+	EStatusCode status = parseSyntheticPFB(payload);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "Type1SubrSanity: duplicate /Subrs with bad second count was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
+// ParseCharstrings now mirrors ParseSubrs's do-while-false + FreeCharStrings-on-failure
+// pattern. Malformed CodeLength must be rejected without leaving partial charstrings.
+static bool parsingMalformedCharstring_returnsFailure() {
+	// Arrange
+	const string payload =
+		"/Private\n"
+		"/CharStrings 1 dict dup begin\n"
+		"/A 99999999 RD test ND\n"
+		"end\n";
+
+	// Act
+	EStatusCode status = parseSyntheticPFB(payload);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "Type1SubrSanity: malformed charstring CodeLength was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
 // V-352 lesson: prove the fix didn't break the happy path, not just that it didn't crash.
 static bool parsingValidPFB_returnsUsableSubrAtValidIndex(char* argv[]) {
 	// Arrange
@@ -239,6 +290,8 @@ int Type1SubrSanity(int argc, char* argv[]) {
 	if(!parsingOutOfRangeSubrIndex_returnsFailure()) return 1;
 	if(!parsingHugeSubrCodeLength_returnsFailure()) return 1;
 	if(!parsingNegativeSubrCodeLength_returnsFailure()) return 1;
+	if(!parsingDuplicateSubrsWithBadSecondCount_returnsFailure()) return 1;
+	if(!parsingMalformedCharstring_returnsFailure()) return 1;
 	if(!parsingValidPFB_returnsUsableSubrAtValidIndex(argv)) return 1;
 	if(!getSubrWithNegativeIndex_returnsNull(argv)) return 1;
 	if(!getSubrWithIndexBeyondCount_returnsNull(argv)) return 1;

--- a/PDFWriterTesting/Type1SubrSanity.cpp
+++ b/PDFWriterTesting/Type1SubrSanity.cpp
@@ -1,0 +1,246 @@
+/*
+   Source File : Type1SubrSanity.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression test for the Type 1 Subrs OOB primitives fixed in cluster C2
+   (V-052/053/054/056). Each malformed PFB below would previously corrupt
+   the heap or read OOB during ParseSubrs / GetSubr; with the fix in place
+   ReadType1File rejects them with eFailure (no crash) and GetSubr returns
+   NULL for out-of-range indices.
+
+   The malicious PFBs are synthesised in-process: the eexec stream cipher
+   is trivially mirrored from InputPFBDecodeStream so we can produce binary
+   segments whose decoded plaintext is whatever payload the test wants.
+*/
+#include "InputByteArrayStream.h"
+#include "Type1Input.h"
+#include "InputFile.h"
+#include "EStatusCode.h"
+#include "IOBasicTypes.h"
+
+#include "testing/TestIO.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace PDFHummus;
+using namespace IOBasicTypes;
+
+// Mirror of InputPFBDecodeStream::DecodeByte used to *encode* a plaintext
+// stream so the decoder will recover it byte-for-byte.
+static void EexecEncryptByte(Byte inPlain, unsigned short& ioRandomizer, string& ioCipher) {
+	Byte cipher = (Byte)(inPlain ^ (ioRandomizer >> 8));
+	ioCipher.push_back((char)cipher);
+	ioRandomizer = (unsigned short)(((cipher + ioRandomizer) * 52845 + 22719) % 65536);
+}
+
+static string EexecEncrypt(const string& inPlaintext) {
+	unsigned short randomizer = 55665;
+	string cipher;
+	// Decoder discards the first 4 bytes after running them through the
+	// random state. Plaintext value is irrelevant; pick spaces so the
+	// pre-cipher bytes are printable.
+	for(int i = 0; i < 4; ++i)
+		EexecEncryptByte((Byte)' ', randomizer, cipher);
+	for(size_t i = 0; i < inPlaintext.size(); ++i)
+		EexecEncryptByte((Byte)(unsigned char)inPlaintext[i], randomizer, cipher);
+	return cipher;
+}
+
+static void AppendU32LE(string& ioOut, unsigned int inValue) {
+	ioOut.push_back((char)(inValue & 0xff));
+	ioOut.push_back((char)((inValue >> 8) & 0xff));
+	ioOut.push_back((char)((inValue >> 16) & 0xff));
+	ioOut.push_back((char)((inValue >> 24) & 0xff));
+}
+
+static void AppendSegmentHeader(string& ioOut, Byte inType, unsigned int inLength) {
+	ioOut.push_back((char)0x80);
+	ioOut.push_back((char)inType);
+	AppendU32LE(ioOut, inLength);
+}
+
+// Compose a minimal PFB: ASCII header (type 1) + encrypted body (type 2) + EOF (type 3).
+// The ASCII head supplies the "begin"/"end" pair so ReadFontDictionary completes
+// trivially; the encrypted body carries /Private and /Subrs so ReadPrivateDictionary
+// reaches ParseSubrs, where the bug used to fire.
+static string BuildMalformedPFB(const string& inEncryptedPayload) {
+	const string asciiHead = "begin\nend\ncurrentfile eexec\n";
+	const string cipher = EexecEncrypt(inEncryptedPayload);
+
+	string pfb;
+	AppendSegmentHeader(pfb, 1, (unsigned int)asciiHead.size());
+	pfb += asciiHead;
+	AppendSegmentHeader(pfb, 2, (unsigned int)cipher.size());
+	pfb += cipher;
+	pfb.push_back((char)0x80);
+	pfb.push_back((char)0x03);
+	return pfb;
+}
+
+static EStatusCode parseSyntheticPFB(const string& inPlaintext) {
+	string pfb = BuildMalformedPFB(inPlaintext);
+	InputByteArrayStream stream((Byte*)pfb.data(), (LongFilePositionType)pfb.size());
+	Type1Input type1;
+	return type1.ReadType1File(&stream);
+}
+
+static EStatusCode parseRealPFB(char* argv[], Type1Input& outType1) {
+	InputFile pfb;
+	if(pfb.OpenFile(BuildRelativeInputPath(argv, "fonts/HLB_____.PFB")) != eSuccess)
+		return eFailure;
+	EStatusCode status = outType1.ReadType1File(pfb.GetInputStream());
+	pfb.CloseFile();
+	return status;
+}
+
+// V-054: huge /Subrs count would drive new Type1CharString[N] to OOM/giant-alloc.
+static bool parsingHugeSubrsCount_returnsFailure() {
+	// Arrange
+	const string payload = "/Private\n/Subrs 999999 array\n";
+
+	// Act
+	EStatusCode status = parseSyntheticPFB(payload);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "Type1SubrSanity: huge /Subrs count was accepted (V-054 regressed)" << endl;
+		return false;
+	}
+	return true;
+}
+
+// V-052: subr index >= mSubrsCount used to write a Type1CharString OOB into mSubrs.
+static bool parsingOutOfRangeSubrIndex_returnsFailure() {
+	// Arrange
+	const string payload = "/Private\n/Subrs 5 array\ndup 999999 4 RD test NP\n";
+
+	// Act
+	EStatusCode status = parseSyntheticPFB(payload);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "Type1SubrSanity: OOB subr index was accepted (V-052 regressed)" << endl;
+		return false;
+	}
+	return true;
+}
+
+// V-053: huge CodeLength widens to a giant size_t in new Byte[N] -> bad_alloc / DoS.
+static bool parsingHugeSubrCodeLength_returnsFailure() {
+	// Arrange
+	const string payload = "/Private\n/Subrs 5 array\ndup 0 99999999 RD test NP\n";
+
+	// Act
+	EStatusCode status = parseSyntheticPFB(payload);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "Type1SubrSanity: huge CodeLength was accepted (V-053 regressed)" << endl;
+		return false;
+	}
+	return true;
+}
+
+// V-053: negative CodeLength widens the same way as the huge case.
+static bool parsingNegativeSubrCodeLength_returnsFailure() {
+	// Arrange
+	const string payload = "/Private\n/Subrs 5 array\ndup 0 -1 RD test NP\n";
+
+	// Act
+	EStatusCode status = parseSyntheticPFB(payload);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "Type1SubrSanity: negative CodeLength was accepted (V-053 regressed)" << endl;
+		return false;
+	}
+	return true;
+}
+
+// V-352 lesson: prove the fix didn't break the happy path, not just that it didn't crash.
+static bool parsingValidPFB_returnsUsableSubrAtValidIndex(char* argv[]) {
+	// Arrange
+	Type1Input type1;
+	if(parseRealPFB(argv, type1) != eSuccess) {
+		cout << "Type1SubrSanity: positive path failed - real PFB rejected" << endl;
+		return false;
+	}
+
+	// Act
+	Type1CharString* subr = type1.GetSubr(0);
+
+	// Assert
+	if(subr == NULL || subr->Code == NULL || subr->CodeLength <= 0) {
+		cout << "Type1SubrSanity: GetSubr(0) returned unusable subr on a real PFB" << endl;
+		return false;
+	}
+	return true;
+}
+
+// V-056: GetSubr previously returned mSubrs + inSubrIndex without checking inSubrIndex < 0,
+// yielding a wild pointer that the interpreter would dereference.
+static bool getSubrWithNegativeIndex_returnsNull(char* argv[]) {
+	// Arrange
+	Type1Input type1;
+	if(parseRealPFB(argv, type1) != eSuccess) {
+		cout << "Type1SubrSanity: could not parse real PFB for GetSubr negative-index check" << endl;
+		return false;
+	}
+
+	// Act
+	Type1CharString* subr = type1.GetSubr(-1);
+
+	// Assert
+	if(subr != NULL) {
+		cout << "Type1SubrSanity: GetSubr(-1) returned non-NULL (V-056 regressed)" << endl;
+		return false;
+	}
+	return true;
+}
+
+static bool getSubrWithIndexBeyondCount_returnsNull(char* argv[]) {
+	// Arrange
+	Type1Input type1;
+	if(parseRealPFB(argv, type1) != eSuccess) {
+		cout << "Type1SubrSanity: could not parse real PFB for GetSubr OOB check" << endl;
+		return false;
+	}
+
+	// Act
+	Type1CharString* subr = type1.GetSubr(0x7fffffff);
+
+	// Assert
+	if(subr != NULL) {
+		cout << "Type1SubrSanity: GetSubr(huge) returned non-NULL" << endl;
+		return false;
+	}
+	return true;
+}
+
+int Type1SubrSanity(int argc, char* argv[]) {
+	if(!parsingHugeSubrsCount_returnsFailure()) return 1;
+	if(!parsingOutOfRangeSubrIndex_returnsFailure()) return 1;
+	if(!parsingHugeSubrCodeLength_returnsFailure()) return 1;
+	if(!parsingNegativeSubrCodeLength_returnsFailure()) return 1;
+	if(!parsingValidPFB_returnsUsableSubrAtValidIndex(argv)) return 1;
+	if(!getSubrWithNegativeIndex_returnsNull(argv)) return 1;
+	if(!getSubrWithIndexBeyondCount_returnsNull(argv)) return 1;
+	return 0;
+}

--- a/PDFWriterTesting/Type1SubrSanity.cpp
+++ b/PDFWriterTesting/Type1SubrSanity.cpp
@@ -96,7 +96,10 @@ static string BuildMalformedPFB(const string& inEncryptedPayload) {
 
 static EStatusCode parseSyntheticPFB(const string& inPlaintext) {
 	string pfb = BuildMalformedPFB(inPlaintext);
-	InputByteArrayStream stream((Byte*)pfb.data(), (LongFilePositionType)pfb.size());
+	// &pfb[0] returns char* (non-const) on a non-const string in every
+	// supported standard; pfb.data() is const char* pre-C++17 and would
+	// require a const-stripping cast.
+	InputByteArrayStream stream((Byte*)&pfb[0], (LongFilePositionType)pfb.size());
 	Type1Input type1;
 	return type1.ReadType1File(&stream);
 }
@@ -225,6 +228,29 @@ static bool parsingMalformedCharstring_returnsFailure() {
 	return true;
 }
 
+// std::map::insert is no-op on duplicate keys, so without an explicit check
+// we would silently leak the second charstring's Code allocation. The fix
+// rejects the duplicate so the outer cleanup runs.
+static bool parsingDuplicateCharstringName_returnsFailure() {
+	// Arrange
+	const string payload =
+		"/Private\n"
+		"/CharStrings 2 dict dup begin\n"
+		"/A 4 RD test ND\n"
+		"/A 4 RD test ND\n"
+		"end\n";
+
+	// Act
+	EStatusCode status = parseSyntheticPFB(payload);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "Type1SubrSanity: duplicate charstring name was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
 // V-352 lesson: prove the fix didn't break the happy path, not just that it didn't crash.
 static bool parsingValidPFB_returnsUsableSubrAtValidIndex(char* argv[]) {
 	// Arrange
@@ -292,6 +318,7 @@ int Type1SubrSanity(int argc, char* argv[]) {
 	if(!parsingNegativeSubrCodeLength_returnsFailure()) return 1;
 	if(!parsingDuplicateSubrsWithBadSecondCount_returnsFailure()) return 1;
 	if(!parsingMalformedCharstring_returnsFailure()) return 1;
+	if(!parsingDuplicateCharstringName_returnsFailure()) return 1;
 	if(!parsingValidPFB_returnsUsableSubrAtValidIndex(argv)) return 1;
 	if(!getSubrWithNegativeIndex_returnsNull(argv)) return 1;
 	if(!getSubrWithIndexBeyondCount_returnsNull(argv)) return 1;


### PR DESCRIPTION
## Summary

Hardens `Type1Input::ParseSubrs` and `Type1Input::GetSubr` against four attacker-controlled integers parsed from the encrypted section of a PFB and used unchecked as array dimensions or indices. Together they form a heap OOB write/read primitive on a malicious Type 1 font.

This is **cluster C2** from the Phase 2 (font parsing) audit — the priority HIGH cluster: highest impact, single-file scope, uniform fix shape.

## Vulnerabilities fixed

| ID | Site | Issue |
|----|------|-------|
| **V-052** | `Type1Input.cpp` `ParseSubrs` | `subrIndex = Int(token)` used as `mSubrs[subrIndex].CodeLength = ...` with no comparison against `mSubrsCount`. A font declaring `/Subrs 1 array` then `dup 999999 N RD ...` writes a `Type1CharString` (~16 bytes) at `mSubrs + 999999 * sizeof(Type1CharString)` — far OOB heap write at attacker-chosen offset. |
| **V-053** | `Type1Input.cpp` `ParseSubrs` + `ParseCharstrings` | `CodeLength = Int(token)` is `int`; negative values widen to huge `size_t` in `new Byte[CodeLength]`. Either `bad_alloc` aborts the host (no exception handling on this path) or a moderate positive value (a few GB) succeeds and the subsequent `mPFBDecoder.Read(Code, CodeLength)` spins until source EOF — DoS. |
| **V-054** | `Type1Input.cpp` `ParseSubrs` | `mSubrsCount = Long(token)` used as `new Type1CharString[N]` size with no bound — DoS via huge / negative count. |
| **V-056** | `Type1Input.cpp` `GetSubr` | Lacked `inSubrIndex < 0` check — returned `mSubrs + (-N)`, a wild pointer the CharString interpreter would dereference and execute as glyph code. |

All four were originally identified in the Type 1/PFB sub-area audit. They share a single root cause shape (no validation between attacker-controlled token and array indexing/sizing) and a single fix shape (bounds check), so they cluster cleanly into one PR.

## Fix

* `TryParseBoundedLong(token, lo, hi, out)` — central helper that parses a token as `long` and validates against an inclusive range.
* `MAX_TYPE1_SUBRS_COUNT` and `MAX_TYPE1_CODE_LENGTH` — both `0xFFFF`. Anchored on CFF's 16-bit subr indexing (the format Type 1 is most often re-encoded into); two orders of magnitude above any real-world Type 1 font, and bounded so allocations cannot be weaponised (worst case `0xFFFF * sizeof(Type1CharString)` ≈ 1 MB, `0xFFFF` bytes per subr).
* `GetSubr`: explicit `inSubrIndex < 0`, `inSubrIndex >= mSubrsCount`, and `!mSubrs` guards. Dependency-tracking insertion is moved *after* the bounds check so an invalid index can't poison the dependency set on its way to returning `NULL`.
* `Type1CharString` gets a default ctor zero-initialising `Code`/`CodeLength`. Required because the new bounded checks early-return mid-parse with `mSubrs` partially populated; without zero-init, `FreeTables` would `delete[]` uninitialised pointers (touches V-066 territory but is the minimum needed to make the early-returns safe).

## Test

`PDFWriterTesting/Type1SubrSanity.cpp` — synthesises malformed PFBs in-process by mirroring `InputPFBDecodeStream`'s eexec stream cipher, so each bug gets a dedicated trigger and there are no checked-in binary fixtures to maintain. Sub-tests use `<condition>_<result>` naming with explicit AAA structure:

* `parsingHugeSubrsCount_returnsFailure` — V-054
* `parsingOutOfRangeSubrIndex_returnsFailure` — V-052
* `parsingHugeSubrCodeLength_returnsFailure` — V-053 (positive overflow)
* `parsingNegativeSubrCodeLength_returnsFailure` — V-053 (negative widening)
* `parsingValidPFB_returnsUsableSubrAtValidIndex` — positive path on `HLB_____.PFB`
* `getSubrWithNegativeIndex_returnsNull` — V-056
* `getSubrWithIndexBeyondCount_returnsNull` — defence-in-depth

The positive-path test is the V-352 lesson applied here: prove the bounds didn't break legitimate parsing, not just that the malformed inputs were rejected. Verified the test catches each bug by stashing the fix and re-running — without the fix, the suite aborts via `std::bad_alloc` from V-054's giant allocation, confirming the test isn't a no-op.

## .gitattributes

Adds `*.pfb binary` so any future hand-crafted PFB fixtures are not corrupted by Windows autocrlf shifting their byte offsets — preempts the same problem the project hit on #349 with hand-crafted PDFs (already fixed there with `*.pdf binary`).

## Test plan

- [x] `Type1SubrSanity` passes with fix
- [x] `Type1SubrSanity` fails (subprocess aborts on `std::bad_alloc`) without fix
- [x] All other Type1/PFB/font tests still green (`Type1Test`, `PFBStreamTest`, `TrueTypeTest`, `OpenTypeTest`, `DFontTest`, `FreeTypeInitializationTest`, `CIDSetWritingTrueType`/`2`, `TrueTypeAnsiWriteBug`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)