### PR TITLE
fix: OpenType ReadHMtx numberOfHMetrics-zero guard (V-021)

### DIFF
--- a/PDFWriter/OpenTypeFileInput.cpp
+++ b/PDFWriter/OpenTypeFileInput.cpp
@@ -565,6 +565,14 @@ EStatusCode OpenTypeFileInput::ReadHMtx()
 		return PDFHummus::eFailure;
 	}
 
+	// numberOfHMetrics must be >= 1 when there are glyphs: the second loop below
+	// reads mHMtx[NumberOfHMetrics-1], and (unsigned short)0 - 1 promotes to int -1.
+	if(mHHea.NumberOfHMetrics == 0 && mMaxp.NumGlyphs > 0)
+	{
+		TRACE_LOG("OpenTypeFileInput::ReadHMtx, numberOfHMetrics is zero with non-empty glyf");
+		return PDFHummus::eFailure;
+	}
+
 	mHMtx = new HMtxTableEntry[mMaxp.NumGlyphs];
 
 	unsigned int i=0;
@@ -575,9 +583,10 @@ EStatusCode OpenTypeFileInput::ReadHMtx()
 		mPrimitivesReader.ReadSHORT(mHMtx[i].LeftSideBearing);
 	}
 
+	unsigned short lastAdvanceWidth = (mHHea.NumberOfHMetrics > 0) ? mHMtx[mHHea.NumberOfHMetrics - 1].AdvanceWidth : 0;
 	for(; i < mMaxp.NumGlyphs; ++i)
 	{
-		mHMtx[i].AdvanceWidth = mHMtx[mHHea.NumberOfHMetrics-1].AdvanceWidth;
+		mHMtx[i].AdvanceWidth = lastAdvanceWidth;
 		mPrimitivesReader.ReadSHORT(mHMtx[i].LeftSideBearing);
 	}
 

--- a/PDFWriter/OpenTypeFileInput.cpp
+++ b/PDFWriter/OpenTypeFileInput.cpp
@@ -569,7 +569,7 @@ EStatusCode OpenTypeFileInput::ReadHMtx()
 	// reads mHMtx[NumberOfHMetrics-1], and (unsigned short)0 - 1 promotes to int -1.
 	if(mHHea.NumberOfHMetrics == 0 && mMaxp.NumGlyphs > 0)
 	{
-		TRACE_LOG("OpenTypeFileInput::ReadHMtx, numberOfHMetrics is zero with non-empty glyf");
+		TRACE_LOG("OpenTypeFileInput::ReadHMtx, numberOfHMetrics is zero with non-zero numGlyphs");
 		return PDFHummus::eFailure;
 	}
 

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -47,6 +47,7 @@ create_test_sourcelist (Tests
   MergeToPDFForm.cpp
   ModifyingEncryptedFile.cpp
   ModifyingExistingFileContent.cpp
+  OpenTypeFileInputTest.cpp
   OpenTypePrimitiveReaderTest.cpp
   OpenTypeTest.cpp
   OutputFileStreamTest.cpp

--- a/PDFWriterTesting/OpenTypeFileInputTest.cpp
+++ b/PDFWriterTesting/OpenTypeFileInputTest.cpp
@@ -1,0 +1,164 @@
+/*
+   Source File : OpenTypeFileInputTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression test for ReadHMtx's numberOfHMetrics-zero guard. The existing
+   guard bounded numberOfHMetrics > numGlyphs, but missed the case
+   numberOfHMetrics == 0 with numGlyphs > 0. The second loop in ReadHMtx
+   then dereferences mHMtx[NumberOfHMetrics-1], where unsigned short 0 - 1
+   promotes to int -1: a one-before-buffer heap read whose contents flow
+   into the produced PDF's /Widths array.
+
+   The negative case patches a real font in memory (arial.ttf) and feeds
+   the modified buffer through ReadOpenTypeFile. The happy path uses the
+   same buffer-driven path so a regression that turned the new validation
+   into a no-op-rejecting parser would also be caught.
+*/
+#include "InputByteArrayStream.h"
+#include "InputFile.h"
+#include "OpenTypeFileInput.h"
+#include "EStatusCode.h"
+#include "IOBasicTypes.h"
+
+#include "testing/TestIO.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace PDFHummus;
+using namespace IOBasicTypes;
+
+// Read entire file into outBytes. Returns false on open / size / read failure.
+static bool readFileBytes(const string& inPath, string& outBytes) {
+	InputFile file;
+	if(file.OpenFile(inPath) != eSuccess)
+		return false;
+	LongFilePositionType size = file.GetFileSize();
+	if(size <= 0)
+		return false;
+	outBytes.resize((size_t)size);
+	LongBufferSizeType wanted = (LongBufferSizeType)size;
+	LongBufferSizeType got = file.GetInputStream()->Read((Byte*)&outBytes[0], wanted);
+	return got == wanted;
+}
+
+// Locate the byte offset of an SFNT table by 4-byte tag. Returns (size_t)-1 on
+// missing table or malformed directory. Assumes the buffer starts at the SFNT
+// header (no resource fork wrapper).
+static size_t findTableOffset(const string& inFont, const char* inTag) {
+	if(inFont.size() < 12)
+		return (size_t)-1;
+	const Byte* p = (const Byte*)inFont.data();
+	unsigned short numTables = (unsigned short)((p[4] << 8) | p[5]);
+	if(inFont.size() < 12u + (size_t)numTables * 16u)
+		return (size_t)-1;
+	for(unsigned short i = 0; i < numTables; ++i) {
+		size_t entry = 12u + (size_t)i * 16u;
+		if(p[entry+0] == (Byte)inTag[0] && p[entry+1] == (Byte)inTag[1]
+		&& p[entry+2] == (Byte)inTag[2] && p[entry+3] == (Byte)inTag[3]) {
+			return ((size_t)p[entry+8] << 24) | ((size_t)p[entry+9] << 16)
+			     | ((size_t)p[entry+10] << 8) | (size_t)p[entry+11];
+		}
+	}
+	return (size_t)-1;
+}
+
+// Pre-fix: the existing > NumGlyphs guard accepted numberOfHMetrics == 0,
+// then the second loop indexed mHMtx[NumberOfHMetrics-1]. (unsigned short)0
+// minus int 1 promotes to int -1, so the access reads one HMtxTableEntry
+// before the heap allocation. ReadOpenTypeFile returned eSuccess and the
+// out-of-bounds AdvanceWidth landed in /Widths. Post-fix the reader rejects
+// this case before allocating mHMtx.
+static bool ReadHMtx_NumberOfHMetricsZero_ReturnsFailure(char* argv[]) {
+	// Arrange
+	string font;
+	if(!readFileBytes(BuildRelativeInputPath(argv, "fonts/arial.ttf"), font)) {
+		cout << "OpenTypeFileInputTest: failed to read arial.ttf" << endl;
+		return false;
+	}
+	size_t hheaOffset = findTableOffset(font, "hhea");
+	if(hheaOffset == (size_t)-1 || hheaOffset + 36 > font.size()) {
+		cout << "OpenTypeFileInputTest: arial.ttf hhea table missing or truncated" << endl;
+		return false;
+	}
+	// numberOfHMetrics is the last USHORT in hhea (offset 34, big-endian).
+	font[hheaOffset + 34] = 0;
+	font[hheaOffset + 35] = 0;
+
+	// Act
+	InputByteArrayStream stream((Byte*)&font[0], (LongFilePositionType)font.size());
+	OpenTypeFileInput openType;
+	EStatusCode status = openType.ReadOpenTypeFile(&stream, 0);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "OpenTypeFileInputTest: numberOfHMetrics=0 was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Happy path: same buffer-driven path used by the negative case, unmodified
+// arial.ttf parses successfully and the relevant tables get populated.
+// Asserts exact values rather than bounds so a future regression that
+// quietly turns the new guard into a no-op-rejecting branch would surface.
+static bool ReadOpenTypeFile_ArialTtf_PopulatesHheaMaxp(char* argv[]) {
+	// Arrange
+	string font;
+	if(!readFileBytes(BuildRelativeInputPath(argv, "fonts/arial.ttf"), font)) {
+		cout << "OpenTypeFileInputTest: failed to read arial.ttf" << endl;
+		return false;
+	}
+
+	// Act
+	InputByteArrayStream stream((Byte*)&font[0], (LongFilePositionType)font.size());
+	OpenTypeFileInput openType;
+	EStatusCode status = openType.ReadOpenTypeFile(&stream, 0);
+
+	// Assert
+	bool ok = false;
+	do {
+		if(status != eSuccess) {
+			cout << "OpenTypeFileInputTest: ReadOpenTypeFile rejected pristine arial.ttf" << endl;
+			break;
+		}
+		if(openType.GetOpenTypeFontType() != EOpenTypeTrueType) {
+			cout << "OpenTypeFileInputTest: expected EOpenTypeTrueType, got " << openType.GetOpenTypeFontType() << endl;
+			break;
+		}
+		// arial.ttf (Microsoft Arial 7.00) has 3415 glyphs and full per-glyph hmtx coverage.
+		if(openType.mMaxp.NumGlyphs != 3415) {
+			cout << "OpenTypeFileInputTest: expected NumGlyphs=3415, got " << openType.mMaxp.NumGlyphs << endl;
+			break;
+		}
+		if(openType.mHHea.NumberOfHMetrics != 3415) {
+			cout << "OpenTypeFileInputTest: expected NumberOfHMetrics=3415, got " << openType.mHHea.NumberOfHMetrics << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+	return ok;
+}
+
+int OpenTypeFileInputTest(int argc, char* argv[]) {
+	(void)argc;
+	if(!ReadHMtx_NumberOfHMetricsZero_ReturnsFailure(argv)) return 1;
+	if(!ReadOpenTypeFile_ArialTtf_PopulatesHheaMaxp(argv)) return 1;
+	return 0;
+}


### PR DESCRIPTION
## Summary

Closes V-021 (Phase 2 audit). The existing guard at `OpenTypeFileInput::ReadHMtx` rejected `numberOfHMetrics > numGlyphs` but missed `numberOfHMetrics == 0` with `numGlyphs > 0`. The second metric-reuse loop then dereferences `mHMtx[NumberOfHMetrics - 1]`; `(unsigned short)0 - 1` promotes to `int -1`, yielding a one-before-buffer heap read whose contents flow straight into the produced PDF's `/Widths` array — a content-disclosure primitive on any font path that hits `ReadHMtx`.

- Tighten the existing guard to also reject `numberOfHMetrics == 0 && numGlyphs > 0`. Spec-anchored: TrueType/OpenType `hhea` requires `numberOfHMetrics >= 1`.
- Hoist `mHMtx[NumberOfHMetrics - 1].AdvanceWidth` out of the inner loop (loop-invariant; ternary keeps the lookup defensive when `numberOfHMetrics == 0`, which after the new guard only happens when `numGlyphs == 0` and the loop doesn't run).

Sibling of `275c7bb` (#332), which fixed the `>` side of the same guard.

## Test plan

- [x] New `OpenTypeFileInputTest`:
  - `ReadHMtx_NumberOfHMetricsZero_ReturnsFailure` — patches `numberOfHMetrics` to 0 in an in-memory copy of `arial.ttf`, feeds the buffer through `ReadOpenTypeFile`, asserts `eFailure`. Verified with stash + rerun: pre-fix returns `eSuccess` (`numberOfHMetrics=0 was accepted`), post-fix returns `eFailure`.
  - `ReadOpenTypeFile_ArialTtf_PopulatesHheaMaxp` — same buffer-driven path on the unmodified font; asserts exact `NumGlyphs == 3415`, `NumberOfHMetrics == 3415`, font type `EOpenTypeTrueType`. Catches a regression that turned the new check into a no-op-rejecting branch.
- [x] Sibling OpenType tests still pass: `OpenTypeTest`, `OpenTypePrimitiveReaderTest`, `TrueTypeTest`, `TrueTypeAnsiWriteBug`, `TTCTest`, `DFontTest`.