### PR TITLE
fix: CFF INDEX offset table sanity (V-033/034/036/037)

### DIFF
--- a/PDFWriter/CFFFileInput.cpp
+++ b/PDFWriter/CFFFileInput.cpp
@@ -338,10 +338,11 @@ EStatusCode CFFFileInput::ReadIndexHeader(unsigned long** outOffsets,unsigned sh
 		if(status != eSuccess)
 			break;
 
-		// CFF spec: first offset is always 1.
+		// offsets[0] must be >= 1: callers do Skip(offsets[0] - 1) to advance past
+		// pre-data padding, and offsets[0] == 0 would underflow that subtraction.
 		if((*outOffsets)[0] < 1)
 		{
-			TRACE_LOG1("CFFFileInput::ReadIndexHeader, INDEX offsets[0] = %lu (must be >= 1)", (*outOffsets)[0]);
+			TRACE_LOG1("CFFFileInput::ReadIndexHeader, INDEX offsets[0] = %lu (must be >= 1; would underflow Skip)", (*outOffsets)[0]);
 			status = PDFHummus::eFailure;
 			break;
 		}

--- a/PDFWriter/CFFFileInput.cpp
+++ b/PDFWriter/CFFFileInput.cpp
@@ -306,19 +306,27 @@ EStatusCode CFFFileInput::ReadIndexHeader(unsigned long** outOffsets,unsigned sh
 {
 	Byte offSizeForIndex;
 
+	*outOffsets = NULL;
+
 	EStatusCode status = mPrimitivesReader.ReadCard16(outItemsCount);
 	if(status != PDFHummus::eSuccess)
 		return PDFHummus::eFailure;
 
 	if(0 == outItemsCount)
-	{
-		*outOffsets = NULL;
 		return PDFHummus::eSuccess;
-	}
 
-	mPrimitivesReader.ReadOffSize(offSizeForIndex);
+	// V-033: capture ReadOffSize's own status (was checking the prior ReadCard16 status by accident).
+	status = mPrimitivesReader.ReadOffSize(offSizeForIndex);
 	if(status != PDFHummus::eSuccess)
 		return PDFHummus::eFailure;
+
+	// V-034: CFF spec requires offSize ∈ {1,2,3,4}. ReadOffset's switch has no default and would
+	// leave offsets uninitialized for any other value.
+	if(offSizeForIndex < 1 || offSizeForIndex > 4)
+	{
+		TRACE_LOG1("CFFFileInput::ReadIndexHeader, invalid INDEX offSize %d (must be 1..4)", offSizeForIndex);
+		return PDFHummus::eFailure;
+	}
 
 	mPrimitivesReader.SetOffSize(offSizeForIndex);
 	*outOffsets = new unsigned long[outItemsCount + 1];
@@ -328,6 +336,25 @@ EStatusCode CFFFileInput::ReadIndexHeader(unsigned long** outOffsets,unsigned sh
 
 	if (status != eSuccess)
 		return status;
+
+	// V-036: reject malformed offset tables before downstream consumers do unsigned subtraction
+	// (offsets[i+1] - offsets[i] wraps to ~ULONG_MAX on non-monotonic input and is fed to new Byte[N]).
+	// CFF spec: first offset is always 1; offsets are monotonically non-decreasing.
+	if((*outOffsets)[0] < 1)
+	{
+		TRACE_LOG1("CFFFileInput::ReadIndexHeader, INDEX offsets[0] = %lu (must be >= 1)", (*outOffsets)[0]);
+		return PDFHummus::eFailure;
+	}
+	for(unsigned long i = 0; i < outItemsCount; ++i)
+	{
+		if((*outOffsets)[i+1] < (*outOffsets)[i])
+		{
+			TRACE_LOG3("CFFFileInput::ReadIndexHeader, non-monotonic INDEX offset at i=%lu: %lu -> %lu",
+				i, (*outOffsets)[i], (*outOffsets)[i+1]);
+			return PDFHummus::eFailure;
+		}
+	}
+
 	return mPrimitivesReader.GetInternalState();
 }
 
@@ -1094,8 +1121,21 @@ EStatusCode CFFFileInput::ReadCharString(	LongFilePositionType inCharStringStart
 											Byte** outCharString)
 {
 	EStatusCode status = PDFHummus::eSuccess;
-	mPrimitivesReader.SetOffset(inCharStringStart);
 	*outCharString = NULL;
+
+	// V-037: defend against end < start (signed subtraction goes negative, then casts to a huge
+	// LongBufferSizeType — uncaught bad_alloc aborts process). The central V-036 fix in
+	// ReadIndexHeader already prevents this for INDEX-derived offsets; this is belt-and-suspenders
+	// since CharString::mStartPosition / mEndPosition are stored fields that could reach here
+	// from any future code path.
+	if(inCharStringEnd < inCharStringStart)
+	{
+		TRACE_LOG2("CFFFileInput::ReadCharString, end (%lld) < start (%lld)",
+			(long long)inCharStringEnd, (long long)inCharStringStart);
+		return PDFHummus::eFailure;
+	}
+
+	mPrimitivesReader.SetOffset(inCharStringStart);
 
 	do
 	{

--- a/PDFWriter/CFFFileInput.cpp
+++ b/PDFWriter/CFFFileInput.cpp
@@ -305,57 +305,71 @@ EStatusCode CFFFileInput::ReadHeader()
 EStatusCode CFFFileInput::ReadIndexHeader(unsigned long** outOffsets,unsigned short& outItemsCount)
 {
 	Byte offSizeForIndex;
+	EStatusCode status = PDFHummus::eFailure;
 
 	*outOffsets = NULL;
 
-	EStatusCode status = mPrimitivesReader.ReadCard16(outItemsCount);
-	if(status != PDFHummus::eSuccess)
-		return PDFHummus::eFailure;
-
-	if(0 == outItemsCount)
-		return PDFHummus::eSuccess;
-
-	// V-033: capture ReadOffSize's own status (was checking the prior ReadCard16 status by accident).
-	status = mPrimitivesReader.ReadOffSize(offSizeForIndex);
-	if(status != PDFHummus::eSuccess)
-		return PDFHummus::eFailure;
-
-	// V-034: CFF spec requires offSize ∈ {1,2,3,4}. ReadOffset's switch has no default and would
-	// leave offsets uninitialized for any other value.
-	if(offSizeForIndex < 1 || offSizeForIndex > 4)
+	do
 	{
-		TRACE_LOG1("CFFFileInput::ReadIndexHeader, invalid INDEX offSize %d (must be 1..4)", offSizeForIndex);
-		return PDFHummus::eFailure;
-	}
+		status = mPrimitivesReader.ReadCard16(outItemsCount);
+		if(status != PDFHummus::eSuccess)
+			break;
 
-	mPrimitivesReader.SetOffSize(offSizeForIndex);
-	*outOffsets = new unsigned long[outItemsCount + 1];
+		if(0 == outItemsCount)
+			break;
 
-	for(unsigned long i = 0; i <= outItemsCount && status == eSuccess; ++ i)
-		status = mPrimitivesReader.ReadOffset((*outOffsets)[i]);
+		status = mPrimitivesReader.ReadOffSize(offSizeForIndex);
+		if(status != PDFHummus::eSuccess)
+			break;
 
-	if (status != eSuccess)
-		return status;
-
-	// V-036: reject malformed offset tables before downstream consumers do unsigned subtraction
-	// (offsets[i+1] - offsets[i] wraps to ~ULONG_MAX on non-monotonic input and is fed to new Byte[N]).
-	// CFF spec: first offset is always 1; offsets are monotonically non-decreasing.
-	if((*outOffsets)[0] < 1)
-	{
-		TRACE_LOG1("CFFFileInput::ReadIndexHeader, INDEX offsets[0] = %lu (must be >= 1)", (*outOffsets)[0]);
-		return PDFHummus::eFailure;
-	}
-	for(unsigned long i = 0; i < outItemsCount; ++i)
-	{
-		if((*outOffsets)[i+1] < (*outOffsets)[i])
+		// CFF spec requires offSize ∈ {1, 2, 3, 4}.
+		if(offSizeForIndex < 1 || offSizeForIndex > 4)
 		{
-			TRACE_LOG3("CFFFileInput::ReadIndexHeader, non-monotonic INDEX offset at i=%lu: %lu -> %lu",
-				i, (*outOffsets)[i], (*outOffsets)[i+1]);
-			return PDFHummus::eFailure;
+			TRACE_LOG1("CFFFileInput::ReadIndexHeader, invalid INDEX offSize %d (must be 1..4)", offSizeForIndex);
+			status = PDFHummus::eFailure;
+			break;
 		}
+
+		mPrimitivesReader.SetOffSize(offSizeForIndex);
+		*outOffsets = new unsigned long[outItemsCount + 1];
+
+		for(unsigned long i = 0; i <= outItemsCount && status == eSuccess; ++ i)
+			status = mPrimitivesReader.ReadOffset((*outOffsets)[i]);
+		if(status != eSuccess)
+			break;
+
+		// CFF spec: first offset is always 1.
+		if((*outOffsets)[0] < 1)
+		{
+			TRACE_LOG1("CFFFileInput::ReadIndexHeader, INDEX offsets[0] = %lu (must be >= 1)", (*outOffsets)[0]);
+			status = PDFHummus::eFailure;
+			break;
+		}
+
+		// Offsets must be monotonically non-decreasing.
+		for(unsigned long i = 0; i < outItemsCount; ++i)
+		{
+			if((*outOffsets)[i+1] < (*outOffsets)[i])
+			{
+				TRACE_LOG3("CFFFileInput::ReadIndexHeader, non-monotonic INDEX offset at i=%lu: %lu -> %lu",
+					i, (*outOffsets)[i], (*outOffsets)[i+1]);
+				status = PDFHummus::eFailure;
+				break;
+			}
+		}
+		if(status != PDFHummus::eSuccess)
+			break;
+
+		status = mPrimitivesReader.GetInternalState();
+	} while(false);
+
+	if(status != PDFHummus::eSuccess)
+	{
+		delete[] *outOffsets;
+		*outOffsets = NULL;
 	}
 
-	return mPrimitivesReader.GetInternalState();
+	return status;
 }
 
 EStatusCode CFFFileInput::ReadNameIndex()
@@ -1123,11 +1137,7 @@ EStatusCode CFFFileInput::ReadCharString(	LongFilePositionType inCharStringStart
 	EStatusCode status = PDFHummus::eSuccess;
 	*outCharString = NULL;
 
-	// V-037: defend against end < start (signed subtraction goes negative, then casts to a huge
-	// LongBufferSizeType — uncaught bad_alloc aborts process). The central V-036 fix in
-	// ReadIndexHeader already prevents this for INDEX-derived offsets; this is belt-and-suspenders
-	// since CharString::mStartPosition / mEndPosition are stored fields that could reach here
-	// from any future code path.
+	// end must be >= start; otherwise the unsigned subtraction below underflows.
 	if(inCharStringEnd < inCharStringStart)
 	{
 		TRACE_LOG2("CFFFileInput::ReadCharString, end (%lld) < start (%lld)",

--- a/PDFWriterTesting/CFFIndexSanity.cpp
+++ b/PDFWriterTesting/CFFIndexSanity.cpp
@@ -1,0 +1,272 @@
+/*
+   Source File : CFFIndexSanity.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression test for the CFF INDEX offset-table sanity checks added in
+   cluster C5 (V-033/034/036/037). Each malformed CFF below would previously
+   reach an unsigned subtraction on garbage offsets and feed the result to
+   `new Byte[N]`, a bad_alloc / OOB primitive depending on the values. With
+   the validation in ReadIndexHeader (and the defensive guard in
+   ReadCharString) in place, every malformed prefix is rejected with
+   eFailure on the very first INDEX (the Name INDEX).
+
+   The malformed streams are synthesised in-process so no binary fixtures
+   are required. The happy-path test parses BrushScriptStd.otf and asserts
+   exact values (font name, font count, .notdef glyph) so we can tell that
+   the validation didn't accidentally turn the parser into a no-op.
+*/
+#include "InputByteArrayStream.h"
+#include "InputFile.h"
+#include "OpenTypeFileInput.h"
+#include "CFFFileInput.h"
+#include "EStatusCode.h"
+#include "IOBasicTypes.h"
+
+#include "testing/TestIO.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace PDFHummus;
+using namespace IOBasicTypes;
+
+// Compose a CFF prefix: 4-byte header followed by a Name INDEX that the
+// caller crafted. The other INDEXes are never reached because parsing
+// fails at the Name INDEX.
+static string BuildCFFPrefix(const string& inNameIndex) {
+	string cff;
+	// Header: major=1, minor=0, hdrSize=4, absOffSize=1. The fourth byte's
+	// value is irrelevant for the rest of parsing — ReadCFFFile only uses
+	// hdrSize to skip to the Name INDEX, which is already at offset 4.
+	cff.push_back((char)0x01);
+	cff.push_back((char)0x00);
+	cff.push_back((char)0x04);
+	cff.push_back((char)0x01);
+	cff += inNameIndex;
+	return cff;
+}
+
+static EStatusCode parseSyntheticCFF(const string& inNameIndex) {
+	string cff = BuildCFFPrefix(inNameIndex);
+	InputByteArrayStream stream((Byte*)&cff[0], (LongFilePositionType)cff.size());
+	CFFFileInput cffInput;
+	return cffInput.ReadCFFFile(&stream);
+}
+
+// V-036: offsets[0] < 1 used to underflow `dataStartPosition + offsets[0] - 1`
+// in ReadSubrsFromIndex (and produce wild charstring start positions).
+static bool parsingZeroFirstOffset_returnsFailure() {
+	// Arrange: count=1, offSize=1, offsets=[0x00, 0x01]
+	string nameIndex;
+	nameIndex.push_back((char)0x00); nameIndex.push_back((char)0x01); // count=1
+	nameIndex.push_back((char)0x01);                                  // offSize=1
+	nameIndex.push_back((char)0x00);                                  // offsets[0]=0
+	nameIndex.push_back((char)0x01);                                  // offsets[1]=1
+	nameIndex.push_back((char)'X');                                   // dummy data byte
+
+	// Act
+	EStatusCode status = parseSyntheticCFF(nameIndex);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "CFFIndexSanity: zero first offset was accepted (V-036 regressed)" << endl;
+		return false;
+	}
+	return true;
+}
+
+// V-036: non-monotonic offsets used to make `offsets[i+1] - offsets[i]` wrap
+// to ~ULONG_MAX in unsigned arithmetic, then drive `new Byte[N]`.
+static bool parsingNonMonotonicOffsets_returnsFailure() {
+	// Arrange: count=1, offSize=1, offsets=[0x05, 0x01] (1 < 5 -> non-monotonic)
+	string nameIndex;
+	nameIndex.push_back((char)0x00); nameIndex.push_back((char)0x01); // count=1
+	nameIndex.push_back((char)0x01);                                  // offSize=1
+	nameIndex.push_back((char)0x05);                                  // offsets[0]=5
+	nameIndex.push_back((char)0x01);                                  // offsets[1]=1 (< prev)
+
+	// Act
+	EStatusCode status = parseSyntheticCFF(nameIndex);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "CFFIndexSanity: non-monotonic offsets were accepted (V-036 regressed)" << endl;
+		return false;
+	}
+	return true;
+}
+
+// V-034: offSize=0 leaves ReadOffset's switch with no matching case,
+// returning eFailure but with offset values uninitialized in the buffer.
+static bool parsingZeroOffSize_returnsFailure() {
+	// Arrange: count=1, offSize=0
+	string nameIndex;
+	nameIndex.push_back((char)0x00); nameIndex.push_back((char)0x01); // count=1
+	nameIndex.push_back((char)0x00);                                  // offSize=0 (invalid)
+
+	// Act
+	EStatusCode status = parseSyntheticCFF(nameIndex);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "CFFIndexSanity: offSize=0 was accepted (V-034 regressed)" << endl;
+		return false;
+	}
+	return true;
+}
+
+// V-034: same with an out-of-range high value.
+static bool parsingOutOfRangeOffSize_returnsFailure() {
+	// Arrange: count=1, offSize=5
+	string nameIndex;
+	nameIndex.push_back((char)0x00); nameIndex.push_back((char)0x01); // count=1
+	nameIndex.push_back((char)0x05);                                  // offSize=5 (invalid)
+
+	// Act
+	EStatusCode status = parseSyntheticCFF(nameIndex);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "CFFIndexSanity: offSize=5 was accepted (V-034 regressed)" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Parses BrushScriptStd.otf and leaves the file open through the caller's
+// scope so the CFF reader's stream pointer stays valid for follow-up
+// ReadCharString calls. Returns eSuccess and populates outOpenType+outFile,
+// otherwise returns eFailure (file is closed in the failure path).
+static EStatusCode openBrushScriptStd(char* argv[], InputFile& outFile, OpenTypeFileInput& outOpenType) {
+	if(outFile.OpenFile(BuildRelativeInputPath(argv, "fonts/BrushScriptStd.otf")) != eSuccess)
+		return eFailure;
+	EStatusCode status = outOpenType.ReadOpenTypeFile(outFile.GetInputStream(), 0);
+	if(status != eSuccess)
+		outFile.CloseFile();
+	return status;
+}
+
+// V-037: ReadCharString with end < start used to underflow the unsigned
+// subtraction fed to `new Byte[N]`. Reachable directly via the public
+// IType2InterpreterImplementation::ReadCharString override.
+static bool readCharStringWithEndBeforeStart_returnsFailure(char* argv[]) {
+	// Arrange: parse a valid font so mPrimitivesReader has a stream.
+	InputFile otfFile;
+	OpenTypeFileInput openType;
+	if(openBrushScriptStd(argv, otfFile, openType) != eSuccess) {
+		cout << "CFFIndexSanity: BrushScriptStd.otf parse failed; cannot test V-037" << endl;
+		return false;
+	}
+
+	// Act: pick legitimate-looking offsets but with end strictly less than start.
+	Byte* charString = NULL;
+	EStatusCode status = openType.mCFF.ReadCharString(/*start*/ 1000, /*end*/ 500, &charString);
+	otfFile.CloseFile();
+
+	// Assert
+	if(status == eSuccess) {
+		delete[] charString;
+		cout << "CFFIndexSanity: ReadCharString accepted end < start (V-037 regressed)" << endl;
+		return false;
+	}
+	if(charString != NULL) {
+		// Function contract: failure path leaves outCharString NULL (never allocated).
+		delete[] charString;
+		cout << "CFFIndexSanity: ReadCharString left non-NULL buffer on failure" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Happy path: prove the new validation didn't break parsing of a real CFF
+// font. Asserts exact expected values rather than just "didn't crash" /
+// "count > 0", so a regression that quietly turns the parser into a no-op
+// (e.g. always returning empty data) would be caught.
+static bool parsingValidCFF_populatesExpectedValues(char* argv[]) {
+	// Arrange
+	InputFile otfFile;
+	OpenTypeFileInput openType;
+	if(openBrushScriptStd(argv, otfFile, openType) != eSuccess) {
+		cout << "CFFIndexSanity: positive path failed - real CFF rejected" << endl;
+		return false;
+	}
+
+	// Assert: Name INDEX produced exactly one font with the expected name.
+	bool ok = true;
+	if(openType.mCFF.mFontsCount != 1) {
+		cout << "CFFIndexSanity: expected 1 font, got " << openType.mCFF.mFontsCount << endl;
+		ok = false;
+	}
+	if(ok && openType.mCFF.mName.size() != 1) {
+		cout << "CFFIndexSanity: expected 1 name entry, got " << openType.mCFF.mName.size() << endl;
+		ok = false;
+	}
+	if(ok && openType.mCFF.mName.front() != "BrushScriptStd") {
+		cout << "CFFIndexSanity: expected font name 'BrushScriptStd', got '"
+		     << openType.mCFF.mName.front() << "'" << endl;
+		ok = false;
+	}
+
+	// Assert: CharStrings INDEX populated and glyph 0 is .notdef (CFF spec invariant).
+	unsigned short glyphCount = openType.mCFF.GetCharStringsCount(0);
+	if(ok && glyphCount == 0) {
+		cout << "CFFIndexSanity: expected non-zero glyph count" << endl;
+		ok = false;
+	}
+	if(ok && openType.mCFF.GetGlyphName(0, 0) != ".notdef") {
+		cout << "CFFIndexSanity: expected glyph 0 name '.notdef', got '"
+		     << openType.mCFF.GetGlyphName(0, 0) << "'" << endl;
+		ok = false;
+	}
+
+	// Assert: ReadCharString round-trips a real glyph (proves our V-037 guard
+	// didn't accidentally reject end == start + N for any positive N).
+	if(ok) {
+		CharString* notdef = openType.mCFF.GetGlyphCharString(0, 0);
+		if(notdef == NULL) {
+			cout << "CFFIndexSanity: GetGlyphCharString returned NULL for .notdef" << endl;
+			ok = false;
+		} else {
+			Byte* buffer = NULL;
+			EStatusCode readStatus = openType.mCFF.ReadCharString(
+				notdef->mStartPosition, notdef->mEndPosition, &buffer);
+			if(readStatus != eSuccess) {
+				cout << "CFFIndexSanity: ReadCharString failed on a real .notdef glyph" << endl;
+				ok = false;
+			} else if(buffer == NULL) {
+				cout << "CFFIndexSanity: ReadCharString reported success but left buffer NULL" << endl;
+				ok = false;
+			}
+			delete[] buffer;
+		}
+	}
+
+	otfFile.CloseFile();
+	return ok;
+}
+
+int CFFIndexSanity(int argc, char* argv[]) {
+	if(!parsingZeroFirstOffset_returnsFailure()) return 1;
+	if(!parsingNonMonotonicOffsets_returnsFailure()) return 1;
+	if(!parsingZeroOffSize_returnsFailure()) return 1;
+	if(!parsingOutOfRangeOffSize_returnsFailure()) return 1;
+	if(!readCharStringWithEndBeforeStart_returnsFailure(argv)) return 1;
+	if(!parsingValidCFF_populatesExpectedValues(argv)) return 1;
+	return 0;
+}

--- a/PDFWriterTesting/CFFIndexSanity.cpp
+++ b/PDFWriterTesting/CFFIndexSanity.cpp
@@ -17,12 +17,11 @@
    limitations under the License.
 
 
-   Regression test for the CFF INDEX offset-table sanity checks added in
-   cluster C5 (V-033/034/036/037). Each malformed CFF below would previously
-   reach an unsigned subtraction on garbage offsets and feed the result to
-   `new Byte[N]`, a bad_alloc / OOB primitive depending on the values. With
-   the validation in ReadIndexHeader (and the defensive guard in
-   ReadCharString) in place, every malformed prefix is rejected with
+   Regression test for the CFF INDEX offset-table sanity checks in
+   ReadIndexHeader and ReadCharString. Each malformed CFF below would
+   previously reach an unsigned subtraction on garbage offsets and feed the
+   result to `new Byte[N]`, a bad_alloc / OOB primitive depending on the
+   values. With validation in place, every malformed prefix is rejected with
    eFailure on the very first INDEX (the Name INDEX).
 
    The malformed streams are synthesised in-process so no binary fixtures
@@ -46,104 +45,78 @@ using namespace std;
 using namespace PDFHummus;
 using namespace IOBasicTypes;
 
-// Compose a CFF prefix: 4-byte header followed by a Name INDEX that the
-// caller crafted. The other INDEXes are never reached because parsing
-// fails at the Name INDEX.
-static string BuildCFFPrefix(const string& inNameIndex) {
-	string cff;
-	// Header: major=1, minor=0, hdrSize=4, absOffSize=1. The fourth byte's
-	// value is irrelevant for the rest of parsing — ReadCFFFile only uses
-	// hdrSize to skip to the Name INDEX, which is already at offset 4.
-	cff.push_back((char)0x01);
-	cff.push_back((char)0x00);
-	cff.push_back((char)0x04);
-	cff.push_back((char)0x01);
-	cff += inNameIndex;
-	return cff;
-}
+// Header: major=1, minor=0, hdrSize=4, absOffSize=1. ReadCFFFile only
+// uses hdrSize to skip to the Name INDEX, which is already at offset 4.
+static const char scCFFHeader[] = "\x01\x00\x04\x01";
+static const size_t scCFFHeaderSize = sizeof(scCFFHeader) - 1;
 
-static EStatusCode parseSyntheticCFF(const string& inNameIndex) {
-	string cff = BuildCFFPrefix(inNameIndex);
+// Drive ReadCFFFile against a 4-byte header + the caller-crafted Name
+// INDEX bytes. The Name INDEX always-fails cases never reach the other
+// INDEXes, so we can stop the synthetic stream right after it.
+static EStatusCode parseSyntheticCFF(const char* inNameIndexBytes, size_t inNameIndexLen) {
+	string cff;
+	cff.append(scCFFHeader, scCFFHeaderSize);
+	cff.append(inNameIndexBytes, inNameIndexLen);
 	InputByteArrayStream stream((Byte*)&cff[0], (LongFilePositionType)cff.size());
 	CFFFileInput cffInput;
 	return cffInput.ReadCFFFile(&stream);
 }
 
-// V-036: offsets[0] < 1 used to underflow `dataStartPosition + offsets[0] - 1`
+// Pass a raw byte literal to parseSyntheticCFF, deriving the length from
+// the literal so embedded \x00 bytes don't truncate the string. Use only
+// with string literals — sizeof on a pointer would silently take 8 bytes.
+#define PARSE_NAME_INDEX(bytes) parseSyntheticCFF((bytes), sizeof(bytes) - 1)
+
+// offsets[0] < 1 would underflow `dataStartPosition + offsets[0] - 1`
 // in ReadSubrsFromIndex (and produce wild charstring start positions).
 static bool parsingZeroFirstOffset_returnsFailure() {
 	// Arrange: count=1, offSize=1, offsets=[0x00, 0x01]
-	string nameIndex;
-	nameIndex.push_back((char)0x00); nameIndex.push_back((char)0x01); // count=1
-	nameIndex.push_back((char)0x01);                                  // offSize=1
-	nameIndex.push_back((char)0x00);                                  // offsets[0]=0
-	nameIndex.push_back((char)0x01);                                  // offsets[1]=1
-	nameIndex.push_back((char)'X');                                   // dummy data byte
-
-	// Act
-	EStatusCode status = parseSyntheticCFF(nameIndex);
+	EStatusCode status = PARSE_NAME_INDEX("\x00\x01\x01\x00\x01");
 
 	// Assert
 	if(status == eSuccess) {
-		cout << "CFFIndexSanity: zero first offset was accepted (V-036 regressed)" << endl;
+		cout << "CFFIndexSanity: zero first offset was accepted" << endl;
 		return false;
 	}
 	return true;
 }
 
-// V-036: non-monotonic offsets used to make `offsets[i+1] - offsets[i]` wrap
+// Non-monotonic offsets used to make `offsets[i+1] - offsets[i]` wrap
 // to ~ULONG_MAX in unsigned arithmetic, then drive `new Byte[N]`.
 static bool parsingNonMonotonicOffsets_returnsFailure() {
 	// Arrange: count=1, offSize=1, offsets=[0x05, 0x01] (1 < 5 -> non-monotonic)
-	string nameIndex;
-	nameIndex.push_back((char)0x00); nameIndex.push_back((char)0x01); // count=1
-	nameIndex.push_back((char)0x01);                                  // offSize=1
-	nameIndex.push_back((char)0x05);                                  // offsets[0]=5
-	nameIndex.push_back((char)0x01);                                  // offsets[1]=1 (< prev)
-
-	// Act
-	EStatusCode status = parseSyntheticCFF(nameIndex);
+	EStatusCode status = PARSE_NAME_INDEX("\x00\x01\x01\x05\x01");
 
 	// Assert
 	if(status == eSuccess) {
-		cout << "CFFIndexSanity: non-monotonic offsets were accepted (V-036 regressed)" << endl;
+		cout << "CFFIndexSanity: non-monotonic offsets were accepted" << endl;
 		return false;
 	}
 	return true;
 }
 
-// V-034: offSize=0 leaves ReadOffset's switch with no matching case,
-// returning eFailure but with offset values uninitialized in the buffer.
+// offSize=0 leaves ReadOffset's switch with no matching case, returning
+// eFailure but with offset values uninitialized in the buffer.
 static bool parsingZeroOffSize_returnsFailure() {
 	// Arrange: count=1, offSize=0
-	string nameIndex;
-	nameIndex.push_back((char)0x00); nameIndex.push_back((char)0x01); // count=1
-	nameIndex.push_back((char)0x00);                                  // offSize=0 (invalid)
-
-	// Act
-	EStatusCode status = parseSyntheticCFF(nameIndex);
+	EStatusCode status = PARSE_NAME_INDEX("\x00\x01\x00");
 
 	// Assert
 	if(status == eSuccess) {
-		cout << "CFFIndexSanity: offSize=0 was accepted (V-034 regressed)" << endl;
+		cout << "CFFIndexSanity: offSize=0 was accepted" << endl;
 		return false;
 	}
 	return true;
 }
 
-// V-034: same with an out-of-range high value.
+// Same with an out-of-range high value.
 static bool parsingOutOfRangeOffSize_returnsFailure() {
 	// Arrange: count=1, offSize=5
-	string nameIndex;
-	nameIndex.push_back((char)0x00); nameIndex.push_back((char)0x01); // count=1
-	nameIndex.push_back((char)0x05);                                  // offSize=5 (invalid)
-
-	// Act
-	EStatusCode status = parseSyntheticCFF(nameIndex);
+	EStatusCode status = PARSE_NAME_INDEX("\x00\x01\x05");
 
 	// Assert
 	if(status == eSuccess) {
-		cout << "CFFIndexSanity: offSize=5 was accepted (V-034 regressed)" << endl;
+		cout << "CFFIndexSanity: offSize=5 was accepted" << endl;
 		return false;
 	}
 	return true;
@@ -151,38 +124,33 @@ static bool parsingOutOfRangeOffSize_returnsFailure() {
 
 // Parses BrushScriptStd.otf and leaves the file open through the caller's
 // scope so the CFF reader's stream pointer stays valid for follow-up
-// ReadCharString calls. Returns eSuccess and populates outOpenType+outFile,
-// otherwise returns eFailure (file is closed in the failure path).
+// ReadCharString calls. The caller's outFile destructor closes the file.
 static EStatusCode openBrushScriptStd(char* argv[], InputFile& outFile, OpenTypeFileInput& outOpenType) {
 	if(outFile.OpenFile(BuildRelativeInputPath(argv, "fonts/BrushScriptStd.otf")) != eSuccess)
 		return eFailure;
-	EStatusCode status = outOpenType.ReadOpenTypeFile(outFile.GetInputStream(), 0);
-	if(status != eSuccess)
-		outFile.CloseFile();
-	return status;
+	return outOpenType.ReadOpenTypeFile(outFile.GetInputStream(), 0);
 }
 
-// V-037: ReadCharString with end < start used to underflow the unsigned
-// subtraction fed to `new Byte[N]`. Reachable directly via the public
+// ReadCharString with end < start would underflow the unsigned subtraction
+// fed to `new Byte[N]`. Reachable directly via the public
 // IType2InterpreterImplementation::ReadCharString override.
 static bool readCharStringWithEndBeforeStart_returnsFailure(char* argv[]) {
 	// Arrange: parse a valid font so mPrimitivesReader has a stream.
 	InputFile otfFile;
 	OpenTypeFileInput openType;
 	if(openBrushScriptStd(argv, otfFile, openType) != eSuccess) {
-		cout << "CFFIndexSanity: BrushScriptStd.otf parse failed; cannot test V-037" << endl;
+		cout << "CFFIndexSanity: BrushScriptStd.otf parse failed" << endl;
 		return false;
 	}
 
 	// Act: pick legitimate-looking offsets but with end strictly less than start.
 	Byte* charString = NULL;
 	EStatusCode status = openType.mCFF.ReadCharString(/*start*/ 1000, /*end*/ 500, &charString);
-	otfFile.CloseFile();
 
 	// Assert
 	if(status == eSuccess) {
 		delete[] charString;
-		cout << "CFFIndexSanity: ReadCharString accepted end < start (V-037 regressed)" << endl;
+		cout << "CFFIndexSanity: ReadCharString accepted end < start" << endl;
 		return false;
 	}
 	if(charString != NULL) {
@@ -207,57 +175,58 @@ static bool parsingValidCFF_populatesExpectedValues(char* argv[]) {
 		return false;
 	}
 
-	// Assert: Name INDEX produced exactly one font with the expected name.
-	bool ok = true;
-	if(openType.mCFF.mFontsCount != 1) {
-		cout << "CFFIndexSanity: expected 1 font, got " << openType.mCFF.mFontsCount << endl;
-		ok = false;
-	}
-	if(ok && openType.mCFF.mName.size() != 1) {
-		cout << "CFFIndexSanity: expected 1 name entry, got " << openType.mCFF.mName.size() << endl;
-		ok = false;
-	}
-	if(ok && openType.mCFF.mName.front() != "BrushScriptStd") {
-		cout << "CFFIndexSanity: expected font name 'BrushScriptStd', got '"
-		     << openType.mCFF.mName.front() << "'" << endl;
-		ok = false;
-	}
+	bool ok = false;
+	Byte* buffer = NULL;
 
-	// Assert: CharStrings INDEX populated and glyph 0 is .notdef (CFF spec invariant).
-	unsigned short glyphCount = openType.mCFF.GetCharStringsCount(0);
-	if(ok && glyphCount == 0) {
-		cout << "CFFIndexSanity: expected non-zero glyph count" << endl;
-		ok = false;
-	}
-	if(ok && openType.mCFF.GetGlyphName(0, 0) != ".notdef") {
-		cout << "CFFIndexSanity: expected glyph 0 name '.notdef', got '"
-		     << openType.mCFF.GetGlyphName(0, 0) << "'" << endl;
-		ok = false;
-	}
+	do {
+		// Assert: Name INDEX produced exactly one font with the expected name.
+		if(openType.mCFF.mFontsCount != 1) {
+			cout << "CFFIndexSanity: expected 1 font, got " << openType.mCFF.mFontsCount << endl;
+			break;
+		}
+		if(openType.mCFF.mName.size() != 1) {
+			cout << "CFFIndexSanity: expected 1 name entry, got " << openType.mCFF.mName.size() << endl;
+			break;
+		}
+		if(openType.mCFF.mName.front() != "BrushScriptStd") {
+			cout << "CFFIndexSanity: expected font name 'BrushScriptStd', got '"
+			     << openType.mCFF.mName.front() << "'" << endl;
+			break;
+		}
 
-	// Assert: ReadCharString round-trips a real glyph (proves our V-037 guard
-	// didn't accidentally reject end == start + N for any positive N).
-	if(ok) {
+		// Assert: CharStrings INDEX populated and glyph 0 is .notdef (CFF spec invariant).
+		if(openType.mCFF.GetCharStringsCount(0) == 0) {
+			cout << "CFFIndexSanity: expected non-zero glyph count" << endl;
+			break;
+		}
+		if(openType.mCFF.GetGlyphName(0, 0) != ".notdef") {
+			cout << "CFFIndexSanity: expected glyph 0 name '.notdef', got '"
+			     << openType.mCFF.GetGlyphName(0, 0) << "'" << endl;
+			break;
+		}
+
+		// Assert: ReadCharString round-trips a real glyph (proves the end >= start
+		// guard didn't accidentally reject the normal end == start + N case).
 		CharString* notdef = openType.mCFF.GetGlyphCharString(0, 0);
 		if(notdef == NULL) {
 			cout << "CFFIndexSanity: GetGlyphCharString returned NULL for .notdef" << endl;
-			ok = false;
-		} else {
-			Byte* buffer = NULL;
-			EStatusCode readStatus = openType.mCFF.ReadCharString(
-				notdef->mStartPosition, notdef->mEndPosition, &buffer);
-			if(readStatus != eSuccess) {
-				cout << "CFFIndexSanity: ReadCharString failed on a real .notdef glyph" << endl;
-				ok = false;
-			} else if(buffer == NULL) {
-				cout << "CFFIndexSanity: ReadCharString reported success but left buffer NULL" << endl;
-				ok = false;
-			}
-			delete[] buffer;
+			break;
 		}
-	}
+		EStatusCode readStatus = openType.mCFF.ReadCharString(
+			notdef->mStartPosition, notdef->mEndPosition, &buffer);
+		if(readStatus != eSuccess) {
+			cout << "CFFIndexSanity: ReadCharString failed on a real .notdef glyph" << endl;
+			break;
+		}
+		if(buffer == NULL) {
+			cout << "CFFIndexSanity: ReadCharString reported success but left buffer NULL" << endl;
+			break;
+		}
 
-	otfFile.CloseFile();
+		ok = true;
+	} while(false);
+
+	delete[] buffer;
 	return ok;
 }
 

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -15,6 +15,7 @@ create_test_sourcelist (Tests
   CIDSetWritingCFF.cpp
   CIDSetWritingTrueType.cpp
   CIDSetWritingTrueType2.cpp
+  CFFIndexSanity.cpp
   ColorEmojiColr.cpp
   ColorEmojiColrV1.cpp
   CopyingAndMergingEmptyPages.cpp


### PR DESCRIPTION
## Summary

Cluster **C5** of the Phase 2 font-parsing audit: four CFF INDEX vulnerabilities centred on `CFFFileInput::ReadIndexHeader` and `ReadCharString`.

| ID | Severity | Issue | Fix location |
|---|---|---|---|
| V-033 | MED | `ReadIndexHeader` checked the prior `ReadCard16` status instead of `ReadOffSize`'s — a failed offset-size read sailed through silently | `ReadIndexHeader` |
| V-034 | MED | `offSize` not validated `∈ {1..4}`. `ReadOffset`'s switch has no `default`, so per-entry offsets were uninitialized for any other value | `ReadIndexHeader` |
| V-036 | HIGH | INDEX offsets accepted without `≥ 1` / monotonic checks. `offsets[i+1] - offsets[i]` is unsigned — non-monotonic offsets wrap to `~ULONG_MAX` and feed `new Byte[N]` (uncaught `bad_alloc` aborts the process; OOB-primitive variants exist depending on which INDEX consumer fires). `offsets[0] == 0` underflows `dataStartPosition + offsets[0] - 1` in `ReadSubrsFromIndex` → wild charstring start | `ReadIndexHeader` (covers all four INDEX consumers — `ReadNameIndex`, `ReadStringIndex`, `ReadSubrsFromIndex`, `ReadTopDictIndex`) |
| V-037 | HIGH | `ReadCharString` did `new Byte[end - start]` with no `end >= start` check — same unsigned underflow when reachable | `ReadCharString` (belt-and-suspenders; central V-036 fix already protects INDEX-derived charstring offsets) |

The four fixes share a single root cause and are bundled in one PR per the cluster's "single source location fixes everything downstream" shape.

### Validation in `ReadIndexHeader`

After the offset-size and offset-table reads:

- `offSize` must be in `{1, 2, 3, 4}`.
- `offsets[0] >= 1` (CFF spec: first offset is always 1).
- `offsets[i+1] >= offsets[i]` for all `i` (monotonic).

Each violation returns `eFailure` with a `TRACE_LOG` describing the value rejected. Existing callers already `delete[]` the offsets buffer regardless of returned status, so the failure path needs no per-callsite changes.

### Decision: no upper-bound caps in this PR

A "valid-looking but huge" offset table is a **memory-DoS** rather than an OOB primitive — same class we explicitly deferred from PR #353 ("better as cross-format hardening PR if pursued"). Picking the right cap requires real-font measurement and isn't required to defeat the OOB primitive these findings describe. Same call here keeps the PR focused.

## Regression test — `CFFIndexSanity`

Mirrors the `Type1SubrSanity` shape:

- **Synthetic malformed cases** (in-process CFF prefix + `InputByteArrayStream`, no binary fixtures):
  - `offsets[0] = 0` (V-036)
  - non-monotonic `offsets = [5, 1]` (V-036)
  - `offSize = 0` (V-034)
  - `offSize = 5` (V-034)
  - `ReadCharString(start=1000, end=500)` (V-037)
- **Happy path**: parses `BrushScriptStd.otf` and asserts **exact values** rather than bounds — `mFontsCount == 1`, `mName.front() == "BrushScriptStd"`, glyph 0 name is `.notdef`, and a real charstring round-trips through `ReadCharString`. Catches "validation accidentally turned the parser into a no-op" regressions.

Verified by reverting the `CFFFileInput.cpp` changes locally: malformed cases crash with `std::bad_alloc` (`EXIT=134`) — i.e. the test exercises the actual bug, not a no-op.

Full local `ctest`: 85/85 pass.

## Test plan

- [x] `ctest -C Release` — all 85 tests pass
- [x] `CFFIndexSanity` passes with the fix
- [x] `CFFIndexSanity` crashes (`std::bad_alloc`) without the fix — confirms the test exercises the real OOB path
- [ ] CI green
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)