### PR TITLE
fix: CFF FDSelect bounds + Encoding overflow + supplements seek (V-030/V-031/V-032)

### DIFF
--- a/PDFWriter/CFFEmbeddedFontWriter.cpp
+++ b/PDFWriter/CFFEmbeddedFontWriter.cpp
@@ -642,9 +642,11 @@ EStatusCode CFFEmbeddedFontWriter::WriteEncodings(const UIntVector& inSubsetGlyp
 		else
 			mPrimitivesWriter.WriteCard8(0);
 
-		// assuming that 0 is in the subset glyphs IDs, which does not require encoding
-		// get the encodings count
-		Byte encodingGlyphsCount = std::min((Byte)(inSubsetGlyphIDs.size()-1),encodingInfo->mEncodingsCount); 
+		// assuming that 0 is in the subset glyphs IDs, which does not require encoding.
+		// Output nCodes is Card8, so anything past 255 cannot be reproduced anyway.
+		unsigned short subsetEncodingCount = (unsigned short)(inSubsetGlyphIDs.size()-1);
+		unsigned short rawCount = std::min<unsigned short>(subsetEncodingCount, encodingInfo->mEncodingsCount);
+		Byte encodingGlyphsCount = (rawCount > 255) ? (Byte)255 : (Byte)rawCount;
 
 		mPrimitivesWriter.WriteCard8(encodingGlyphsCount);
 		for(Byte i=0; i < encodingGlyphsCount;++i)

--- a/PDFWriter/CFFFileInput.cpp
+++ b/PDFWriter/CFFFileInput.cpp
@@ -843,15 +843,20 @@ EStatusCode CFFFileInput::ReadEncodings()
 	LongFilePositionTypeToEncodingsInfoMap offsetToEncoding;
 	LongFilePositionTypeToEncodingsInfoMap::iterator it;
 
-	for(unsigned long i=0; i < mFontsCount && (PDFHummus::eSuccess == status); ++i)
+	for(unsigned long i=0; i < mFontsCount; ++i)
 	{
 		LongFilePositionType encodingPosition = GetEncodingPosition(i);
 		it = offsetToEncoding.find(encodingPosition);
 		if(it == offsetToEncoding.end())
 		{
 			EncodingsInfo* encoding = new EncodingsInfo();
-			ReadEncoding(encoding,encodingPosition);
+			status = ReadEncoding(encoding,encodingPosition);
 			mEncodings.push_back(encoding);
+			if(status != PDFHummus::eSuccess)
+			{
+				TRACE_LOG1("CFFFileInput::ReadEncodings, failed to read encoding for font index %lu", i);
+				break;
+			}
 			it = offsetToEncoding.insert(LongFilePositionTypeToEncodingsInfoMap::value_type(encodingPosition,encoding)).first;
 		}
 		mTopDictIndex[i].mEncoding = it->second;
@@ -864,86 +869,105 @@ EStatusCode CFFFileInput::ReadEncodings()
 
 }
 
-void CFFFileInput::ReadEncoding(EncodingsInfo* inEncoding,LongFilePositionType inEncodingPosition)
+EStatusCode CFFFileInput::ReadEncoding(EncodingsInfo* inEncoding,LongFilePositionType inEncodingPosition)
 {
 	if(inEncodingPosition <= 1)
 	{
 		inEncoding->mEncodingStart = inEncoding->mEncodingEnd = inEncodingPosition;
 		inEncoding->mType = (EEncodingType)inEncodingPosition;
+		return PDFHummus::eSuccess;
 	}
-	else
+
+	inEncoding->mType = eEncodingCustom;
+	Byte encodingFormat = 0;
+	inEncoding->mEncodingStart = inEncodingPosition;
+	mPrimitivesReader.SetOffset(inEncodingPosition);
+	mPrimitivesReader.ReadCard8(encodingFormat);
+
+	if(0 == (encodingFormat & 0x1))
 	{
-		inEncoding->mType = eEncodingCustom;
-		Byte encodingFormat = 0;
-		inEncoding->mEncodingStart = inEncodingPosition;
-		mPrimitivesReader.SetOffset(inEncodingPosition);
-		mPrimitivesReader.ReadCard8(encodingFormat);
-
-		if(0 == (encodingFormat & 0x1))
+		Byte rawCount = 0;
+		mPrimitivesReader.ReadCard8(rawCount);
+		inEncoding->mEncodingsCount = rawCount;
+		if(inEncoding->mEncodingsCount > 0)
 		{
-			mPrimitivesReader.ReadCard8(inEncoding->mEncodingsCount);
-			if(inEncoding->mEncodingsCount > 0)
-			{
-				inEncoding->mEncoding = new Byte[inEncoding->mEncodingsCount];
-				for(Byte i=0; i< inEncoding->mEncodingsCount;++i)
-					mPrimitivesReader.ReadCard8(inEncoding->mEncoding[i]);
-			}
+			inEncoding->mEncoding = new Byte[inEncoding->mEncodingsCount];
+			for(unsigned short i=0; i < inEncoding->mEncodingsCount; ++i)
+				mPrimitivesReader.ReadCard8(inEncoding->mEncoding[i]);
 		}
-		else // format = 1
-		{
-			Byte rangesCount = 0;
-			mPrimitivesReader.ReadCard8(rangesCount);
-			if(rangesCount > 0)
-			{
-				Byte firstCode;
-				Byte left;
-
-				inEncoding->mEncodingsCount = 0;
-				// get the encoding count (yap, reading twice here)				
-				for(Byte i=0; i < rangesCount; ++i)
-				{
-					mPrimitivesReader.ReadCard8(firstCode);
-					mPrimitivesReader.ReadCard8(left);
-					inEncoding->mEncodingsCount+= left;
-				}
-				inEncoding->mEncoding = new Byte[inEncoding->mEncodingsCount];
-				mPrimitivesReader.SetOffset(inEncodingPosition+2); // reset encoding to beginning of range reading
-
-				// now read the encoding array
-				Byte encodingIndex = 0;
-				for(Byte i=0; i < rangesCount; ++i)
-				{
-					mPrimitivesReader.ReadCard8(firstCode);
-					mPrimitivesReader.ReadCard8(left);
-					for(Byte j=0;j < left;++j)
-						inEncoding->mEncoding[encodingIndex+j] = firstCode+j;
-					encodingIndex+=left;
-				}
-			}
-		}
-		if((encodingFormat & 0x80) !=  0) // supplaments exist, need to add to encoding end
-		{
-			mPrimitivesReader.SetOffset(inEncoding->mEncodingEnd); // set position to end of encoding, and start of supplamental, so that can read their count
-			Byte supplamentalsCount = 0;
-			mPrimitivesReader.ReadCard8(supplamentalsCount);
-			if(supplamentalsCount > 0)
-			{
-				Byte encoding;
-				unsigned short SID;
-				for(Byte i=0; i < supplamentalsCount; ++i)
-				{
-					mPrimitivesReader.ReadCard8(encoding);
-					mPrimitivesReader.ReadCard16(SID);
-
-					UShortToByteList::iterator it = inEncoding->mSupplements.find(SID);
-					if(it == inEncoding->mSupplements.end())
-						it = inEncoding->mSupplements.insert(UShortToByteList::value_type(SID,ByteList())).first;
-					it->second.push_back(encoding);
-				}
-			}
-		}
-		inEncoding->mEncodingEnd =  mPrimitivesReader.GetCurrentPosition();
 	}
+	else // format = 1
+	{
+		Byte rangesCount = 0;
+		mPrimitivesReader.ReadCard8(rangesCount);
+		if(rangesCount > 0)
+		{
+			Byte firstCode;
+			Byte left;
+
+			// First pass: sum range lengths into a 16-bit accumulator so the
+			// total can't wrap before we cap it. Encoding covers codes 0..255,
+			// so the spec ceiling on the sum is 256.
+			unsigned short totalCount = 0;
+			for(Byte i=0; i < rangesCount; ++i)
+			{
+				mPrimitivesReader.ReadCard8(firstCode);
+				mPrimitivesReader.ReadCard8(left);
+				totalCount += left;
+			}
+			if(totalCount > 256)
+			{
+				TRACE_LOG1("CFFFileInput::ReadEncoding, format-1 range sum %u exceeds 256-code spec ceiling", totalCount);
+				return PDFHummus::eFailure;
+			}
+			inEncoding->mEncodingsCount = totalCount;
+			inEncoding->mEncoding = new Byte[inEncoding->mEncodingsCount];
+			mPrimitivesReader.SetOffset(inEncodingPosition+2); // reset encoding to beginning of range reading
+
+			// Second pass: encodingIndex must be 16-bit too — Byte += Byte wraps at 256
+			// and the writes would then alias the start of the (correctly-sized) buffer.
+			unsigned short encodingIndex = 0;
+			for(Byte i=0; i < rangesCount; ++i)
+			{
+				mPrimitivesReader.ReadCard8(firstCode);
+				mPrimitivesReader.ReadCard8(left);
+				for(Byte j=0;j < left;++j)
+					inEncoding->mEncoding[encodingIndex+j] = firstCode+j;
+				encodingIndex+=left;
+			}
+		}
+	}
+	// Record the post-base-encoding position before the supplements block.
+	// The supplements block reads from the current position, so anchoring
+	// mEncodingEnd here keeps the struct field meaningful for callers and
+	// also documents the position the previous code was trying to seek
+	// back to (the prior SetOffset(mEncodingEnd) read mEncodingEnd before
+	// it had ever been set on the custom-encoding path).
+	inEncoding->mEncodingEnd = mPrimitivesReader.GetCurrentPosition();
+
+	if((encodingFormat & 0x80) !=  0) // supplements exist, need to add to encoding end
+	{
+		Byte supplementsCount = 0;
+		mPrimitivesReader.ReadCard8(supplementsCount);
+		if(supplementsCount > 0)
+		{
+			Byte encoding;
+			unsigned short SID;
+			for(Byte i=0; i < supplementsCount; ++i)
+			{
+				mPrimitivesReader.ReadCard8(encoding);
+				mPrimitivesReader.ReadCard16(SID);
+
+				UShortToByteList::iterator it = inEncoding->mSupplements.find(SID);
+				if(it == inEncoding->mSupplements.end())
+					it = inEncoding->mSupplements.insert(UShortToByteList::value_type(SID,ByteList())).first;
+				it->second.push_back(encoding);
+			}
+		}
+		inEncoding->mEncodingEnd = mPrimitivesReader.GetCurrentPosition();
+	}
+
+	return mPrimitivesReader.GetInternalState();
 }
 
 void CFFFileInput::SetupSIDToGlyphMapWithStandard(	const unsigned short* inStandardCharSet,
@@ -1342,6 +1366,7 @@ EStatusCode CFFFileInput::ReadFDArray(unsigned short inFontIndex)
 			mPrimitivesReader.Skip(offsets[0] - 1);
 
 		mTopDictIndex[inFontIndex].mFDArray = new FontDictInfo[dictionariesCount];
+		mTopDictIndex[inFontIndex].mFDArrayCount = dictionariesCount;
 
 		for(i = 0; i < dictionariesCount && (PDFHummus::eSuccess == status); ++i)
 		{
@@ -1384,6 +1409,7 @@ EStatusCode CFFFileInput::ReadFDSelect(unsigned short inFontIndex)
 {
 	LongFilePositionType fdSelectLocation = GetFDSelectPosition(inFontIndex);
 	unsigned short glyphCount = mCharStrings[inFontIndex].mCharStringsCount;
+	unsigned short fdArrayCount = mTopDictIndex[inFontIndex].mFDArrayCount;
 	EStatusCode status = PDFHummus::eSuccess;
 	Byte format;
 
@@ -1402,8 +1428,15 @@ EStatusCode CFFFileInput::ReadFDSelect(unsigned short inFontIndex)
 		for(unsigned long i=0; i < glyphCount && PDFHummus::eSuccess == status; ++i)
 		{
 			status = mPrimitivesReader.ReadCard8(fdIndex);
-			if(status != PDFHummus::eFailure)
-				mTopDictIndex[inFontIndex].mFDSelect[i] = mTopDictIndex[inFontIndex].mFDArray+ fdIndex;
+			if(status == PDFHummus::eSuccess)
+			{
+				if(fdIndex >= fdArrayCount)
+				{
+					TRACE_LOG2("CFFFileInput::ReadFDSelect, format 0 fdIndex %u out of range (fdArrayCount=%u)", fdIndex, fdArrayCount);
+					return PDFHummus::eFailure;
+				}
+				mTopDictIndex[inFontIndex].mFDSelect[i] = mTopDictIndex[inFontIndex].mFDArray + fdIndex;
+			}
 		}
 	}
 	else // format 3
@@ -1414,19 +1447,47 @@ EStatusCode CFFFileInput::ReadFDSelect(unsigned short inFontIndex)
 		Byte fdIndex;
 
 		status = mPrimitivesReader.ReadCard16(rangesCount);
-		if(status != PDFHummus::eFailure)
+		if(status == PDFHummus::eSuccess)
 		{
 			status = mPrimitivesReader.ReadCard16(firstGlyphIndex);
+			if(status == PDFHummus::eSuccess && firstGlyphIndex != 0)
+			{
+				// Format 3 must cover every glyph; a non-zero starting index
+				// would leave mFDSelect[0..firstGlyphIndex) uninitialized for
+				// later glyph-interpretation lookups to dereference.
+				TRACE_LOG1("CFFFileInput::ReadFDSelect, format 3 initial firstGlyphIndex %u != 0 leaves leading glyphs unassigned", firstGlyphIndex);
+				return PDFHummus::eFailure;
+			}
 			for(unsigned long i=0; i < rangesCount && PDFHummus::eSuccess == status;++i)
 			{
 				mPrimitivesReader.ReadCard8(fdIndex);
 				mPrimitivesReader.ReadCard16(nextRangeGlyphIndex);
 				status = mPrimitivesReader.GetInternalState();
-				if(status != PDFHummus::eFailure)
-					for(unsigned short j=firstGlyphIndex; j < nextRangeGlyphIndex;++j)
-						mTopDictIndex[inFontIndex].mFDSelect[j] = 
-							mTopDictIndex[inFontIndex].mFDArray + fdIndex;
+				if(status != PDFHummus::eSuccess)
+					break;
+				if(fdIndex >= fdArrayCount)
+				{
+					TRACE_LOG2("CFFFileInput::ReadFDSelect, format 3 fdIndex %u out of range (fdArrayCount=%u)", fdIndex, fdArrayCount);
+					return PDFHummus::eFailure;
+				}
+				if(nextRangeGlyphIndex > glyphCount || nextRangeGlyphIndex <= firstGlyphIndex)
+				{
+					TRACE_LOG2("CFFFileInput::ReadFDSelect, format 3 nextRangeGlyphIndex %u outside (firstGlyphIndex, glyphCount=%u]", nextRangeGlyphIndex, glyphCount);
+					return PDFHummus::eFailure;
+				}
+				for(unsigned short j=firstGlyphIndex; j < nextRangeGlyphIndex;++j)
+					mTopDictIndex[inFontIndex].mFDSelect[j] =
+						mTopDictIndex[inFontIndex].mFDArray + fdIndex;
 				firstGlyphIndex = nextRangeGlyphIndex;
+			}
+			if(status == PDFHummus::eSuccess && firstGlyphIndex != glyphCount)
+			{
+				// After the loop firstGlyphIndex holds the final sentinel
+				// (or the initial value if rangesCount was 0). It must equal
+				// glyphCount; otherwise mFDSelect[firstGlyphIndex..glyphCount)
+				// stays uninitialized.
+				TRACE_LOG2("CFFFileInput::ReadFDSelect, format 3 final sentinel %u != glyphCount %u leaves trailing glyphs unassigned", firstGlyphIndex, glyphCount);
+				return PDFHummus::eFailure;
 			}
 		}
 	}
@@ -1684,16 +1745,22 @@ EStatusCode CFFFileInput::ReadCharsets(unsigned short inFontIndex)
 
 EStatusCode CFFFileInput::ReadEncodings(unsigned short inFontIndex)
 {
-	// read all encodings positions
 	LongFilePositionType encodingPosition = GetEncodingPosition(inFontIndex);
 	EncodingsInfo* encoding = new EncodingsInfo();
 
-	ReadEncoding(encoding,encodingPosition);
+	// Push first so mEncodings owns the buffer regardless of outcome — the
+	// destructor walks it for cleanup. Only assign mTopDictIndex on success
+	// to avoid pinning a partially-initialised encoding as the font's.
+	EStatusCode status = ReadEncoding(encoding, encodingPosition);
 	mEncodings.push_back(encoding);
+	if(status != PDFHummus::eSuccess)
+	{
+		TRACE_LOG1("CFFFileInput::ReadEncodings, failed to read encoding for font index %u", inFontIndex);
+		return status;
+	}
 	mTopDictIndex[inFontIndex].mEncoding = encoding;
 
 	return mPrimitivesReader.GetInternalState();
-
 }
 
 EStatusCode CFFFileInput::ReadCIDInformation(unsigned short inFontIndex)

--- a/PDFWriter/CFFFileInput.h
+++ b/PDFWriter/CFFFileInput.h
@@ -98,16 +98,22 @@ typedef std::pair<Byte,unsigned short> ByteAndUShort;
 
 struct EncodingsInfo
 {
-	EncodingsInfo() {mEncoding = NULL;}
+	EncodingsInfo() {
+		mEncodingStart = 0;
+		mEncodingEnd = 0;
+		mType = eEncodingStandard;
+		mEncodingsCount = 0;
+		mEncoding = NULL;
+	}
 
 	LongFilePositionType mEncodingStart;
 	LongFilePositionType mEncodingEnd;
 
 	EEncodingType mType;
-	Byte mEncodingsCount;
+	unsigned short mEncodingsCount;
 	Byte* mEncoding;
 	UShortToByteList mSupplements;
-	
+
 };
 
 struct PrivateDictInfo
@@ -135,6 +141,7 @@ struct TopDictInfo
 {
 	TopDictInfo() {
 					mFDArray = NULL;
+					mFDArrayCount = 0;
 					mFDSelect = NULL;
 					mCharSet = NULL;
 					mEncoding = NULL;
@@ -144,6 +151,7 @@ struct TopDictInfo
 	CharSetInfo* mCharSet;
 	EncodingsInfo* mEncoding;
 	FontDictInfo* mFDArray;
+	unsigned short mFDArrayCount;
 	FontDictInfo** mFDSelect; // size is like glyphsize. each cell references the relevant FontDict
 };
 
@@ -304,7 +312,7 @@ private:
 	PDFHummus::EStatusCode ReadPrivateDicts(unsigned short inFontIndex);
 	PDFHummus::EStatusCode ReadLocalSubrs(unsigned short inFontIndex);
 	PDFHummus::EStatusCode ReadCharsets(unsigned short inFontIndex);
-	void ReadEncoding(EncodingsInfo* inEncoding,LongFilePositionType inEncodingPosition);
+	PDFHummus::EStatusCode ReadEncoding(EncodingsInfo* inEncoding,LongFilePositionType inEncodingPosition);
 	PDFHummus::EStatusCode ReadEncodings(unsigned short inFontIndex);
 	PDFHummus::EStatusCode ReadCIDInformation(unsigned short inFontIndex);
 	PDFHummus::EStatusCode ReadCFFFileByIndexOrName(IByteReaderWithPosition* inCFFFile,const std::string& inFontName,unsigned short inFontIndex);

--- a/PDFWriterTesting/CFFFileInputTest.cpp
+++ b/PDFWriterTesting/CFFFileInputTest.cpp
@@ -17,26 +17,35 @@
    limitations under the License.
 
 
-   Regression test for CFF DICT operand-list bounds in
-   GetSingleIntegerValueFromDict and ReadPrivateDict. Both used to call
-   front()/back() on the operand list without checking it was non-empty
-   or that the operand was actually an integer, so a malformed CFF that
-   emitted an operator with no operands (or with a real where the spec
-   requires an integer) reached UB / type-punned union reads that flowed
-   into seek offsets and ReadDict's read amount.
+   Regression tests for CFFFileInput's input-validation paths:
 
-   The malformed streams are synthesised in-process so no binary fixtures
-   are required. The happy-path test parses BrushScriptStd.otf and asserts
-   exact private-dict values so we can tell the new validation didn't
-   accidentally turn the parser into a no-op.
+     * V-041: GetSingleIntegerValueFromDict / ReadPrivateDict were calling
+       front()/back() on the operand list with no checks, so a malformed Top
+       DICT could feed UB / type-punned union reads into seek offsets and
+       ReadDict's read amount.
+     * V-031: ReadEncoding's format-1 path summed each range's `left` byte
+       into a Byte mEncodingsCount that wrapped at 256, undersizing the
+       allocation and overflowing the heap during the second-pass fill.
+     * V-032: ReadEncoding's supplements branch seeked to an uninitialized
+       mEncodingEnd before it had been assigned on the custom-encoding
+       path, landing the cursor at a junk offset.
+     * V-030: ReadFDSelect failed to bound fdIndex against the FDArray
+       length and (for format 3) failed to bound nextRangeGlyphIndex
+       against glyphCount, yielding a wild-pointer write or a heap write
+       past the end of mFDSelect.
+
+   Cases are grouped by the function they exercise (sc<Function>Cases) and
+   driven by Run<Function>Cases runners. Each row's label states
+   <Condition>_<ExpectedResult>; the runner prefixes the function name so
+   failure messages stay readable.
 */
+#include "CFFFileInput.h"
+#include "CFFSyntheticBuilder.h"
+#include "DictOperand.h"
+#include "EStatusCode.h"
 #include "InputByteArrayStream.h"
 #include "InputFile.h"
 #include "OpenTypeFileInput.h"
-#include "CFFFileInput.h"
-#include "DictOperand.h"
-#include "EStatusCode.h"
-#include "IOBasicTypes.h"
 
 #include "testing/TestIO.h"
 
@@ -45,237 +54,336 @@
 
 using namespace std;
 using namespace PDFHummus;
-using namespace IOBasicTypes;
 
-// Header: major=1, minor=0, hdrSize=4, absOffSize=1.
-static const char scCFFHeader[] = "\x01\x00\x04\x01";
+typedef string (*CFFBuilderFn)(const char*, size_t);
 
-// Empty INDEXes for String INDEX and Global Subrs INDEX, which we don't
-// exercise but ReadCFFFile insists on parsing before reaching ReadCharStrings
-// and ReadPrivateDicts.
-static const char scEmptyIndex[] = "\x00\x00";
+// A row in a parameterised failure-case table: each row supplies a label
+// plus the malformed payload bytes that should be rejected by the function
+// under test (called via the table runner's bound builder + ParseAsCFF).
+struct ParseFailureCase {
+	const char* mLabel;
+	const char* mPayload;
+	size_t mPayloadLen;
+};
 
-// Build a complete CFF buffer ending at the Global Subrs INDEX. The Top DICT
-// payload (the part between the operator-encoded Top DICT INDEX header and the
-// String INDEX) is supplied by the caller so each test crafts the malformed
-// region it cares about. Top DICT length is capped at 254 so it fits a single
-// 1-byte offset entry.
-static string buildSyntheticCFF(const char* inTopDictBytes, size_t inTopDictLen) {
-	string cff;
-	cff.append(scCFFHeader, sizeof(scCFFHeader) - 1);
+// Row for tables where parsing must SUCCEED but the parser should have
+// fallen back to a documented default (e.g. /CharStrings with a malformed
+// operand list — GetSingleIntegerValueFromDict returns the default 0 and
+// ReadCharStrings becomes a no-op).
+struct ParseFallbackCase {
+	const char* mLabel;
+	const char* mPayload;
+	size_t mPayloadLen;
+	unsigned short mExpectedCharStringsCount;
+};
 
-	// Name INDEX: count=1, offSize=1, offsets=[1, 2], data="A"
-	cff.append("\x00\x01\x01\x01\x02\x41", 6);
+// Shared inner loop for failure-case tables. Reports every unexpectedly-
+// successful parse so a single test run shows all regressions, not just
+// the first.
+static bool ExpectAllParseFailures(const char* inFunctionName,
+                                   CFFBuilderFn inBuild,
+                                   const ParseFailureCase* inCases,
+                                   size_t inCaseCount) {
+	bool ok = true;
+	for(size_t i = 0; i < inCaseCount; ++i) {
+		// Arrange
+		CFFFileInput cff;
+		string bytes = inBuild(inCases[i].mPayload, inCases[i].mPayloadLen);
 
-	// Top DICT INDEX: count=1, offSize=1, offsets=[1, 1+len], data=<top dict>
-	cff.append("\x00\x01\x01\x01", 4);
-	cff.push_back((char)(1 + (Byte)inTopDictLen));
-	cff.append(inTopDictBytes, inTopDictLen);
+		// Act
+		EStatusCode status = CFFSyntheticBuilder::ParseAsCFF(bytes, cff);
 
-	// String INDEX (empty), Global Subrs INDEX (empty)
-	cff.append(scEmptyIndex, sizeof(scEmptyIndex) - 1);
-	cff.append(scEmptyIndex, sizeof(scEmptyIndex) - 1);
-
-	return cff;
+		// Assert
+		if(status == eSuccess) {
+			cout << "CFFFileInputTest [" << inFunctionName << "::" << inCases[i].mLabel
+			     << "]: malformed input was accepted" << endl;
+			ok = false;
+		}
+	}
+	return ok;
 }
 
-static EStatusCode parseSyntheticCFF(const char* inTopDictBytes, size_t inTopDictLen, CFFFileInput& outCFF) {
-	string cff = buildSyntheticCFF(inTopDictBytes, inTopDictLen);
-	InputByteArrayStream stream((Byte*)&cff[0], (LongFilePositionType)cff.size());
-	return outCFF.ReadCFFFile(&stream);
+// V-041: GetSingleIntegerValueFromDict ignored empty-list / non-integer /
+// negative operands. Pre-fix, /CharStrings with any of these shapes fed
+// garbage into SetOffset and ReadCard16. Post-fix the helper falls back to
+// the supplied default (0), turning ReadCharStrings into a no-op.
+static const ParseFallbackCase scGetSingleIntegerValueFromDictCases[] = {
+	// Single operator, zero operands. Pre-fix did front().IntegerValue on
+	// an empty list — UB.
+	{"EmptyOperandList_FallsBackToDefault", CFF_BYTES("\x11"), 0},
+	// Real where the spec requires an integer. IntegerValue was read from
+	// the union over RealValue, yielding a platform-dependent bit pattern.
+	{"RealOperand_FallsBackToDefault", CFF_BYTES("\x1E\x0A\x5F\x11"), 0},
+	// Negative integer would have driven SetOffset(negative) and failed
+	// the seek; the helper now rejects negatives.
+	{"NegativeOperand_FallsBackToDefault", CFF_BYTES("\x1C\xFF\xFF\x11"), 0},
+};
+
+static bool RunGetSingleIntegerValueFromDictCases() {
+	bool ok = true;
+	const size_t caseCount = sizeof(scGetSingleIntegerValueFromDictCases) /
+	                         sizeof(scGetSingleIntegerValueFromDictCases[0]);
+	for(size_t i = 0; i < caseCount; ++i) {
+		const ParseFallbackCase& c = scGetSingleIntegerValueFromDictCases[i];
+
+		// Arrange
+		CFFFileInput cff;
+		string bytes = CFFSyntheticBuilder::TopDictOnly(c.mPayload, c.mPayloadLen);
+
+		// Act
+		EStatusCode status = CFFSyntheticBuilder::ParseAsCFF(bytes, cff);
+
+		// Assert
+		if(status != eSuccess) {
+			cout << "CFFFileInputTest [GetSingleIntegerValueFromDict::" << c.mLabel
+			     << "]: parse failed; expected fallback to default" << endl;
+			ok = false;
+			continue;
+		}
+		if(cff.GetCharStringsCount(0) != c.mExpectedCharStringsCount) {
+			cout << "CFFFileInputTest [GetSingleIntegerValueFromDict::" << c.mLabel
+			     << "]: charstrings count = " << cff.GetCharStringsCount(0)
+			     << ", expected " << c.mExpectedCharStringsCount << endl;
+			ok = false;
+		}
+	}
+	return ok;
 }
 
-// Pass a raw byte literal to parseSyntheticCFF, deriving the length from
-// the literal so embedded \x00 bytes don't truncate. Use only with string
-// literals — sizeof on a pointer would silently take 8 bytes.
-#define PARSE_TOP_DICT(cff, bytes) parseSyntheticCFF((bytes), sizeof(bytes) - 1, (cff))
+// V-041: ReadPrivateDict accepted operand lists that violated the spec's
+// (size, offset) shape. Each row used to flow garbage into SetOffset /
+// ReadDict's read amount; post-fix every shape is rejected with eFailure.
+static const ParseFailureCase scReadPrivateDictCases[] = {
+	// /Private (key 18) with no operands — front()/back() on empty list
+	// were UB.
+	{"EmptyOperandList_ReturnsFailure", CFF_BYTES("\x12")},
+	// /Private with one integer — front()==back() so size and offset
+	// became the same value; with operand 0 ReadDict silently parsed zero
+	// bytes and ReadCFFFile returned success.
+	{"SingleIntegerOperand_ReturnsFailure", CFF_BYTES("\x8B\x12")},
+	// /Private with a real where the spec requires an integer —
+	// IntegerValue read from the union over RealValue.
+	{"RealOperand_ReturnsFailure", CFF_BYTES("\x1E\x0A\x5F\x8B\x12")},
+	// /Private with a negative size would convert to a huge unsigned value
+	// when fed to ReadDict's unsigned read amount.
+	{"NegativeSizeOperand_ReturnsFailure", CFF_BYTES("\x1C\xFF\xFF\x8B\x12")},
+};
 
-// /CharStrings (key 17) with no operand: pre-fix, GetCharStringsPosition
-// did `front().IntegerValue` on an empty list and seeded SetOffset/ReadCard16
-// with garbage. Post-fix, the empty list maps to the supplied default (0),
-// which makes ReadCharStrings a no-op and lets ReadCFFFile complete cleanly.
-static bool GetSingleIntegerValueFromDict_EmptyOperandList_FallsBackToDefault() {
-	// Arrange: top dict = [<op CharStrings>] — single operator, zero operands.
+static bool RunReadPrivateDictCases() {
+	return ExpectAllParseFailures("ReadPrivateDict",
+	                              CFFSyntheticBuilder::TopDictOnly,
+	                              scReadPrivateDictCases,
+	                              sizeof(scReadPrivateDictCases) / sizeof(scReadPrivateDictCases[0]));
+}
+
+// V-031: ReadEncoding's format-1 path summed each range's `left` field into
+// a Byte mEncodingsCount that wrapped at 256, undersizing the allocation
+// and overflowing the heap during the second-pass fill loop. Post-fix the
+// sum is computed in unsigned short and rejected if it exceeds the
+// 256-code spec ceiling.
+static const ParseFailureCase scReadEncodingCases[] = {
+	// format=0x01, ranges=2, each covers 255 codes (sum=510 > 256).
+	{"Format1RangeSumExceedsCeiling_ReturnsFailure", CFF_BYTES("\x01\x02\x00\xFF\x01\xFF")},
+};
+
+// Format-1 happy path: a single range [first=0x40, left=5] should populate
+// mEncoding[0..4] with codes 0x40..0x44. Catches a regression where the
+// widening of mEncodingsCount accidentally broke the second-pass fill loop.
+static bool ReadEncoding_Format1ValidRange_PopulatesEncodingArray() {
+	// Arrange: format=0x01, ranges=1, range0={first=0x40, left=5}.
 	CFFFileInput cff;
-	EStatusCode status = PARSE_TOP_DICT(cff, "\x11");
+	string bytes = CFFSyntheticBuilder::WithEncoding(CFF_BYTES("\x01\x01\x40\x05"));
+
+	// Act
+	EStatusCode status = CFFSyntheticBuilder::ParseAsCFF(bytes, cff);
 
 	// Assert
 	if(status != eSuccess) {
-		cout << "CFFFileInputTest: ReadCFFFile failed for empty-operand CharStrings key" << endl;
+		cout << "CFFFileInputTest [ReadEncoding::Format1ValidRange_PopulatesEncodingArray]: parse failed" << endl;
 		return false;
 	}
-	if(cff.GetCharStringsCount(0) != 0) {
-		cout << "CFFFileInputTest: expected 0 charstrings, got " << cff.GetCharStringsCount(0) << endl;
+	const EncodingsInfo* enc = cff.mTopDictIndex[0].mEncoding;
+	if(enc == NULL) {
+		cout << "CFFFileInputTest [ReadEncoding::Format1ValidRange_PopulatesEncodingArray]: mEncoding is NULL" << endl;
 		return false;
+	}
+	if(enc->mEncodingsCount != 5) {
+		cout << "CFFFileInputTest [ReadEncoding::Format1ValidRange_PopulatesEncodingArray]: encodings count = "
+		     << enc->mEncodingsCount << ", expected 5" << endl;
+		return false;
+	}
+	for(unsigned short i = 0; i < 5; ++i) {
+		IOBasicTypes::Byte expected = (IOBasicTypes::Byte)(0x40 + i);
+		if(enc->mEncoding[i] != expected) {
+			cout << "CFFFileInputTest [ReadEncoding::Format1ValidRange_PopulatesEncodingArray]: encoding["
+			     << i << "] = " << (int)enc->mEncoding[i] << ", expected " << (int)expected << endl;
+			return false;
+		}
 	}
 	return true;
 }
 
-// /CharStrings (key 17) with a real operand: pre-fix, IntegerValue was read
-// from the union after RealValue had been written, yielding a platform-
-// dependent bit-pattern that became a wild SetOffset target. Post-fix the
-// non-integer operand falls back to the default and parsing continues.
-static bool GetSingleIntegerValueFromDict_RealOperand_FallsBackToDefault() {
-	// Arrange: top dict = [<real 0.5> <op CharStrings>].
-	// Real BCD: 0x1E header, nibbles {0, '.'(0xa), 5, end(0xf)} = bytes 0x0A 0x5F.
+// V-032: supplements branch seeked to an uninitialized mEncodingEnd before
+// it was assigned on the custom-encoding path. Pre-fix the seek landed at
+// junk and mSupplements never got the (encoding, SID) pair from the file.
+// Post-fix the cursor is already at the supplements bytes when the branch
+// runs, so the seek is removed and the entries land where they belong.
+static bool ReadEncoding_Format0WithSupplements_PopulatesSupplementMap() {
+	// Arrange: format byte 0x80 = format-0 base + supplements flag,
+	// format-0 body rawCount=0, supplements count=1,
+	// entry={encoding=0x42, SID=0x0001}.
 	CFFFileInput cff;
-	EStatusCode status = PARSE_TOP_DICT(cff, "\x1E\x0A\x5F\x11");
+	string bytes = CFFSyntheticBuilder::WithEncoding(CFF_BYTES("\x80\x00\x01\x42\x00\x01"));
+
+	// Act
+	EStatusCode status = CFFSyntheticBuilder::ParseAsCFF(bytes, cff);
 
 	// Assert
 	if(status != eSuccess) {
-		cout << "CFFFileInputTest: ReadCFFFile failed for real-operand CharStrings key" << endl;
+		cout << "CFFFileInputTest [ReadEncoding::Format0WithSupplements_PopulatesSupplementMap]: parse failed" << endl;
 		return false;
 	}
-	if(cff.GetCharStringsCount(0) != 0) {
-		cout << "CFFFileInputTest: expected 0 charstrings (real-operand fallback), got "
-		     << cff.GetCharStringsCount(0) << endl;
+	const EncodingsInfo* enc = cff.mTopDictIndex[0].mEncoding;
+	if(enc == NULL) {
+		cout << "CFFFileInputTest [ReadEncoding::Format0WithSupplements_PopulatesSupplementMap]: mEncoding is NULL" << endl;
 		return false;
 	}
-	return true;
-}
-
-// /CharStrings with a negative integer operand: every caller of this
-// helper treats the result as a non-negative offset / enum-id, so a
-// negative value would have flowed into SetOffset(negative) and failed
-// the seek. Post-fix the helper rejects negative and falls back to the
-// default (0), which makes ReadCharStrings a no-op.
-static bool GetSingleIntegerValueFromDict_NegativeOperand_FallsBackToDefault() {
-	// Arrange: top dict = [<int -1> <op CharStrings>]. -1 in CFF 2-byte
-	// signed form: 0x1C 0xFF 0xFF.
-	CFFFileInput cff;
-	EStatusCode status = PARSE_TOP_DICT(cff, "\x1C\xFF\xFF\x11");
-
-	// Assert
-	if(status != eSuccess) {
-		cout << "CFFFileInputTest: ReadCFFFile failed for negative-operand CharStrings key" << endl;
+	if(enc->mEncodingsCount != 0) {
+		cout << "CFFFileInputTest [ReadEncoding::Format0WithSupplements_PopulatesSupplementMap]: base encoding count = "
+		     << enc->mEncodingsCount << ", expected 0" << endl;
 		return false;
 	}
-	if(cff.GetCharStringsCount(0) != 0) {
-		cout << "CFFFileInputTest: expected 0 charstrings (negative-operand fallback), got "
-		     << cff.GetCharStringsCount(0) << endl;
+	UShortToByteList::const_iterator it = enc->mSupplements.find(1);
+	if(it == enc->mSupplements.end()) {
+		cout << "CFFFileInputTest [ReadEncoding::Format0WithSupplements_PopulatesSupplementMap]: SID 1 not in supplements map" << endl;
+		return false;
+	}
+	if(it->second.size() != 1 || it->second.front() != 0x42) {
+		cout << "CFFFileInputTest [ReadEncoding::Format0WithSupplements_PopulatesSupplementMap]: supplements[SID 1] mismatch" << endl;
 		return false;
 	}
 	return true;
 }
 
-// /Private (key 18) with no operands: pre-fix, both front() and back() on
-// the empty list were UB; the resulting garbage was passed to SetOffset
-// and ReadDict. Post-fix, the empty list is rejected with eFailure.
-static bool ReadPrivateDict_EmptyOperandList_ReturnsFailure() {
-	// Arrange: top dict = [<op Private>]
+// The single-font ReadEncodings(unsigned short) overload (driven by the
+// by-index / by-name ReadCFFFile entry points) used to call ReadEncoding
+// and discard its return, then report mPrimitivesReader.GetInternalState().
+// V-031's reject path returns eFailure without flipping the primitive
+// reader's state, so the malformed encoding was accepted on those entries.
+// This case feeds the same payload as the format-1-overflow row through
+// ReadCFFFile(stream, fontIndex=0) so the fix is exercised on the by-index
+// path too.
+static bool ReadEncodings_ByFontIndex_PropagatesEncodingFailure() {
+	// Arrange
+	string bytes = CFFSyntheticBuilder::WithEncoding(CFF_BYTES("\x01\x02\x00\xFF\x01\xFF"));
+	InputByteArrayStream stream((IOBasicTypes::Byte*)bytes.data(),
+	                            (LongFilePositionType)bytes.size());
 	CFFFileInput cff;
-	EStatusCode status = PARSE_TOP_DICT(cff, "\x12");
 
-	// Assert
-	if(status == eSuccess) {
-		cout << "CFFFileInputTest: empty-operand Private was accepted" << endl;
-		return false;
-	}
-	return true;
-}
-
-// /Private with a single integer operand: pre-fix, front()==back() so size
-// and offset became the same value; in particular, with operand 0 ReadDict
-// silently parses zero bytes and ReadCFFFile returns success — exercising
-// the "silently wrong" pre-fix branch (no crash, no wrong-offset failure).
-// Post-fix, size() < 2 is rejected with eFailure.
-static bool ReadPrivateDict_SingleOperand_ReturnsFailure() {
-	// Arrange: top dict = [<int 0> <op Private>]. Encoding for int 0 is 0x8B
-	// (139 - 139). Single operand for what spec requires to be (size, offset).
-	CFFFileInput cff;
-	EStatusCode status = PARSE_TOP_DICT(cff, "\x8B\x12");
+	// Act
+	EStatusCode status = cff.ReadCFFFile(&stream, (unsigned short)0);
 
 	// Assert
 	if(status == eSuccess) {
-		cout << "CFFFileInputTest: single-operand Private was accepted" << endl;
+		cout << "CFFFileInputTest [ReadEncodings::ByFontIndex_PropagatesEncodingFailure]: "
+		        "malformed format-1 encoding accepted by by-index ReadCFFFile" << endl;
 		return false;
 	}
 	return true;
 }
 
-// /Private with a real where an integer is required: pre-fix, IntegerValue
-// reads were taken from the union over RealValue, yielding garbage offsets
-// fed to SetOffset / ReadDict. Post-fix, non-integer operands are rejected.
-static bool ReadPrivateDict_NonIntegerOperand_ReturnsFailure() {
-	// Arrange: top dict = [<real 0.5> <int 0> <op Private>]. Two operands,
-	// but the first (size) is a real — exactly the union-misuse case.
-	CFFFileInput cff;
-	EStatusCode status = PARSE_TOP_DICT(cff, "\x1E\x0A\x5F\x8B\x12");
-
-	// Assert
-	if(status == eSuccess) {
-		cout << "CFFFileInputTest: real-operand Private was accepted" << endl;
+static bool RunReadEncodingCases() {
+	if(!ExpectAllParseFailures("ReadEncoding",
+	                           CFFSyntheticBuilder::WithEncoding,
+	                           scReadEncodingCases,
+	                           sizeof(scReadEncodingCases) / sizeof(scReadEncodingCases[0])))
 		return false;
-	}
+	if(!ReadEncoding_Format1ValidRange_PopulatesEncodingArray()) return false;
+	if(!ReadEncoding_Format0WithSupplements_PopulatesSupplementMap()) return false;
+	if(!ReadEncodings_ByFontIndex_PropagatesEncodingFailure()) return false;
 	return true;
 }
 
-// /Private with a negative size: passes IsInteger, but as a signed long
-// would convert to a huge unsigned value when fed to ReadDict's unsigned
-// read amount, causing excessive parsing. Post-fix, non-negative checks
-// reject it before the call.
-static bool ReadPrivateDict_NegativeSize_ReturnsFailure() {
-	// Arrange: top dict = [<int -1> <int 0> <op Private>].
-	// -1 in CFF 2-byte signed form: 0x1C 0xFF 0xFF (operand prefix + s16).
-	// 0 in CFF short form: 0x8B (139 - 139).
-	CFFFileInput cff;
-	EStatusCode status = PARSE_TOP_DICT(cff, "\x1C\xFF\xFF\x8B\x12");
+// V-030: ReadFDSelect didn't bound fdIndex against the FDArray entry count
+// (wild-pointer write into mFDSelect) and format-3 didn't enforce coverage
+// of [0, glyphCount) (uninitialized mFDSelect entries dereferenced by
+// later glyph-interpretation lookups). CFFSyntheticBuilder::WithFDSelect
+// produces a CID font with glyphCount=1 and fdArrayCount=1 so each
+// malformed-input row is a single payload.
+static const ParseFailureCase scReadFDSelectCases[] = {
+	// Format 0, fdIndex[0]=0xFF — pre-fix stored `mFDArray + 0xFF` in
+	// mFDSelect[0] (wild pointer write).
+	{"Format0FdIndexBeyondFDArray_ReturnsFailure", CFF_BYTES("\x00\xFF")},
+	// Format 3, range fdIndex=0xFF — same wild-pointer-write primitive on
+	// the format-3 read path.
+	{"Format3FdIndexBeyondFDArray_ReturnsFailure", CFF_BYTES("\x03\x00\x01\x00\x00\xFF\x00\x01")},
+	// Format 3, range covers glyphs [0, 5) but glyphCount is 1 — pre-fix
+	// inner loop wrote mFDSelect[1..4] past the end of the heap buffer.
+	{"Format3NextRangeBeyondGlyphCount_ReturnsFailure", CFF_BYTES("\x03\x00\x01\x00\x00\x00\x00\x05")},
+	// Format 3 with rangesCount=0, firstGlyphIndex=1 — leaves mFDSelect[0]
+	// uninitialized for later deref. Caught by the initial-firstGlyphIndex
+	// check (must be 0 so every glyph is covered).
+	{"Format3InitialFirstGlyphIndexNonZero_ReturnsFailure", CFF_BYTES("\x03\x00\x00\x00\x01")},
+	// Format 3 with rangesCount=0, firstGlyphIndex=0 — loop never assigns
+	// anything, so the trailing-coverage check fires because the final
+	// sentinel (still 0) is less than glyphCount (1).
+	{"Format3FinalSentinelBelowGlyphCount_ReturnsFailure", CFF_BYTES("\x03\x00\x00\x00\x00")},
+};
 
-	// Assert
-	if(status == eSuccess) {
-		cout << "CFFFileInputTest: negative-size Private was accepted" << endl;
-		return false;
-	}
-	return true;
+static bool RunReadFDSelectCases() {
+	return ExpectAllParseFailures("ReadFDSelect",
+	                              CFFSyntheticBuilder::WithFDSelect,
+	                              scReadFDSelectCases,
+	                              sizeof(scReadFDSelectCases) / sizeof(scReadFDSelectCases[0]));
 }
 
-// Happy path: prove the new validation didn't break parsing of a real CFF
-// font. Asserts exact expected values rather than just "didn't crash" /
-// "size > 0", so a regression that quietly turns the parser into a no-op
-// would be caught.
+// Real-font happy path: prove the new validation didn't break parsing of a
+// real CFF font. Asserts exact expected values rather than just "didn't
+// crash" / "size > 0", so a regression that quietly turns the parser into
+// a no-op would be caught.
 static bool ReadCFFFile_BrushScriptStd_PopulatesPrivateDict(char* argv[]) {
 	// Arrange
 	InputFile otfFile;
 	OpenTypeFileInput openType;
 	if(otfFile.OpenFile(BuildRelativeInputPath(argv, "fonts/BrushScriptStd.otf")) != eSuccess) {
-		cout << "CFFFileInputTest: failed to open BrushScriptStd.otf" << endl;
+		cout << "CFFFileInputTest [ReadCFFFile::BrushScriptStd_PopulatesPrivateDict]: failed to open font" << endl;
 		return false;
 	}
+
+	// Act
 	if(openType.ReadOpenTypeFile(otfFile.GetInputStream(), 0) != eSuccess) {
-		cout << "CFFFileInputTest: positive path failed - real CFF rejected" << endl;
+		cout << "CFFFileInputTest [ReadCFFFile::BrushScriptStd_PopulatesPrivateDict]: real CFF rejected" << endl;
 		return false;
 	}
 
+	// Assert
 	bool ok = false;
-
 	do {
-		// Assert: exactly one Private DICT, span is non-empty (start < end).
 		if(openType.mCFF.mFontsCount != 1) {
-			cout << "CFFFileInputTest: expected 1 font, got " << openType.mCFF.mFontsCount << endl;
+			cout << "CFFFileInputTest [ReadCFFFile::BrushScriptStd_PopulatesPrivateDict]: expected 1 font, got "
+			     << openType.mCFF.mFontsCount << endl;
 			break;
 		}
 		if(openType.mCFF.mPrivateDicts == NULL) {
-			cout << "CFFFileInputTest: mPrivateDicts is NULL" << endl;
+			cout << "CFFFileInputTest [ReadCFFFile::BrushScriptStd_PopulatesPrivateDict]: mPrivateDicts is NULL" << endl;
 			break;
 		}
 		const PrivateDictInfo& priv = openType.mCFF.mPrivateDicts[0];
 		// Exact byte positions for BrushScriptStd's Private DICT (offset=17676, size=28).
 		if(priv.mPrivateDictStart != 17676) {
-			cout << "CFFFileInputTest: expected Private DICT start 17676, got "
-			     << priv.mPrivateDictStart << endl;
+			cout << "CFFFileInputTest [ReadCFFFile::BrushScriptStd_PopulatesPrivateDict]: Private DICT start "
+			     << priv.mPrivateDictStart << ", expected 17676" << endl;
 			break;
 		}
 		if(priv.mPrivateDictEnd != 17704) {
-			cout << "CFFFileInputTest: expected Private DICT end 17704, got "
-			     << priv.mPrivateDictEnd << endl;
+			cout << "CFFFileInputTest [ReadCFFFile::BrushScriptStd_PopulatesPrivateDict]: Private DICT end "
+			     << priv.mPrivateDictEnd << ", expected 17704" << endl;
 			break;
 		}
-		// Sanity-check that ReadDict actually populated the inner dict.
 		if(priv.mPrivateDict.empty()) {
-			cout << "CFFFileInputTest: inner Private DICT is empty" << endl;
+			cout << "CFFFileInputTest [ReadCFFFile::BrushScriptStd_PopulatesPrivateDict]: inner Private DICT empty" << endl;
 			break;
 		}
-
 		ok = true;
 	} while(false);
 
@@ -283,13 +391,10 @@ static bool ReadCFFFile_BrushScriptStd_PopulatesPrivateDict(char* argv[]) {
 }
 
 int CFFFileInputTest(int argc, char* argv[]) {
-	if(!GetSingleIntegerValueFromDict_EmptyOperandList_FallsBackToDefault()) return 1;
-	if(!GetSingleIntegerValueFromDict_RealOperand_FallsBackToDefault()) return 1;
-	if(!GetSingleIntegerValueFromDict_NegativeOperand_FallsBackToDefault()) return 1;
-	if(!ReadPrivateDict_EmptyOperandList_ReturnsFailure()) return 1;
-	if(!ReadPrivateDict_SingleOperand_ReturnsFailure()) return 1;
-	if(!ReadPrivateDict_NonIntegerOperand_ReturnsFailure()) return 1;
-	if(!ReadPrivateDict_NegativeSize_ReturnsFailure()) return 1;
+	if(!RunGetSingleIntegerValueFromDictCases()) return 1;
+	if(!RunReadPrivateDictCases()) return 1;
+	if(!RunReadEncodingCases()) return 1;
+	if(!RunReadFDSelectCases()) return 1;
 	if(!ReadCFFFile_BrushScriptStd_PopulatesPrivateDict(argv)) return 1;
 	return 0;
 }

--- a/PDFWriterTesting/CFFIndexSanity.cpp
+++ b/PDFWriterTesting/CFFIndexSanity.cpp
@@ -21,20 +21,22 @@
    ReadIndexHeader and ReadCharString. Each malformed CFF below would
    previously reach an unsigned subtraction on garbage offsets and feed the
    result to `new Byte[N]`, a bad_alloc / OOB primitive depending on the
-   values. With validation in place, every malformed prefix is rejected with
-   eFailure on the very first INDEX (the Name INDEX).
+   values. With validation in place, every malformed prefix is rejected
+   with eFailure on the very first INDEX (the Name INDEX).
 
-   The malformed streams are synthesised in-process so no binary fixtures
-   are required. The happy-path test parses BrushScriptStd.otf and asserts
-   exact values (font name, font count, .notdef glyph) so we can tell that
-   the validation didn't accidentally turn the parser into a no-op.
+   Cases are grouped by the function they exercise (sc<Function>Cases) and
+   driven by Run<Function>Cases runners. Each row's label states
+   <Condition>_<ExpectedResult>; the runner prefixes the function name so
+   failure messages stay readable. Synthetic streams come from
+   CFFSyntheticBuilder; the happy-path test parses BrushScriptStd.otf and
+   asserts exact values (font name, font count, .notdef glyph) so a
+   regression that quietly turns the parser into a no-op would be caught.
 */
-#include "InputByteArrayStream.h"
+#include "CFFFileInput.h"
+#include "CFFSyntheticBuilder.h"
+#include "EStatusCode.h"
 #include "InputFile.h"
 #include "OpenTypeFileInput.h"
-#include "CFFFileInput.h"
-#include "EStatusCode.h"
-#include "IOBasicTypes.h"
 
 #include "testing/TestIO.h"
 
@@ -45,81 +47,50 @@ using namespace std;
 using namespace PDFHummus;
 using namespace IOBasicTypes;
 
-// Header: major=1, minor=0, hdrSize=4, absOffSize=1. ReadCFFFile only
-// uses hdrSize to skip to the Name INDEX, which is already at offset 4.
-static const char scCFFHeader[] = "\x01\x00\x04\x01";
-static const size_t scCFFHeaderSize = sizeof(scCFFHeader) - 1;
+struct ReadIndexHeaderCase {
+	const char* mLabel;
+	const char* mPayload;
+	size_t mPayloadLen;
+};
 
-// Drive ReadCFFFile against a 4-byte header + the caller-crafted Name
-// INDEX bytes. The Name INDEX always-fails cases never reach the other
-// INDEXes, so we can stop the synthetic stream right after it.
-static EStatusCode parseSyntheticCFF(const char* inNameIndexBytes, size_t inNameIndexLen) {
-	string cff;
-	cff.append(scCFFHeader, scCFFHeaderSize);
-	cff.append(inNameIndexBytes, inNameIndexLen);
-	InputByteArrayStream stream((Byte*)&cff[0], (LongFilePositionType)cff.size());
-	CFFFileInput cffInput;
-	return cffInput.ReadCFFFile(&stream);
-}
+// Each row is a malformed Name INDEX that ReadIndexHeader must reject.
+// Pre-fix, all four reached an unsigned subtraction on garbage offsets and
+// fed it to `new Byte[N]`.
+static const ReadIndexHeaderCase scReadIndexHeaderCases[] = {
+	// offsets[0] < 1 would underflow `dataStartPosition + offsets[0] - 1`
+	// in ReadSubrsFromIndex (and produce wild charstring start positions).
+	{"ZeroFirstOffset_ReturnsFailure", CFF_BYTES("\x00\x01\x01\x00\x01")},
+	// Non-monotonic offsets used to make `offsets[i+1] - offsets[i]` wrap
+	// to ~ULONG_MAX in unsigned arithmetic, then drive `new Byte[N]`.
+	{"NonMonotonicOffsets_ReturnsFailure", CFF_BYTES("\x00\x01\x01\x05\x01")},
+	// offSize=0 leaves ReadOffset's switch with no matching case, returning
+	// eFailure but with offset values uninitialized in the buffer.
+	{"ZeroOffSize_ReturnsFailure", CFF_BYTES("\x00\x01\x00")},
+	// offSize=5 is out of the spec-required {1..4} range.
+	{"OutOfRangeOffSize_ReturnsFailure", CFF_BYTES("\x00\x01\x05")},
+};
 
-// Pass a raw byte literal to parseSyntheticCFF, deriving the length from
-// the literal so embedded \x00 bytes don't truncate the string. Use only
-// with string literals — sizeof on a pointer would silently take 8 bytes.
-#define PARSE_NAME_INDEX(bytes) parseSyntheticCFF((bytes), sizeof(bytes) - 1)
+static bool RunReadIndexHeaderCases() {
+	bool ok = true;
+	const size_t caseCount = sizeof(scReadIndexHeaderCases) / sizeof(scReadIndexHeaderCases[0]);
+	for(size_t i = 0; i < caseCount; ++i) {
+		const ReadIndexHeaderCase& c = scReadIndexHeaderCases[i];
 
-// offsets[0] < 1 would underflow `dataStartPosition + offsets[0] - 1`
-// in ReadSubrsFromIndex (and produce wild charstring start positions).
-static bool parsingZeroFirstOffset_returnsFailure() {
-	// Arrange: count=1, offSize=1, offsets=[0x00, 0x01]
-	EStatusCode status = PARSE_NAME_INDEX("\x00\x01\x01\x00\x01");
+		// Arrange
+		CFFFileInput cff;
+		string bytes = CFFSyntheticBuilder::HeaderPlusBytes(c.mPayload, c.mPayloadLen);
 
-	// Assert
-	if(status == eSuccess) {
-		cout << "CFFIndexSanity: zero first offset was accepted" << endl;
-		return false;
+		// Act
+		EStatusCode status = CFFSyntheticBuilder::ParseAsCFF(bytes, cff);
+
+		// Assert
+		if(status == eSuccess) {
+			cout << "CFFIndexSanity [ReadIndexHeader::" << c.mLabel
+			     << "]: malformed input was accepted" << endl;
+			ok = false;
+		}
 	}
-	return true;
-}
-
-// Non-monotonic offsets used to make `offsets[i+1] - offsets[i]` wrap
-// to ~ULONG_MAX in unsigned arithmetic, then drive `new Byte[N]`.
-static bool parsingNonMonotonicOffsets_returnsFailure() {
-	// Arrange: count=1, offSize=1, offsets=[0x05, 0x01] (1 < 5 -> non-monotonic)
-	EStatusCode status = PARSE_NAME_INDEX("\x00\x01\x01\x05\x01");
-
-	// Assert
-	if(status == eSuccess) {
-		cout << "CFFIndexSanity: non-monotonic offsets were accepted" << endl;
-		return false;
-	}
-	return true;
-}
-
-// offSize=0 leaves ReadOffset's switch with no matching case, returning
-// eFailure but with offset values uninitialized in the buffer.
-static bool parsingZeroOffSize_returnsFailure() {
-	// Arrange: count=1, offSize=0
-	EStatusCode status = PARSE_NAME_INDEX("\x00\x01\x00");
-
-	// Assert
-	if(status == eSuccess) {
-		cout << "CFFIndexSanity: offSize=0 was accepted" << endl;
-		return false;
-	}
-	return true;
-}
-
-// Same with an out-of-range high value.
-static bool parsingOutOfRangeOffSize_returnsFailure() {
-	// Arrange: count=1, offSize=5
-	EStatusCode status = PARSE_NAME_INDEX("\x00\x01\x05");
-
-	// Assert
-	if(status == eSuccess) {
-		cout << "CFFIndexSanity: offSize=5 was accepted" << endl;
-		return false;
-	}
-	return true;
+	return ok;
 }
 
 // Parses BrushScriptStd.otf and leaves the file open through the caller's
@@ -134,12 +105,12 @@ static EStatusCode openBrushScriptStd(char* argv[], InputFile& outFile, OpenType
 // ReadCharString with end < start would underflow the unsigned subtraction
 // fed to `new Byte[N]`. Reachable directly via the public
 // IType2InterpreterImplementation::ReadCharString override.
-static bool readCharStringWithEndBeforeStart_returnsFailure(char* argv[]) {
+static bool ReadCharString_EndBeforeStart_ReturnsFailure(char* argv[]) {
 	// Arrange: parse a valid font so mPrimitivesReader has a stream.
 	InputFile otfFile;
 	OpenTypeFileInput openType;
 	if(openBrushScriptStd(argv, otfFile, openType) != eSuccess) {
-		cout << "CFFIndexSanity: BrushScriptStd.otf parse failed" << endl;
+		cout << "CFFIndexSanity [ReadCharString::EndBeforeStart_ReturnsFailure]: BrushScriptStd.otf parse failed" << endl;
 		return false;
 	}
 
@@ -150,13 +121,13 @@ static bool readCharStringWithEndBeforeStart_returnsFailure(char* argv[]) {
 	// Assert
 	if(status == eSuccess) {
 		delete[] charString;
-		cout << "CFFIndexSanity: ReadCharString accepted end < start" << endl;
+		cout << "CFFIndexSanity [ReadCharString::EndBeforeStart_ReturnsFailure]: end < start was accepted" << endl;
 		return false;
 	}
 	if(charString != NULL) {
 		// Function contract: failure path leaves outCharString NULL (never allocated).
 		delete[] charString;
-		cout << "CFFIndexSanity: ReadCharString left non-NULL buffer on failure" << endl;
+		cout << "CFFIndexSanity [ReadCharString::EndBeforeStart_ReturnsFailure]: non-NULL buffer left on failure" << endl;
 		return false;
 	}
 	return true;
@@ -166,60 +137,59 @@ static bool readCharStringWithEndBeforeStart_returnsFailure(char* argv[]) {
 // font. Asserts exact expected values rather than just "didn't crash" /
 // "count > 0", so a regression that quietly turns the parser into a no-op
 // (e.g. always returning empty data) would be caught.
-static bool parsingValidCFF_populatesExpectedValues(char* argv[]) {
-	// Arrange
+static bool ReadCFFFile_BrushScriptStd_PopulatesExpectedValues(char* argv[]) {
+	// Arrange + Act
 	InputFile otfFile;
 	OpenTypeFileInput openType;
 	if(openBrushScriptStd(argv, otfFile, openType) != eSuccess) {
-		cout << "CFFIndexSanity: positive path failed - real CFF rejected" << endl;
+		cout << "CFFIndexSanity [ReadCFFFile::BrushScriptStd_PopulatesExpectedValues]: real CFF rejected" << endl;
 		return false;
 	}
 
+	// Assert
 	bool ok = false;
 	Byte* buffer = NULL;
-
 	do {
-		// Assert: Name INDEX produced exactly one font with the expected name.
 		if(openType.mCFF.mFontsCount != 1) {
-			cout << "CFFIndexSanity: expected 1 font, got " << openType.mCFF.mFontsCount << endl;
+			cout << "CFFIndexSanity [ReadCFFFile::BrushScriptStd_PopulatesExpectedValues]: expected 1 font, got "
+			     << openType.mCFF.mFontsCount << endl;
 			break;
 		}
 		if(openType.mCFF.mName.size() != 1) {
-			cout << "CFFIndexSanity: expected 1 name entry, got " << openType.mCFF.mName.size() << endl;
+			cout << "CFFIndexSanity [ReadCFFFile::BrushScriptStd_PopulatesExpectedValues]: expected 1 name entry, got "
+			     << openType.mCFF.mName.size() << endl;
 			break;
 		}
 		if(openType.mCFF.mName.front() != "BrushScriptStd") {
-			cout << "CFFIndexSanity: expected font name 'BrushScriptStd', got '"
+			cout << "CFFIndexSanity [ReadCFFFile::BrushScriptStd_PopulatesExpectedValues]: expected font name 'BrushScriptStd', got '"
 			     << openType.mCFF.mName.front() << "'" << endl;
 			break;
 		}
-
-		// Assert: CharStrings INDEX populated and glyph 0 is .notdef (CFF spec invariant).
 		if(openType.mCFF.GetCharStringsCount(0) == 0) {
-			cout << "CFFIndexSanity: expected non-zero glyph count" << endl;
+			cout << "CFFIndexSanity [ReadCFFFile::BrushScriptStd_PopulatesExpectedValues]: expected non-zero glyph count" << endl;
 			break;
 		}
 		if(openType.mCFF.GetGlyphName(0, 0) != ".notdef") {
-			cout << "CFFIndexSanity: expected glyph 0 name '.notdef', got '"
+			cout << "CFFIndexSanity [ReadCFFFile::BrushScriptStd_PopulatesExpectedValues]: expected glyph 0 name '.notdef', got '"
 			     << openType.mCFF.GetGlyphName(0, 0) << "'" << endl;
 			break;
 		}
 
-		// Assert: ReadCharString round-trips a real glyph (proves the end >= start
+		// ReadCharString round-trips a real glyph (proves the end >= start
 		// guard didn't accidentally reject the normal end == start + N case).
 		CharString* notdef = openType.mCFF.GetGlyphCharString(0, 0);
 		if(notdef == NULL) {
-			cout << "CFFIndexSanity: GetGlyphCharString returned NULL for .notdef" << endl;
+			cout << "CFFIndexSanity [ReadCFFFile::BrushScriptStd_PopulatesExpectedValues]: GetGlyphCharString returned NULL for .notdef" << endl;
 			break;
 		}
 		EStatusCode readStatus = openType.mCFF.ReadCharString(
 			notdef->mStartPosition, notdef->mEndPosition, &buffer);
 		if(readStatus != eSuccess) {
-			cout << "CFFIndexSanity: ReadCharString failed on a real .notdef glyph" << endl;
+			cout << "CFFIndexSanity [ReadCFFFile::BrushScriptStd_PopulatesExpectedValues]: ReadCharString failed on .notdef glyph" << endl;
 			break;
 		}
 		if(buffer == NULL) {
-			cout << "CFFIndexSanity: ReadCharString reported success but left buffer NULL" << endl;
+			cout << "CFFIndexSanity [ReadCFFFile::BrushScriptStd_PopulatesExpectedValues]: ReadCharString reported success but left buffer NULL" << endl;
 			break;
 		}
 
@@ -231,11 +201,8 @@ static bool parsingValidCFF_populatesExpectedValues(char* argv[]) {
 }
 
 int CFFIndexSanity(int argc, char* argv[]) {
-	if(!parsingZeroFirstOffset_returnsFailure()) return 1;
-	if(!parsingNonMonotonicOffsets_returnsFailure()) return 1;
-	if(!parsingZeroOffSize_returnsFailure()) return 1;
-	if(!parsingOutOfRangeOffSize_returnsFailure()) return 1;
-	if(!readCharStringWithEndBeforeStart_returnsFailure(argv)) return 1;
-	if(!parsingValidCFF_populatesExpectedValues(argv)) return 1;
+	if(!RunReadIndexHeaderCases()) return 1;
+	if(!ReadCharString_EndBeforeStart_ReturnsFailure(argv)) return 1;
+	if(!ReadCFFFile_BrushScriptStd_PopulatesExpectedValues(argv)) return 1;
 	return 0;
 }

--- a/PDFWriterTesting/CFFSyntheticBuilder.cpp
+++ b/PDFWriterTesting/CFFSyntheticBuilder.cpp
@@ -1,0 +1,118 @@
+#include "CFFSyntheticBuilder.h"
+
+#include "CFFFileInput.h"
+#include "InputByteArrayStream.h"
+#include "IOBasicTypes.h"
+
+using namespace std;
+using namespace PDFHummus;
+using namespace IOBasicTypes;
+
+// Header: major=1, minor=0, hdrSize=4, absOffSize=1.
+static const char scCFFHeader[] = "\x01\x00\x04\x01";
+static const size_t scCFFHeaderSize = sizeof(scCFFHeader) - 1;
+
+// Empty INDEX (count=0). Used as filler for String / Global Subrs INDEXes and,
+// in the encoding builder, the CharStrings INDEX as well.
+static const char scEmptyIndex[] = "\x00\x00";
+static const size_t scEmptyIndexSize = sizeof(scEmptyIndex) - 1;
+
+string CFFSyntheticBuilder::HeaderPlusBytes(const char* inBytes, size_t inLen)
+{
+    string cff;
+    cff.append(scCFFHeader, scCFFHeaderSize);
+    cff.append(inBytes, inLen);
+    return cff;
+}
+
+string CFFSyntheticBuilder::TopDictOnly(const char* inTopDictBytes, size_t inTopDictLen)
+{
+    string cff;
+    // Top DICT length is capped at 254 so the second offset of the single-
+    // entry INDEX stays 1-byte. Refuse to silently truncate via (Byte)cast —
+    // an inconsistent INDEX would surface as a confusing parse failure
+    // unrelated to whatever the caller was trying to test. Returning empty
+    // makes ReadCFFFile fail on the header check.
+    if(inTopDictLen > 254)
+        return cff;
+
+    cff.append(scCFFHeader, scCFFHeaderSize);
+
+    // Name INDEX: count=1, offSize=1, offsets=[1, 2], data="A"
+    cff.append("\x00\x01\x01\x01\x02\x41", 6);
+
+    // Top DICT INDEX: count=1, offSize=1, offsets=[1, 1+len], data=<top dict>.
+    cff.append("\x00\x01\x01\x01", 4);
+    cff.push_back((char)(1 + (Byte)inTopDictLen));
+    cff.append(inTopDictBytes, inTopDictLen);
+
+    // String INDEX (empty), Global Subrs INDEX (empty)
+    cff.append(scEmptyIndex, scEmptyIndexSize);
+    cff.append(scEmptyIndex, scEmptyIndexSize);
+
+    return cff;
+}
+
+string CFFSyntheticBuilder::WithEncoding(const char* inEncodingBytes, size_t inEncodingLen)
+{
+    string cff;
+    cff.append(scCFFHeader, scCFFHeaderSize);
+
+    // Name INDEX
+    cff.append("\x00\x01\x01\x01\x02\x41", 6);
+
+    // Top DICT INDEX: count=1, offSize=1, offsets=[1, 5], 4-byte top dict.
+    // Top dict: <int 23> 0x11 (CharStrings), <int 25> 0x10 (Encoding).
+    // Single-byte CFF int encodes value-139, so 23->0xA2, 25->0xA4.
+    cff.append("\x00\x01\x01\x01\x05" "\xA2\x11\xA4\x10", 9);
+
+    // Empty String / Global Subrs / CharStrings INDEXes (each: count=0).
+    cff.append(scEmptyIndex, scEmptyIndexSize);
+    cff.append(scEmptyIndex, scEmptyIndexSize);
+    cff.append(scEmptyIndex, scEmptyIndexSize);
+
+    cff.append(inEncodingBytes, inEncodingLen);
+    return cff;
+}
+
+string CFFSyntheticBuilder::WithFDSelect(const char* inFDSelectBytes, size_t inFDSelectLen)
+{
+    string cff;
+    cff.append(scCFFHeader, scCFFHeaderSize);
+
+    // Name INDEX
+    cff.append("\x00\x01\x01\x01\x02\x41", 6);
+
+    // Top DICT INDEX: count=1, offSize=1, offsets=[1, 14], 13-byte top dict.
+    //   <int 32> 0x11           CharStrings @ 32 -> 0xAB
+    //   <int 38> 0x0C 0x24      FDArray     @ 38 -> 0xB1
+    //   <int 43> 0x0C 0x25      FDSelect    @ 43 -> 0xB6
+    //   0x8C 0x8C 0x8B 0x0C 0x1E   /ROS with SID 1, SID 1, supplement 0
+    cff.append("\x00\x01\x01\x01\x0E"
+               "\xAB\x11"
+               "\xB1\x0C\x24"
+               "\xB6\x0C\x25"
+               "\x8C\x8C\x8B\x0C\x1E", 18);
+
+    // Empty String / Global Subrs INDEXes
+    cff.append(scEmptyIndex, scEmptyIndexSize);
+    cff.append(scEmptyIndex, scEmptyIndexSize);
+
+    // CharStrings INDEX: count=1, offSize=1, offsets=[1, 2], data=0x0E (endchar)
+    cff.append("\x00\x01\x01\x01\x02\x0E", 6);
+
+    // FDArray INDEX: count=1, offSize=1, offsets=[1, 1] (single zero-length
+    // font dict — ReadDict returns empty dict, ReadPrivateDict treats missing
+    // /Private as start=end=0).
+    cff.append("\x00\x01\x01\x01\x01", 5);
+
+    cff.append(inFDSelectBytes, inFDSelectLen);
+    return cff;
+}
+
+EStatusCode CFFSyntheticBuilder::ParseAsCFF(const string& inCFFBytes, CFFFileInput& outCFF)
+{
+    // data() is well-defined for empty buffers; &str[0] would be UB pre-C++11.
+    InputByteArrayStream stream((Byte*)inCFFBytes.data(), (LongFilePositionType)inCFFBytes.size());
+    return outCFF.ReadCFFFile(&stream);
+}

--- a/PDFWriterTesting/CFFSyntheticBuilder.h
+++ b/PDFWriterTesting/CFFSyntheticBuilder.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "EStatusCode.h"
+
+#include <string>
+#include <stddef.h>
+
+class CFFFileInput;
+
+// Test-only helper for synthesizing minimal CFF byte streams in-process so
+// regression tests for CFFFileInput can run without binary fixtures. Each
+// builder produces a complete CFF up to the point where the caller-supplied
+// payload is appended; ParseAsCFF then drives ReadCFFFile against it.
+//
+// Pass byte literals through the CFF_BYTES macro so the length is derived from
+// sizeof(literal) - 1 and embedded \x00 bytes are preserved (sizeof on a
+// pointer would silently take the pointer width).
+class CFFSyntheticBuilder
+{
+public:
+    // Header (4) + caller-supplied bytes. Stops as soon as the caller's
+    // bytes exhaust — useful for malformed Name INDEX cases that fail before
+    // the parser reaches any later INDEX.
+    static std::string HeaderPlusBytes(const char* inBytes, size_t inLen);
+
+    // CFF up to the Global Subrs INDEX. The Top DICT body is caller-supplied
+    // (capped at 254 bytes so the index offset entry stays 1-byte). Useful
+    // for malformed Top-DICT operand-list tests where ReadCFFFile fails (or
+    // falls back to a default) before reaching CharStrings.
+    static std::string TopDictOnly(const char* inTopDictBytes, size_t inTopDictLen);
+
+    // Non-CID CFF whose Top DICT references both /CharStrings (key 17 -> empty
+    // CharStrings INDEX at offset 23) and /Encoding (key 16 -> caller payload
+    // at offset 25). ReadEncoding parses the caller's bytes against
+    // ReadCard8(format) and the format-0/1 readers.
+    static std::string WithEncoding(const char* inEncodingBytes, size_t inEncodingLen);
+
+    // CID CFF whose Top DICT references /ROS, /CharStrings (1-glyph INDEX at
+    // offset 32), /FDArray (1-entry INDEX at offset 38), and /FDSelect (caller
+    // payload at offset 43). glyphCount is 1 and fdArrayCount is 1, so the
+    // OOB primitives V-030 fixed are reachable with single-byte malformed
+    // fdIndex / nextRangeGlyphIndex values.
+    static std::string WithFDSelect(const char* inFDSelectBytes, size_t inFDSelectLen);
+
+    // ReadCFFFile shim wrapping the synthesized buffer in an
+    // InputByteArrayStream and returning the parser's status.
+    static PDFHummus::EStatusCode ParseAsCFF(const std::string& inCFFBytes, CFFFileInput& outCFF);
+};
+
+// Use only with string literals — sizeof on a pointer would silently take the
+// pointer width. Reused by case tables in tests so each entry stays one line.
+#define CFF_BYTES(literal) (literal), (sizeof(literal) - 1)

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -101,6 +101,7 @@ add_executable (PDFWriterTesting
     testing/WindowsPath.cpp
 
     # and test specific additionals
+    CFFSyntheticBuilder.cpp
     PDFComment.cpp
     PDFCommentWriter.cpp
     AnnotationsWriter.cpp


### PR DESCRIPTION
## Summary

Three CFF parser memory-safety bugs in the same file, fixed together because each touches the same `ReadEncoding` / `ReadFDSelect` region and adding V-030 + V-031's hardening surface made V-032 in-scope as defense-in-depth (caught by Copilot on the first review pass).

### V-030 — `ReadFDSelect` writes/reads OOB

- **Format 0**: each per-glyph `fdIndex` was used unchecked: `mFDSelect[i] = mFDArray + fdIndex`. A malicious `fdIndex` past the FDArray length stores a wild pointer that any later `PrepareForGlyphIntepretation` / `mFDSelect[gid]->mPrivateDict.mLocalSubrs` lookup dereferences.
- **Format 3**: the inner loop wrote `mFDSelect[j]` for `j ∈ [firstGlyphIndex, nextRangeGlyphIndex)` with no bound on `nextRangeGlyphIndex` vs. `glyphCount` — heap write past the end of `new FontDictInfo*[glyphCount]`.

Fix: `ReadFDArray` records the entry count in a new `TopDictInfo::mFDArrayCount`. `ReadFDSelect` rejects `fdIndex >= mFDArrayCount` (both formats) and rejects format-3 `nextRangeGlyphIndex` outside `(firstGlyphIndex, glyphCount]`.

### V-031 — `ReadEncoding` 8-bit overflow

`mEncodingsCount` and the second-pass `encodingIndex` were `Byte`. Format-1 sums each range's `left` field into the count; with 2 ranges of `left=255`, the sum (510) wrapped to 254. Allocator returned 254 bytes. Second-pass Byte `encodingIndex` then wrapped from 255 mid-write so subsequent ranges aliased the buffer start — heap overflow.

Fix: `mEncodingsCount` and `encodingIndex` widened to `unsigned short`; first pass accumulates into a 16-bit `totalCount`; totals exceeding the 256-code spec ceiling are rejected.

`CFFEmbeddedFontWriter::WriteEncodings` saturates the output `nCodes` at 255 (output field is `Card8`).

### V-032 — Supplements branch seeks to uninitialized offset (folded from review)

The `(encodingFormat & 0x80)` supplements branch did `SetOffset(inEncoding->mEncodingEnd)` before `mEncodingEnd` was ever assigned on the custom-encoding path. `EncodingsInfo`'s ctor only initialized `mEncoding`, so the field held uninitialized memory; the seek landed at an arbitrary offset, and subsequent `ReadCard8` / `ReadCard16` reads either failed the seek or interpreted unrelated bytes as supplement entries.

Fix: the supplements block is always parsed from the post-base-encoding cursor — which is exactly where the reader already sits — so the explicit seek is removed. `mEncodingEnd` is captured immediately before the supplements branch (and re-captured after) so the struct field stays meaningful for callers. The `EncodingsInfo` ctor now initializes every member as a defense-in-depth net.

## Test reorganization

The synthetic-CFF byte layouts that previously lived in `CFFFileInputTest.cpp` and `CFFIndexSanity.cpp` moved into a shared `CFFSyntheticBuilder` helper (sibling of the other test-specific helpers under `PDFWriterTesting/`) with four builders:

- `HeaderPlusBytes` — header + caller-supplied bytes (Name INDEX malformed cases)
- `TopDictOnly` — header + name + top-dict-index + empty string/gsubr
- `WithEncoding` — non-CID font; caller payload is the /Encoding bytes
- `WithFDSelect` — CID font with 1-glyph CharStrings + 1-entry FDArray; caller payload is the /FDSelect bytes

Both test files now drive their cases off labelled case-tables (`ParseFailureCase` / `CharStringsCountCase` / `NameIndexFailureCase`) so each malformed shape is one row and failure messages identify the case by shape + label.

`CFFFileInputTest` regression cases for this PR:

- Format-1 happy path — asserts decoded codes 0x40..0x44 and exact count.
- Format-1 range-sum overflow (V-031).
- Format-0 fdIndex overflow (V-030).
- Format-3 fdIndex overflow (V-030).
- Format-3 nextRangeGlyphIndex > glyphCount (V-030).
- **New** Format-0 with supplements happy path — asserts `mSupplements[SID 1] == [0x42]`. Pre-fix the uninit seek lands somewhere other than the supplement bytes, so the assertion catches V-032.

Stash + rerun against pre-fix sources confirmed every malformed-input case (and the supplements happy-path case) detects the bug.

## Test plan

- [x] `cmake --build build --config Release --target PDFWriterTesting`
- [x] `ctest --test-dir build -C Release` — all 93 tests pass
- [x] Stash production fixes, rerun `CFFFileInputTest` in accumulator mode — V-030/V-031/V-032 tests fail pre-fix as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)