### PR TITLE
fix: Type 1 PostScript-token helper boundary checks (V-060/V-071)

### DIFF
--- a/PDFWriter/CMakeLists.txt
+++ b/PDFWriter/CMakeLists.txt
@@ -166,6 +166,7 @@ TrueTypeDescendentFontWriter.cpp
 TrueTypeEmbeddedFontWriter.cpp
 TrueTypePrimitiveWriter.cpp
 Type1Input.cpp
+Type1PSTokens.cpp
 Type1ToCFFEmbeddedFontWriter.cpp
 Type1ToType2Converter.cpp
 Type2CharStringWriter.cpp
@@ -376,6 +377,7 @@ TrueTypeDescendentFontWriter.h
 TrueTypeEmbeddedFontWriter.h
 TrueTypePrimitiveWriter.h
 Type1Input.h
+Type1PSTokens.h
 Type1ToCFFEmbeddedFontWriter.h
 Type1ToType2Converter.h
 Type2CharStringWriter.h
@@ -927,6 +929,8 @@ PSBool.cpp
 PSBool.h
 Type1Input.cpp
 Type1Input.h
+Type1PSTokens.cpp
+Type1PSTokens.h
 Type1ToCFFEmbeddedFontWriter.cpp
 Type1ToCFFEmbeddedFontWriter.h
 Type1ToType2Converter.cpp

--- a/PDFWriter/Type1Input.cpp
+++ b/PDFWriter/Type1Input.cpp
@@ -25,7 +25,7 @@
 #include "StandardEncoding.h"
 #include "Trace.h"
 #include "CharStringType1Interpreter.h"
-#include <sstream>
+#include "Type1PSTokens.h"
 
 using namespace PDFHummus;
 
@@ -150,7 +150,7 @@ EStatusCode Type1Input::ReadType1File(IByteReaderWithPosition* inType1)
 				continue;
 
 			// skip comments
-			if(IsComment(token.second))
+			if(Type1PSTokens::IsComment(token.second))
 				continue;
 
 			// look for "begin". at this level that would be catching the "begin"
@@ -184,11 +184,6 @@ EStatusCode Type1Input::ReadType1File(IByteReaderWithPosition* inType1)
 	return status;
 }
 
-bool Type1Input::IsComment(const std::string& inToken)
-{
-	return inToken.at(0) == '%';
-}
-
 EStatusCode Type1Input::ReadFontDictionary()
 {
 	EStatusCode status = eSuccess;
@@ -202,7 +197,7 @@ EStatusCode Type1Input::ReadFontDictionary()
 			continue;
 
 		// skip comments
-		if(IsComment(token.second))
+		if(Type1PSTokens::IsComment(token.second))
 			continue;
 
 		// found end, done with dictionary
@@ -216,7 +211,7 @@ EStatusCode Type1Input::ReadFontDictionary()
 		}
 		if(token.second.compare("/FontName") == 0)
 		{
-			mFontDictionary.FontName = FromPSName(mPFBDecoder.GetNextToken().second);
+			mFontDictionary.FontName = Type1PSTokens::FromPSName(mPFBDecoder.GetNextToken().second);
 			continue;
 		}
 		if(token.second.compare("/PaintType") == 0)
@@ -288,7 +283,7 @@ EStatusCode Type1Input::ReadFontInfoDictionary()
 			continue;
 
 		// skip comments
-		if(IsComment(token.second))
+		if(Type1PSTokens::IsComment(token.second))
 			continue;
 
 		// "end" encountered, dictionary finished, return.
@@ -297,32 +292,32 @@ EStatusCode Type1Input::ReadFontInfoDictionary()
 
 		if(token.second.compare("/version") == 0)
 		{
-			mFontInfoDictionary.version = FromPSString(mPFBDecoder.GetNextToken().second);
+			mFontInfoDictionary.version = Type1PSTokens::FromPSString(mPFBDecoder.GetNextToken().second);
 			continue;
 		}
 		if(token.second.compare("/Notice") == 0)
 		{
-			mFontInfoDictionary.Notice = FromPSString(mPFBDecoder.GetNextToken().second);
+			mFontInfoDictionary.Notice = Type1PSTokens::FromPSString(mPFBDecoder.GetNextToken().second);
 			continue;
 		}
 		if(token.second.compare("/Copyright") == 0)
 		{
-			mFontInfoDictionary.Copyright = FromPSString(mPFBDecoder.GetNextToken().second);
+			mFontInfoDictionary.Copyright = Type1PSTokens::FromPSString(mPFBDecoder.GetNextToken().second);
 			continue;
 		}
 		if(token.second.compare("/FullName") == 0)
 		{
-			mFontInfoDictionary.FullName = FromPSString(mPFBDecoder.GetNextToken().second);
+			mFontInfoDictionary.FullName = Type1PSTokens::FromPSString(mPFBDecoder.GetNextToken().second);
 			continue;
 		}
 		if(token.second.compare("/FamilyName") == 0)
 		{
-			mFontInfoDictionary.FamilyName = FromPSString(mPFBDecoder.GetNextToken().second);
+			mFontInfoDictionary.FamilyName = Type1PSTokens::FromPSString(mPFBDecoder.GetNextToken().second);
 			continue;
 		}
 		if(token.second.compare("/Weight") == 0)
 		{
-			mFontInfoDictionary.Weight = FromPSString(mPFBDecoder.GetNextToken().second);
+			mFontInfoDictionary.Weight = Type1PSTokens::FromPSString(mPFBDecoder.GetNextToken().second);
 			continue;
 		}
 		if(token.second.compare("/ItalicAngle") == 0)
@@ -357,11 +352,6 @@ EStatusCode Type1Input::ReadFontInfoDictionary()
 		}
 	}
 	return status;	
-}
-
-std::string Type1Input::FromPSName(const std::string& inPostScriptName)
-{
-	return inPostScriptName.substr(1);
 }
 
 EStatusCode Type1Input::ParseDoubleArray(double* inArray,int inArraySize)
@@ -445,7 +435,7 @@ EStatusCode Type1Input::ParseEncoding()
 		token = mPFBDecoder.GetNextToken();
 		if(!token.first)
 			break;
-		mEncoding.mCustomEncoding[encodingIndex] = FromPSName(token.second);
+		mEncoding.mCustomEncoding[encodingIndex] = Type1PSTokens::FromPSName(token.second);
 
 		// skip the put
 		token = mPFBDecoder.GetNextToken();
@@ -511,7 +501,7 @@ EStatusCode Type1Input::ReadPrivateDictionary()
 			continue;
 
 		// skip comments
-		if(IsComment(token.second))
+		if(Type1PSTokens::IsComment(token.second))
 			continue;
 
 		// "end" encountered, dictionary finished, return.
@@ -813,7 +803,7 @@ EStatusCode Type1Input::ParseCharstrings()
 			if("end" == token.second)
 				break;
 
-			characterName = FromPSName(token.second);
+			characterName = Type1PSTokens::FromPSName(token.second);
 
 			long codeLength;
 			if(!TryParseBoundedLong(mPFBDecoder.GetNextToken().second,1,MAX_TYPE1_CODE_LENGTH,codeLength))
@@ -1012,71 +1002,6 @@ std::string Type1Input::GetGlyphCharStringName(Byte inCharStringIndex)
 
 		return standardEncoding.GetEncodedGlyphName(inCharStringIndex);
 	}
-}
-
-std::string Type1Input::FromPSString(const std::string& inPSString)
-{
-	std::stringbuf stringBuffer;
-	Byte buffer;
-	std::string::const_iterator it = inPSString.begin();
-	size_t i=1;
-	++it; // skip first paranthesis
-	
-	for(; i < inPSString.size()-1;++it,++i)
-	{
-		if(*it == '\\')
-		{
-			++it;
-			if('0' <= *it && *it <= '7')
-			{
-				buffer = (*it - '0') * 64;
-				++it;
-				buffer += (*it - '0') * 8;
-				++it;
-				buffer += (*it - '0');
-			}
-			else
-			{
-				switch(*it)
-				{
-					case 'n':
-						buffer = '\n';
-						break;
-					case 'r':
-						buffer = '\r';
-						break;
-					case 't':
-						buffer = '\t';
-						break;
-					case 'b':
-						buffer = '\b';
-						break;
-					case 'f':
-						buffer = '\f';
-						break;
-					case '\\':
-						buffer = '\\';
-						break;
-					case '(':
-						buffer = '(';
-						break;
-					case ')':
-						buffer = ')';
-						break;
-					default:
-						// error!
-						buffer = 0;
-						break;
-				}
-			}
-		}
-		else
-		{
-			buffer = *it;
-		}
-		stringBuffer.sputn((const char*)&buffer,1);
-	}
-	return stringBuffer.str();
 }
 
 Byte Type1Input::GetEncoding(const std::string& inCharStringName)

--- a/PDFWriter/Type1Input.h
+++ b/PDFWriter/Type1Input.h
@@ -112,6 +112,7 @@ class IByteReaderWithPosition;
 
 class Type1Input : public Type1InterpreterImplementationAdapter
 {
+
 public:
 	Type1Input(void);
 	~Type1Input(void);
@@ -155,10 +156,8 @@ private:
 	void FreeTables();
 	void FreeSubrs();
 	void FreeCharStrings();
-	bool IsComment(const std::string& inToken);
 	PDFHummus::EStatusCode ReadFontDictionary();
 	PDFHummus::EStatusCode ReadFontInfoDictionary();
-	std::string FromPSName(const std::string& inPostScriptName);
 	PDFHummus::EStatusCode ParseEncoding();
 	PDFHummus::EStatusCode ReadPrivateDictionary();
 	PDFHummus::EStatusCode ParseIntVector(std::vector<int>& inVector);
@@ -166,6 +165,5 @@ private:
 	PDFHummus::EStatusCode ParseSubrs();
 	PDFHummus::EStatusCode ParseCharstrings();
 	PDFHummus::EStatusCode ParseDoubleArray(double* inArray,int inArraySize);
-	std::string FromPSString(const std::string& inPSString);
 	void CalculateReverseEncoding();
 };

--- a/PDFWriter/Type1PSTokens.cpp
+++ b/PDFWriter/Type1PSTokens.cpp
@@ -1,0 +1,111 @@
+/*
+   Source File : Type1PSTokens.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+*/
+#include "Type1PSTokens.h"
+#include "IOBasicTypes.h"
+
+#include <sstream>
+
+using namespace IOBasicTypes;
+
+static const std::string scEmpty;
+
+bool Type1PSTokens::IsComment(const std::string& inToken)
+{
+	return !inToken.empty() && inToken[0] == '%';
+}
+
+std::string Type1PSTokens::FromPSName(const std::string& inPostScriptName)
+{
+	return inPostScriptName.empty() ? scEmpty : inPostScriptName.substr(1);
+}
+
+std::string Type1PSTokens::FromPSString(const std::string& inPSString)
+{
+	// PostScript string literal must contain at least the opening and closing parens.
+	if(inPSString.size() < 2)
+		return scEmpty;
+
+	std::stringbuf stringBuffer;
+	std::string::const_iterator it = inPSString.begin();
+	std::string::const_iterator stop = inPSString.end() - 1; // closing paren position
+	++it; // skip first paranthesis
+
+	while(it != stop)
+	{
+		Byte buffer;
+		if(*it == '\\')
+		{
+			++it;
+			if(it == stop) break;
+			if('0' <= *it && *it <= '7')
+			{
+				buffer = (*it - '0') * 64;
+				++it;
+				if(it == stop) break;
+				buffer += (*it - '0') * 8;
+				++it;
+				if(it == stop) break;
+				buffer += (*it - '0');
+			}
+			else
+			{
+				switch(*it)
+				{
+					case 'n':
+						buffer = '\n';
+						break;
+					case 'r':
+						buffer = '\r';
+						break;
+					case 't':
+						buffer = '\t';
+						break;
+					case 'b':
+						buffer = '\b';
+						break;
+					case 'f':
+						buffer = '\f';
+						break;
+					case '\\':
+						buffer = '\\';
+						break;
+					case '(':
+						buffer = '(';
+						break;
+					case ')':
+						buffer = ')';
+						break;
+					default:
+						// error!
+						buffer = 0;
+						break;
+				}
+			}
+		}
+		else
+		{
+			buffer = *it;
+		}
+		stringBuffer.sputn((const char*)&buffer,1);
+		++it;
+	}
+	return stringBuffer.str();
+}

--- a/PDFWriter/Type1PSTokens.h
+++ b/PDFWriter/Type1PSTokens.h
@@ -1,0 +1,32 @@
+/*
+   Source File : Type1PSTokens.h
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+*/
+#pragma once
+#include <string>
+
+// Stateless PostScript token-string utilities used by the Type 1 (.PFB)
+// parser.
+class Type1PSTokens
+{
+public:
+	static bool IsComment(const std::string& inToken);
+	static std::string FromPSName(const std::string& inPostScriptName);
+	static std::string FromPSString(const std::string& inPSString);
+};

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -77,6 +77,8 @@ create_test_sourcelist (Tests
   TrueTypeAnsiWriteBug.cpp
   TrueTypeTest.cpp
   TTCTest.cpp
+  Type1InputTest.cpp
+  Type1PSTokensTest.cpp
   Type1SubrSanity.cpp
   Type1Test.cpp
   UnicodeTextUsage.cpp

--- a/PDFWriterTesting/Type1InputTest.cpp
+++ b/PDFWriterTesting/Type1InputTest.cpp
@@ -1,0 +1,87 @@
+/*
+   Source File : Type1InputTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   End-to-end Type1Input regression tests. Driven through ReadType1File
+   against the real Helvetica PFB to assert exact parsed values for the
+   Font dictionary and FontInfo dictionary fields -- proves the boundary
+   helpers in Type1PSTokens (IsComment / FromPSName / FromPSString) and
+   the surrounding parser still consume legitimate input cleanly.
+*/
+#include "InputFile.h"
+#include "Type1Input.h"
+#include "EStatusCode.h"
+
+#include "testing/TestIO.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace PDFHummus;
+
+static bool ReadType1File_RealPFB_ParsesFontInfoStrings(char* argv[]) {
+	bool ok = false;
+	InputFile pfb;
+	Type1Input type1;
+	do {
+		// Arrange
+		if(pfb.OpenFile(BuildRelativeInputPath(argv, "fonts/HLB_____.PFB")) != eSuccess) {
+			cout << "Type1InputTest: failed to open HLB_____.PFB" << endl;
+			break;
+		}
+
+		// Act
+		if(type1.ReadType1File(pfb.GetInputStream()) != eSuccess) {
+			cout << "Type1InputTest: ReadType1File rejected the real PFB" << endl;
+			break;
+		}
+
+		// Assert (exact-value)
+		if(type1.mFontDictionary.FontName != "HelveticaNeue-Bold") {
+			cout << "Type1InputTest: FontName mismatch: \"" << type1.mFontDictionary.FontName << "\"" << endl;
+			break;
+		}
+		if(type1.mFontInfoDictionary.version != "001.102") {
+			cout << "Type1InputTest: version mismatch: \"" << type1.mFontInfoDictionary.version << "\"" << endl;
+			break;
+		}
+		if(type1.mFontInfoDictionary.FullName != "Helvetica 75 Bold") {
+			cout << "Type1InputTest: FullName mismatch: \"" << type1.mFontInfoDictionary.FullName << "\"" << endl;
+			break;
+		}
+		if(type1.mFontInfoDictionary.FamilyName != "Helvetica Neue") {
+			cout << "Type1InputTest: FamilyName mismatch: \"" << type1.mFontInfoDictionary.FamilyName << "\"" << endl;
+			break;
+		}
+		if(type1.mFontInfoDictionary.Weight != "Bold") {
+			cout << "Type1InputTest: Weight mismatch: \"" << type1.mFontInfoDictionary.Weight << "\"" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	pfb.CloseFile();
+	return ok;
+}
+
+int Type1InputTest(int argc, char* argv[]) {
+	(void) argc;
+	if(!ReadType1File_RealPFB_ParsesFontInfoStrings(argv)) return 1;
+	return 0;
+}

--- a/PDFWriterTesting/Type1PSTokensTest.cpp
+++ b/PDFWriterTesting/Type1PSTokensTest.cpp
@@ -1,0 +1,176 @@
+/*
+   Source File : Type1PSTokensTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression tests for the Type 1 PostScript-token boundary helpers
+   (Type1PSTokens::IsComment / FromPSName / FromPSString) extracted from
+   Type1Input. Pre-extraction these were private members and pre-fix:
+
+     * IsComment("")        -> std::out_of_range from at(0)
+     * FromPSName("")       -> std::out_of_range from substr(1)
+     * FromPSString("")     -> size()-1 underflows size_t to SIZE_MAX,
+                               loop runs until ++it past end() segfaults
+     * FromPSString("(\\01") -> truncated octal escape advances iterator
+                                three positions past end(); *it reads OOB
+
+   End-to-end coverage on a real PFB lives in Type1InputTest.
+*/
+#include "Type1PSTokens.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+// Pre-fix: at(0) on an empty string throws std::out_of_range, which
+// the caller (the hot token loop in ReadType1File / ReadFontDictionary
+// / ReadFontInfoDictionary / ParseCharstrings) does not catch. Empty
+// tokens are reachable through the tokenizer's edge cases (e.g. an
+// empty hex literal "<>"), so a malformed PFB can abort the process.
+static bool IsComment_EmptyToken_ReturnsFalse() {
+	// Act + Assert
+	if(Type1PSTokens::IsComment(string())) {
+		cout << "Type1PSTokensTest: IsComment(\"\") returned true" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Sanity: the empty-token guard didn't turn IsComment into a no-op.
+static bool IsComment_PercentToken_ReturnsTrue() {
+	// Act + Assert
+	if(!Type1PSTokens::IsComment("% comment")) {
+		cout << "Type1PSTokensTest: IsComment(\"% comment\") returned false" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Pre-fix: substr(1) on an empty string throws std::out_of_range. A
+// crafted PFB with an empty token after /FontName / /Encoding /
+// charstring name aborts the process.
+static bool FromPSName_EmptyToken_ReturnsEmpty() {
+	// Act + Assert
+	if(!Type1PSTokens::FromPSName(string()).empty()) {
+		cout << "Type1PSTokensTest: FromPSName(\"\") returned non-empty" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Sanity: the empty-token guard didn't break the leading-slash strip.
+static bool FromPSName_SlashedName_StripsLeadingSlash() {
+	// Act
+	string result = Type1PSTokens::FromPSName("/HelveticaNeue-Bold");
+
+	// Assert
+	if(result != "HelveticaNeue-Bold") {
+		cout << "Type1PSTokensTest: FromPSName(\"/HelveticaNeue-Bold\") returned \"" << result << "\"" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Pre-fix: the for loop bound `i < inPSString.size()-1` underflows
+// size_t to SIZE_MAX when size()==0, and the loop runs until ++it
+// past end() segfaults.
+static bool FromPSString_Empty_ReturnsEmpty() {
+	// Act + Assert
+	if(!Type1PSTokens::FromPSString(string()).empty()) {
+		cout << "Type1PSTokensTest: FromPSString(\"\") returned non-empty" << endl;
+		return false;
+	}
+	return true;
+}
+
+// A single "(" is not a valid PostScript string literal (need both
+// opening and closing parens). Pre-fix: size()-1 == 0, the loop never
+// runs and the function silently returns "" -- but only by accident,
+// since the underflow above was avoided. Post-fix: the size < 2 guard
+// makes the empty return explicit.
+static bool FromPSString_OneChar_ReturnsEmpty() {
+	// Act + Assert
+	if(!Type1PSTokens::FromPSString("(").empty()) {
+		cout << "Type1PSTokensTest: FromPSString(\"(\") returned non-empty" << endl;
+		return false;
+	}
+	return true;
+}
+
+// V-071 / V-2.3-020: Pre-fix the octal-escape branch did three
+// unconditional ++it. With input "(\\01" the third ++it lands one
+// position past end() and *it reads OOB. The bounded loop must abort
+// the partial escape and produce a best-effort prefix without
+// reading past end().
+static bool FromPSString_TruncatedOctalEscape_DoesNotReadPastEnd() {
+	// Act
+	// Input bytes: '(', '\\', '0', '1'  -- closing paren missing, third
+	// octal digit missing. The post-fix loop treats the final char ('1')
+	// as the closing-paren sentinel and breaks out mid-escape; nothing
+	// is emitted because the escape never completes.
+	string result = Type1PSTokens::FromPSString("(\\01");
+
+	// Assert
+	if(!result.empty()) {
+		cout << "Type1PSTokensTest: FromPSString(\"(\\\\01\") emitted \"" << result << "\"" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Sanity: a complete octal escape still decodes to the encoded byte.
+// Plaintext "(\\101)" -> octal 101 == 'A'.
+static bool FromPSString_OctalEscape_DecodesToByte() {
+	// Act
+	string result = Type1PSTokens::FromPSString("(\\101)");
+
+	// Assert
+	if(result != "A") {
+		cout << "Type1PSTokensTest: FromPSString(\"(\\\\101)\") returned \"" << result << "\" (expected \"A\")" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Sanity: a plain string round-trips with no escape handling.
+static bool FromPSString_PlainLiteral_RoundTrips() {
+	// Act
+	string result = Type1PSTokens::FromPSString("(Bold)");
+
+	// Assert
+	if(result != "Bold") {
+		cout << "Type1PSTokensTest: FromPSString(\"(Bold)\") returned \"" << result << "\"" << endl;
+		return false;
+	}
+	return true;
+}
+
+int Type1PSTokensTest(int argc, char* argv[]) {
+	(void) argc;
+	(void) argv;
+	if(!IsComment_EmptyToken_ReturnsFalse()) return 1;
+	if(!IsComment_PercentToken_ReturnsTrue()) return 1;
+	if(!FromPSName_EmptyToken_ReturnsEmpty()) return 1;
+	if(!FromPSName_SlashedName_StripsLeadingSlash()) return 1;
+	if(!FromPSString_Empty_ReturnsEmpty()) return 1;
+	if(!FromPSString_OneChar_ReturnsEmpty()) return 1;
+	if(!FromPSString_TruncatedOctalEscape_DoesNotReadPastEnd()) return 1;
+	if(!FromPSString_OctalEscape_DecodesToByte()) return 1;
+	if(!FromPSString_PlainLiteral_RoundTrips()) return 1;
+	return 0;
+}


### PR DESCRIPTION
## Summary
- Extract the three Type 1 PostScript-token helpers (`IsComment` / `FromPSName` / `FromPSString`) out of `Type1Input` into a new `Type1PSTokens` utility class with public static methods. Pure-function helpers, no state.
- Fix V-060: empty-token crashes — `IsComment("")` and `FromPSName("")` previously threw uncaught `std::out_of_range`; `FromPSString("")` underflowed `size_t` via `size()-1` and ran the loop until `++it` past `end()` segfaulted. Each helper now tolerates empty / short input.
- Fix V-071 (folded): `FromPSString` octal-escape branch previously did three unconditional `++it`. On truncated input like `"(\\01"` the third advance lands one past `end()` and `*it` reads OOB. Loop rewritten to drop the parallel `i` counter (which already failed to track the iterator past escapes) and bound every `++it` against `end() - 1`; breaks out mid-escape on truncation.

## Reachability
All three helpers are reached from the standard PFB read flow (`ReadType1File` → `ReadFontDictionary` / `ReadFontInfoDictionary` / `ParseCharstrings`). Attacker payload is just a malformed `.pfb`. Crash-DoS and silent OOB read; not a direct memory-write primitive.

## Tests
- New `Type1PSTokensTest` — 9 boundary cases driven directly against the helpers (empty / one-char / truncated-octal / escape decode / round-trip).
- New `Type1InputTest` — end-to-end on `HLB_____.PFB` with exact-value assertions on `FontName` / `version` / `FullName` / `FamilyName` / `Weight`. Proves the bounded-loop rewrite didn't corrupt valid input.
- Pre-fix verification: temporarily restored the old helper bodies → `Type1PSTokensTest` aborts on the first case (`IsComment("")` `std::out_of_range`). Post-fix: 90/90 green.

## Test plan
- [x] `cmake --build . --config Release` clean
- [x] `ctest -C Release` — 90/90 pass
- [x] Pre-fix stash + rerun: confirmed `Type1PSTokensTest` catches the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)