### PR TITLE
fix: CFF DICT operand-list bounds (V-041)

### DIFF
--- a/PDFWriter/CFFFileInput.cpp
+++ b/PDFWriter/CFFFileInput.cpp
@@ -643,10 +643,13 @@ long CFFFileInput::GetSingleIntegerValueFromDict(const UShortToDictOperandListMa
 {
 	UShortToDictOperandListMap::const_iterator it = inDict.find(inKey);
 
-	// Reject malformed entries (key with no operands, or a real where an
-	// integer is expected) so garbage from front() / the union doesn't flow
-	// into seek offsets and INDEX read amounts downstream.
-	if(it == inDict.end() || it->second.empty() || !it->second.front().IsInteger)
+	// Every caller treats the returned value as a non-negative quantity
+	// (file offset, intra-dict offset, or enum-like type id). Empty list,
+	// non-integer, or negative integer all fall back to the supplied
+	// default so garbage from front() / the union / a malicious negative
+	// doesn't flow into SetOffset / INDEX read amounts downstream.
+	if(it == inDict.end() || it->second.empty() || !it->second.front().IsInteger
+		|| it->second.front().IntegerValue < 0)
 		return inDefault;
 
 	return it->second.front().IntegerValue;

--- a/PDFWriter/CFFFileInput.cpp
+++ b/PDFWriter/CFFFileInput.cpp
@@ -702,11 +702,22 @@ EStatusCode CFFFileInput::ReadPrivateDict(const UShortToDictOperandListMap& inRe
 			TRACE_LOG("CFFFileInput::ReadPrivateDict, /Private size and offset must be integers");
 			return PDFHummus::eFailure;
 		}
+		// Negative size would convert to a huge value when passed to
+		// ReadDict's unsigned read amount; negative offset would seek to
+		// junk. Both are malformed for what the spec defines as a byte
+		// position and a byte count.
+		if(sizeOperand.IntegerValue < 0 || offsetOperand.IntegerValue < 0)
+		{
+			TRACE_LOG2("CFFFileInput::ReadPrivateDict, /Private size=%ld and offset=%ld must be non-negative",
+				sizeOperand.IntegerValue, offsetOperand.IntegerValue);
+			return PDFHummus::eFailure;
+		}
 
 		outPrivateDict->mPrivateDictStart = (LongFilePositionType)offsetOperand.IntegerValue;
-		outPrivateDict->mPrivateDictEnd = (LongFilePositionType)(
-														offsetOperand.IntegerValue +
-														sizeOperand.IntegerValue);
+		// Add in LongFilePositionType (signed 64-bit) so the sum can't
+		// overflow `long` on platforms where it's 32-bit.
+		outPrivateDict->mPrivateDictEnd = (LongFilePositionType)offsetOperand.IntegerValue +
+		                                  (LongFilePositionType)sizeOperand.IntegerValue;
 
 		mPrimitivesReader.SetOffset(offsetOperand.IntegerValue);
 		status = ReadDict(sizeOperand.IntegerValue,outPrivateDict->mPrivateDict);

--- a/PDFWriter/CFFFileInput.cpp
+++ b/PDFWriter/CFFFileInput.cpp
@@ -643,11 +643,13 @@ long CFFFileInput::GetSingleIntegerValueFromDict(const UShortToDictOperandListMa
 {
 	UShortToDictOperandListMap::const_iterator it = inDict.find(inKey);
 
-	if(it != inDict.end())
-		return it->second.front().IntegerValue;
-	else
+	// Reject malformed entries (key with no operands, or a real where an
+	// integer is expected) so garbage from front() / the union doesn't flow
+	// into seek offsets and INDEX read amounts downstream.
+	if(it == inDict.end() || it->second.empty() || !it->second.front().IsInteger)
 		return inDefault;
 
+	return it->second.front().IntegerValue;
 }
 
 static const unsigned short scCharstringType = 0x0C06;
@@ -684,13 +686,30 @@ EStatusCode CFFFileInput::ReadPrivateDict(const UShortToDictOperandListMap& inRe
 	}
 	else
 	{
-		outPrivateDict->mPrivateDictStart = (LongFilePositionType)it->second.back().IntegerValue;
-		outPrivateDict->mPrivateDictEnd = (LongFilePositionType)(
-														it->second.back().IntegerValue + 
-														it->second.front().IntegerValue);
+		// /Private operand list is (size, offset) — two integers. Reject
+		// fewer operands or non-integer reals before they flow into
+		// SetOffset and ReadDict's read amount.
+		if(it->second.size() < 2)
+		{
+			TRACE_LOG1("CFFFileInput::ReadPrivateDict, /Private has %lu operands (need at least 2)",
+				(unsigned long)it->second.size());
+			return PDFHummus::eFailure;
+		}
+		const DictOperand& sizeOperand = it->second.front();
+		const DictOperand& offsetOperand = it->second.back();
+		if(!sizeOperand.IsInteger || !offsetOperand.IsInteger)
+		{
+			TRACE_LOG("CFFFileInput::ReadPrivateDict, /Private size and offset must be integers");
+			return PDFHummus::eFailure;
+		}
 
-		mPrimitivesReader.SetOffset(it->second.back().IntegerValue);
-		status = ReadDict(it->second.front().IntegerValue,outPrivateDict->mPrivateDict);
+		outPrivateDict->mPrivateDictStart = (LongFilePositionType)offsetOperand.IntegerValue;
+		outPrivateDict->mPrivateDictEnd = (LongFilePositionType)(
+														offsetOperand.IntegerValue +
+														sizeOperand.IntegerValue);
+
+		mPrimitivesReader.SetOffset(offsetOperand.IntegerValue);
+		status = ReadDict(sizeOperand.IntegerValue,outPrivateDict->mPrivateDict);
 	}
 	return status;
 }

--- a/PDFWriterTesting/CFFFileInputTest.cpp
+++ b/PDFWriterTesting/CFFFileInputTest.cpp
@@ -1,0 +1,254 @@
+/*
+   Source File : CFFFileInputTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression test for CFF DICT operand-list bounds in
+   GetSingleIntegerValueFromDict and ReadPrivateDict. Both used to call
+   front()/back() on the operand list without checking it was non-empty
+   or that the operand was actually an integer, so a malformed CFF that
+   emitted an operator with no operands (or with a real where the spec
+   requires an integer) reached UB / type-punned union reads that flowed
+   into seek offsets and ReadDict's read amount.
+
+   The malformed streams are synthesised in-process so no binary fixtures
+   are required. The happy-path test parses BrushScriptStd.otf and asserts
+   exact private-dict values so we can tell the new validation didn't
+   accidentally turn the parser into a no-op.
+*/
+#include "InputByteArrayStream.h"
+#include "InputFile.h"
+#include "OpenTypeFileInput.h"
+#include "CFFFileInput.h"
+#include "DictOperand.h"
+#include "EStatusCode.h"
+#include "IOBasicTypes.h"
+
+#include "testing/TestIO.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace PDFHummus;
+using namespace IOBasicTypes;
+
+// CFF spec keys (operator bytes) used to drive the bug paths from a Top DICT.
+static const Byte scOpCharStrings = 0x11;   // CharStrings (key 17)
+static const Byte scOpPrivate     = 0x12;   // Private (key 18)
+
+// Header: major=1, minor=0, hdrSize=4, absOffSize=1.
+static const char scCFFHeader[] = "\x01\x00\x04\x01";
+
+// Empty INDEXes for String INDEX and Global Subrs INDEX, which we don't
+// exercise but ReadCFFFile insists on parsing before reaching ReadCharStrings
+// and ReadPrivateDicts.
+static const char scEmptyIndex[] = "\x00\x00";
+
+// Build a complete CFF buffer ending at the Global Subrs INDEX. The Top DICT
+// payload (the part between the operator-encoded Top DICT INDEX header and the
+// String INDEX) is supplied by the caller so each test crafts the malformed
+// region it cares about. Top DICT length is capped at 254 so it fits a single
+// 1-byte offset entry.
+static string buildSyntheticCFF(const char* inTopDictBytes, size_t inTopDictLen) {
+	string cff;
+	cff.append(scCFFHeader, sizeof(scCFFHeader) - 1);
+
+	// Name INDEX: count=1, offSize=1, offsets=[1, 2], data="A"
+	cff.append("\x00\x01\x01\x01\x02\x41", 6);
+
+	// Top DICT INDEX: count=1, offSize=1, offsets=[1, 1+len], data=<top dict>
+	cff.append("\x00\x01\x01\x01", 4);
+	cff.push_back((char)(1 + (Byte)inTopDictLen));
+	cff.append(inTopDictBytes, inTopDictLen);
+
+	// String INDEX (empty), Global Subrs INDEX (empty)
+	cff.append(scEmptyIndex, sizeof(scEmptyIndex) - 1);
+	cff.append(scEmptyIndex, sizeof(scEmptyIndex) - 1);
+
+	return cff;
+}
+
+static EStatusCode parseSyntheticCFF(const char* inTopDictBytes, size_t inTopDictLen, CFFFileInput& outCFF) {
+	string cff = buildSyntheticCFF(inTopDictBytes, inTopDictLen);
+	InputByteArrayStream stream((Byte*)&cff[0], (LongFilePositionType)cff.size());
+	return outCFF.ReadCFFFile(&stream);
+}
+
+// Pass a raw byte literal to parseSyntheticCFF, deriving the length from
+// the literal so embedded \x00 bytes don't truncate. Use only with string
+// literals — sizeof on a pointer would silently take 8 bytes.
+#define PARSE_TOP_DICT(cff, bytes) parseSyntheticCFF((bytes), sizeof(bytes) - 1, (cff))
+
+// /CharStrings (key 17) with no operand: pre-fix, GetCharStringsPosition
+// did `front().IntegerValue` on an empty list and seeded SetOffset/ReadCard16
+// with garbage. Post-fix, the empty list maps to the supplied default (0),
+// which makes ReadCharStrings a no-op and lets ReadCFFFile complete cleanly.
+static bool GetSingleIntegerValueFromDict_EmptyOperandList_FallsBackToDefault() {
+	// Arrange: top dict = [<op CharStrings>] — single operator, zero operands.
+	CFFFileInput cff;
+	EStatusCode status = PARSE_TOP_DICT(cff, "\x11");
+
+	// Assert
+	if(status != eSuccess) {
+		cout << "CFFFileInputTest: ReadCFFFile failed for empty-operand CharStrings key" << endl;
+		return false;
+	}
+	if(cff.GetCharStringsCount(0) != 0) {
+		cout << "CFFFileInputTest: expected 0 charstrings, got " << cff.GetCharStringsCount(0) << endl;
+		return false;
+	}
+	return true;
+}
+
+// /CharStrings (key 17) with a real operand: pre-fix, IntegerValue was read
+// from the union after RealValue had been written, yielding a platform-
+// dependent bit-pattern that became a wild SetOffset target. Post-fix the
+// non-integer operand falls back to the default and parsing continues.
+static bool GetSingleIntegerValueFromDict_RealOperand_FallsBackToDefault() {
+	// Arrange: top dict = [<real 0.5> <op CharStrings>].
+	// Real BCD: 0x1E header, nibbles {0, '.'(0xa), 5, end(0xf)} = bytes 0x0A 0x5F.
+	CFFFileInput cff;
+	EStatusCode status = PARSE_TOP_DICT(cff, "\x1E\x0A\x5F\x11");
+
+	// Assert
+	if(status != eSuccess) {
+		cout << "CFFFileInputTest: ReadCFFFile failed for real-operand CharStrings key" << endl;
+		return false;
+	}
+	if(cff.GetCharStringsCount(0) != 0) {
+		cout << "CFFFileInputTest: expected 0 charstrings (real-operand fallback), got "
+		     << cff.GetCharStringsCount(0) << endl;
+		return false;
+	}
+	return true;
+}
+
+// /Private (key 18) with no operands: pre-fix, both front() and back() on
+// the empty list were UB; the resulting garbage was passed to SetOffset
+// and ReadDict. Post-fix, the empty list is rejected with eFailure.
+static bool ReadPrivateDict_EmptyOperandList_ReturnsFailure() {
+	// Arrange: top dict = [<op Private>]
+	CFFFileInput cff;
+	EStatusCode status = PARSE_TOP_DICT(cff, "\x12");
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "CFFFileInputTest: empty-operand Private was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
+// /Private with a single integer operand: pre-fix, front()==back() so size
+// and offset became the same value; in particular, with operand 0 ReadDict
+// silently parses zero bytes and ReadCFFFile returns success — exercising
+// the "silently wrong" pre-fix branch (no crash, no wrong-offset failure).
+// Post-fix, size() < 2 is rejected with eFailure.
+static bool ReadPrivateDict_SingleOperand_ReturnsFailure() {
+	// Arrange: top dict = [<int 0> <op Private>]. Encoding for int 0 is 0x8B
+	// (139 - 139). Single operand for what spec requires to be (size, offset).
+	CFFFileInput cff;
+	EStatusCode status = PARSE_TOP_DICT(cff, "\x8B\x12");
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "CFFFileInputTest: single-operand Private was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
+// /Private with a real where an integer is required: pre-fix, IntegerValue
+// reads were taken from the union over RealValue, yielding garbage offsets
+// fed to SetOffset / ReadDict. Post-fix, non-integer operands are rejected.
+static bool ReadPrivateDict_NonIntegerOperand_ReturnsFailure() {
+	// Arrange: top dict = [<real 0.5> <int 0> <op Private>]. Two operands,
+	// but the first (size) is a real — exactly the union-misuse case.
+	CFFFileInput cff;
+	EStatusCode status = PARSE_TOP_DICT(cff, "\x1E\x0A\x5F\x8B\x12");
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "CFFFileInputTest: real-operand Private was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Happy path: prove the new validation didn't break parsing of a real CFF
+// font. Asserts exact expected values rather than just "didn't crash" /
+// "size > 0", so a regression that quietly turns the parser into a no-op
+// would be caught.
+static bool ReadCFFFile_BrushScriptStd_PopulatesPrivateDict(char* argv[]) {
+	// Arrange
+	InputFile otfFile;
+	OpenTypeFileInput openType;
+	if(otfFile.OpenFile(BuildRelativeInputPath(argv, "fonts/BrushScriptStd.otf")) != eSuccess) {
+		cout << "CFFFileInputTest: failed to open BrushScriptStd.otf" << endl;
+		return false;
+	}
+	if(openType.ReadOpenTypeFile(otfFile.GetInputStream(), 0) != eSuccess) {
+		cout << "CFFFileInputTest: positive path failed - real CFF rejected" << endl;
+		return false;
+	}
+
+	bool ok = false;
+
+	do {
+		// Assert: exactly one Private DICT, span is non-empty (start < end).
+		if(openType.mCFF.mFontsCount != 1) {
+			cout << "CFFFileInputTest: expected 1 font, got " << openType.mCFF.mFontsCount << endl;
+			break;
+		}
+		if(openType.mCFF.mPrivateDicts == NULL) {
+			cout << "CFFFileInputTest: mPrivateDicts is NULL" << endl;
+			break;
+		}
+		const PrivateDictInfo& priv = openType.mCFF.mPrivateDicts[0];
+		// Exact byte positions for BrushScriptStd's Private DICT (offset=17676, size=28).
+		if(priv.mPrivateDictStart != 17676) {
+			cout << "CFFFileInputTest: expected Private DICT start 17676, got "
+			     << priv.mPrivateDictStart << endl;
+			break;
+		}
+		if(priv.mPrivateDictEnd != 17704) {
+			cout << "CFFFileInputTest: expected Private DICT end 17704, got "
+			     << priv.mPrivateDictEnd << endl;
+			break;
+		}
+		// Sanity-check that ReadDict actually populated the inner dict.
+		if(priv.mPrivateDict.empty()) {
+			cout << "CFFFileInputTest: inner Private DICT is empty" << endl;
+			break;
+		}
+
+		ok = true;
+	} while(false);
+
+	return ok;
+}
+
+int CFFFileInputTest(int argc, char* argv[]) {
+	if(!GetSingleIntegerValueFromDict_EmptyOperandList_FallsBackToDefault()) return 1;
+	if(!GetSingleIntegerValueFromDict_RealOperand_FallsBackToDefault()) return 1;
+	if(!ReadPrivateDict_EmptyOperandList_ReturnsFailure()) return 1;
+	if(!ReadPrivateDict_SingleOperand_ReturnsFailure()) return 1;
+	if(!ReadPrivateDict_NonIntegerOperand_ReturnsFailure()) return 1;
+	if(!ReadCFFFile_BrushScriptStd_PopulatesPrivateDict(argv)) return 1;
+	return 0;
+}

--- a/PDFWriterTesting/CFFFileInputTest.cpp
+++ b/PDFWriterTesting/CFFFileInputTest.cpp
@@ -134,6 +134,30 @@ static bool GetSingleIntegerValueFromDict_RealOperand_FallsBackToDefault() {
 	return true;
 }
 
+// /CharStrings with a negative integer operand: every caller of this
+// helper treats the result as a non-negative offset / enum-id, so a
+// negative value would have flowed into SetOffset(negative) and failed
+// the seek. Post-fix the helper rejects negative and falls back to the
+// default (0), which makes ReadCharStrings a no-op.
+static bool GetSingleIntegerValueFromDict_NegativeOperand_FallsBackToDefault() {
+	// Arrange: top dict = [<int -1> <op CharStrings>]. -1 in CFF 2-byte
+	// signed form: 0x1C 0xFF 0xFF.
+	CFFFileInput cff;
+	EStatusCode status = PARSE_TOP_DICT(cff, "\x1C\xFF\xFF\x11");
+
+	// Assert
+	if(status != eSuccess) {
+		cout << "CFFFileInputTest: ReadCFFFile failed for negative-operand CharStrings key" << endl;
+		return false;
+	}
+	if(cff.GetCharStringsCount(0) != 0) {
+		cout << "CFFFileInputTest: expected 0 charstrings (negative-operand fallback), got "
+		     << cff.GetCharStringsCount(0) << endl;
+		return false;
+	}
+	return true;
+}
+
 // /Private (key 18) with no operands: pre-fix, both front() and back() on
 // the empty list were UB; the resulting garbage was passed to SetOffset
 // and ReadDict. Post-fix, the empty list is rejected with eFailure.
@@ -261,6 +285,7 @@ static bool ReadCFFFile_BrushScriptStd_PopulatesPrivateDict(char* argv[]) {
 int CFFFileInputTest(int argc, char* argv[]) {
 	if(!GetSingleIntegerValueFromDict_EmptyOperandList_FallsBackToDefault()) return 1;
 	if(!GetSingleIntegerValueFromDict_RealOperand_FallsBackToDefault()) return 1;
+	if(!GetSingleIntegerValueFromDict_NegativeOperand_FallsBackToDefault()) return 1;
 	if(!ReadPrivateDict_EmptyOperandList_ReturnsFailure()) return 1;
 	if(!ReadPrivateDict_SingleOperand_ReturnsFailure()) return 1;
 	if(!ReadPrivateDict_NonIntegerOperand_ReturnsFailure()) return 1;

--- a/PDFWriterTesting/CFFFileInputTest.cpp
+++ b/PDFWriterTesting/CFFFileInputTest.cpp
@@ -47,10 +47,6 @@ using namespace std;
 using namespace PDFHummus;
 using namespace IOBasicTypes;
 
-// CFF spec keys (operator bytes) used to drive the bug paths from a Top DICT.
-static const Byte scOpCharStrings = 0x11;   // CharStrings (key 17)
-static const Byte scOpPrivate     = 0x12;   // Private (key 18)
-
 // Header: major=1, minor=0, hdrSize=4, absOffSize=1.
 static const char scCFFHeader[] = "\x01\x00\x04\x01";
 
@@ -190,6 +186,25 @@ static bool ReadPrivateDict_NonIntegerOperand_ReturnsFailure() {
 	return true;
 }
 
+// /Private with a negative size: passes IsInteger, but as a signed long
+// would convert to a huge unsigned value when fed to ReadDict's unsigned
+// read amount, causing excessive parsing. Post-fix, non-negative checks
+// reject it before the call.
+static bool ReadPrivateDict_NegativeSize_ReturnsFailure() {
+	// Arrange: top dict = [<int -1> <int 0> <op Private>].
+	// -1 in CFF 2-byte signed form: 0x1C 0xFF 0xFF (operand prefix + s16).
+	// 0 in CFF short form: 0x8B (139 - 139).
+	CFFFileInput cff;
+	EStatusCode status = PARSE_TOP_DICT(cff, "\x1C\xFF\xFF\x8B\x12");
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "CFFFileInputTest: negative-size Private was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
 // Happy path: prove the new validation didn't break parsing of a real CFF
 // font. Asserts exact expected values rather than just "didn't crash" /
 // "size > 0", so a regression that quietly turns the parser into a no-op
@@ -249,6 +264,7 @@ int CFFFileInputTest(int argc, char* argv[]) {
 	if(!ReadPrivateDict_EmptyOperandList_ReturnsFailure()) return 1;
 	if(!ReadPrivateDict_SingleOperand_ReturnsFailure()) return 1;
 	if(!ReadPrivateDict_NonIntegerOperand_ReturnsFailure()) return 1;
+	if(!ReadPrivateDict_NegativeSize_ReturnsFailure()) return 1;
 	if(!ReadCFFFile_BrushScriptStd_PopulatesPrivateDict(argv)) return 1;
 	return 0;
 }

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -15,6 +15,7 @@ create_test_sourcelist (Tests
   CIDSetWritingCFF.cpp
   CIDSetWritingTrueType.cpp
   CIDSetWritingTrueType2.cpp
+  CFFFileInputTest.cpp
   CFFIndexSanity.cpp
   CharStringType1InterpreterTest.cpp
   CharStringType2InterpreterTest.cpp


### PR DESCRIPTION
## Summary

Closes **V-041** (Phase 2 / Cluster C6 — last item) and **V-042** (Phase 2 / Cluster C8 standalone), both in `CFFFileInput.cpp`.

### V-041 — operand-list bounds in DICT readers
`GetSingleIntegerValueFromDict` and `ReadPrivateDict` called `front()` / `back()` on the operand list without checking it was non-empty or that the operand was actually an integer. A malformed CFF that emitted an operator with no operands, or with a real where the spec requires an integer, reached UB / type-punned union reads that flowed into `mPrimitivesReader.SetOffset` and `ReadDict`'s read amount.

- `GetSingleIntegerValueFromDict` falls back to the supplied default when the entry is missing, the operand list is empty, or the front operand is not an integer.
- `ReadPrivateDict` rejects `/Private` entries with fewer than 2 operands, or where either operand is non-integer, with `eFailure` before they reach `SetOffset` / `ReadDict`.

### V-042 — negative `IntegerValue` size/offset (closed via Copilot follow-up)
Even after the `IsInteger` check, a malformed `/Private` could still carry a negative `IntegerValue` for size or offset. A negative size cast to `unsigned long` for `ReadDict` expands to a huge read amount; a negative offset seeks to junk. Pre-fix, this was silently accepted (the wraparound short-circuited the read loop and `ReadCFFFile` returned `eSuccess` with an empty inner Private DICT).

- `ReadPrivateDict` now rejects negative `size` / `offset` before `SetOffset` / `ReadDict`.
- `mPrivateDictEnd` is computed by widening each operand to `LongFilePositionType` before the `+`, so the addition can't overflow on platforms where `long` is 32-bit.

`ReadPrivateDict` is the only attacker-reachable caller of `ReadDict` that passed a signed `IntegerValue` (the other site, `ReadFDArray`, derives its size from already-validated unsigned INDEX offsets), so closing the gap at the caller is sufficient for V-042 in practice.

### Out of scope (deferred — same precedent as C2 / C5)
No upper-bound caps on `/Private` size / offset. That's the memory-budget-cap class explicitly deferred in C2 (Type1 subrs/charstrings) and C5 (CFF INDEX); picking the right cap needs real-font measurement and belongs in a cross-format hardening PR if pursued.

### Regression test (`PDFWriterTesting/CFFFileInputTest.cpp`)
Seven cases driven through `ReadCFFFile` with in-process synthetic CFF buffers (no binary fixtures):
- Empty- and real-operand `/CharStrings` keys → `ReadCFFFile` succeeds with `GetCharStringsCount(0) == 0` (default fallback).
- Empty-, single-, real-operand, and **negative-size** `/Private` entries → `ReadCFFFile` returns `eFailure`.
- Happy path on `BrushScriptStd.otf` → asserts exact Private DICT byte positions (start=17676, end=17704) so a regression that quietly turns the parser into a no-op would be caught.

Stash + rerun confirmed the test catches the bug pre-fix on three cases:
- Single-operand `/Private` (silently-wrong `eSuccess` pre-fix).
- Real-operand `/CharStrings` (wild `SetOffset` → status mismatch pre-fix).
- Negative-size `/Private` (silently-wrong `eSuccess` pre-fix — the V-042 case).

## Test plan

- [x] `ctest -C Release -R '^CFFFileInputTest$'` passes
- [x] Full `ctest -C Release` suite (88 tests) passes
- [x] Stash + rerun confirms tests catch the bug pre-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)