### PR TITLE
fix: TrueType composite-glyph walker rejects cyclic dependencies (V-018)

### DIFF
--- a/PDFWriter/CMakeLists.txt
+++ b/PDFWriter/CMakeLists.txt
@@ -164,6 +164,7 @@ TrailerInformation.cpp
 TrueTypeANSIFontWriter.cpp
 TrueTypeDescendentFontWriter.cpp
 TrueTypeEmbeddedFontWriter.cpp
+TrueTypeGlyphDependencies.cpp
 TrueTypePrimitiveWriter.cpp
 Type1Input.cpp
 Type1PSTokens.cpp
@@ -375,6 +376,7 @@ TrailerInformation.h
 TrueTypeANSIFontWriter.h
 TrueTypeDescendentFontWriter.h
 TrueTypeEmbeddedFontWriter.h
+TrueTypeGlyphDependencies.h
 TrueTypePrimitiveWriter.h
 Type1Input.h
 Type1PSTokens.h

--- a/PDFWriter/TrueTypeEmbeddedFontWriter.cpp
+++ b/PDFWriter/TrueTypeEmbeddedFontWriter.cpp
@@ -27,6 +27,7 @@
 #include "OutputStreamTraits.h"
 #include "InputStringBufferStream.h"
 #include "OpenTypeFileInput.h"
+#include "TrueTypeGlyphDependencies.h"
 #include "FSType.h"
 
 #include <sstream>
@@ -298,7 +299,8 @@ void TrueTypeEmbeddedFontWriter::AddDependentGlyphs(UIntVector& ioSubsetGlyphIDs
 	bool hasCompositeGlyphs = false;
 
 	for(;it != ioSubsetGlyphIDs.end(); ++it)
-		hasCompositeGlyphs |= AddComponentGlyphs(*it,glyphsSet);
+		hasCompositeGlyphs |= TrueTypeGlyphDependencies::WalkComponents(
+			*it, mTrueTypeInput.mGlyf, mTrueTypeInput.mMaxp.NumGlyphs, glyphsSet);
 
 	if(hasCompositeGlyphs)
 	{
@@ -310,36 +312,9 @@ void TrueTypeEmbeddedFontWriter::AddDependentGlyphs(UIntVector& ioSubsetGlyphIDs
 		ioSubsetGlyphIDs.clear();
 		for(itNewGlyphs = glyphsSet.begin(); itNewGlyphs != glyphsSet.end(); ++itNewGlyphs)
 			ioSubsetGlyphIDs.push_back(*itNewGlyphs);
-		
+
 		sort(ioSubsetGlyphIDs.begin(),ioSubsetGlyphIDs.end());
 	}
-}
-
-bool TrueTypeEmbeddedFontWriter::AddComponentGlyphs(unsigned int inGlyphID,UIntSet& ioComponents)
-{
-	GlyphEntry* glyfTableEntry;
-	UIntList::iterator itComponentGlyphs;
-	bool isComposite = false;
-
-	if(inGlyphID >= mTrueTypeInput.mMaxp.NumGlyphs)
-	{
-		TRACE_LOG2("TrueTypeEmbeddedFontWriter::AddComponentGlyphs, error, requested glyph index %ld is larger than the maximum glyph index for this font which is %ld. ",inGlyphID,mTrueTypeInput.mMaxp.NumGlyphs-1);
-		return false;
-	}
-
-	glyfTableEntry = mTrueTypeInput.mGlyf[inGlyphID];
-	if(glyfTableEntry != NULL && glyfTableEntry->mComponentGlyphs.size() > 0)
-	{
-		isComposite = true;
-		for(itComponentGlyphs = glyfTableEntry->mComponentGlyphs.begin(); 
-				itComponentGlyphs != glyfTableEntry->mComponentGlyphs.end(); 
-				++itComponentGlyphs)
-		{
-				ioComponents.insert(*itComponentGlyphs);
-				AddComponentGlyphs(*itComponentGlyphs,ioComponents);
-		}
-	}
-	return isComposite;
 }
 
 unsigned short TrueTypeEmbeddedFontWriter::GetSmallerPower2(unsigned short inNumber)

--- a/PDFWriter/TrueTypeEmbeddedFontWriter.cpp
+++ b/PDFWriter/TrueTypeEmbeddedFontWriter.cpp
@@ -299,7 +299,7 @@ void TrueTypeEmbeddedFontWriter::AddDependentGlyphs(UIntVector& ioSubsetGlyphIDs
 	bool hasCompositeGlyphs = false;
 
 	for(;it != ioSubsetGlyphIDs.end(); ++it)
-		hasCompositeGlyphs |= TrueTypeGlyphDependencies::WalkComponents(
+		hasCompositeGlyphs |= TrueTypeGlyphDependencies::CollectComponentGlyphs(
 			*it, mTrueTypeInput.mGlyf, mTrueTypeInput.mMaxp.NumGlyphs, glyphsSet);
 
 	if(hasCompositeGlyphs)

--- a/PDFWriter/TrueTypeEmbeddedFontWriter.h
+++ b/PDFWriter/TrueTypeEmbeddedFontWriter.h
@@ -89,7 +89,6 @@ private:
 										MyStringBuf& outFontProgram);
 
 	void AddDependentGlyphs(UIntVector& ioSubsetGlyphIDs);
-	bool AddComponentGlyphs(unsigned int inGlyphID,UIntSet& ioComponents);
 
 	PDFHummus::EStatusCode WriteTrueTypeHeader();
 	unsigned short GetSmallerPower2(unsigned short inNumber);

--- a/PDFWriter/TrueTypeGlyphDependencies.cpp
+++ b/PDFWriter/TrueTypeGlyphDependencies.cpp
@@ -1,0 +1,54 @@
+/*
+   Source File : TrueTypeGlyphDependencies.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+*/
+#include "TrueTypeGlyphDependencies.h"
+
+#include "Trace.h"
+
+bool TrueTypeGlyphDependencies::WalkComponents(unsigned int inGlyphID,
+	GlyphEntry* const* inGlyfTable,
+	unsigned int inNumGlyphs,
+	UIntSet& ioComponents)
+{
+	if(inGlyphID >= inNumGlyphs)
+	{
+		TRACE_LOG2("TrueTypeGlyphDependencies::WalkComponents, error, requested glyph index %u is larger than the maximum glyph index for this font which is %u.",
+			inGlyphID, inNumGlyphs - 1);
+		return false;
+	}
+
+	GlyphEntry* glyfTableEntry = inGlyfTable[inGlyphID];
+	if(glyfTableEntry == NULL || glyfTableEntry->mComponentGlyphs.size() == 0)
+		return false;
+
+	UIntList::iterator itComponentGlyphs;
+	for(itComponentGlyphs = glyfTableEntry->mComponentGlyphs.begin();
+		itComponentGlyphs != glyfTableEntry->mComponentGlyphs.end();
+		++itComponentGlyphs)
+	{
+		// Recurse only when the component is new to the set. A glyph
+		// referencing itself or two glyphs referencing each other would
+		// otherwise drive the call stack until it overflows. The set
+		// doubles as the visited marker for cycle detection.
+		if(ioComponents.insert(*itComponentGlyphs).second)
+			WalkComponents(*itComponentGlyphs, inGlyfTable, inNumGlyphs, ioComponents);
+	}
+	return true;
+}

--- a/PDFWriter/TrueTypeGlyphDependencies.cpp
+++ b/PDFWriter/TrueTypeGlyphDependencies.cpp
@@ -22,15 +22,33 @@
 
 #include "Trace.h"
 
+// Recursion depth cap. Adobe's TrueType reference recommends max
+// composite depth of 16; we use that literal rather than the font-
+// supplied maxp.MaxComponentDepth because the latter is attacker-
+// controlled.
+static const unsigned int scMaxCompositeDepth = 16;
+
 bool TrueTypeGlyphDependencies::CollectComponentGlyphs(unsigned int inGlyphID,
 	GlyphEntry* const* inGlyfTable,
 	unsigned int inNumGlyphs,
-	UIntSet& ioComponents)
+	UIntSet& ioComponents,
+	unsigned int inDepth)
 {
 	if(inGlyphID >= inNumGlyphs)
 	{
-		TRACE_LOG2("TrueTypeGlyphDependencies::CollectComponentGlyphs, error, requested glyph index %u is larger than the maximum glyph index for this font which is %u.",
-			inGlyphID, inNumGlyphs - 1);
+		TRACE_LOG2("TrueTypeGlyphDependencies::CollectComponentGlyphs, error, requested glyph index %u is out of range for a font with %u glyphs.",
+			inGlyphID, inNumGlyphs);
+		return false;
+	}
+
+	if(inDepth > scMaxCompositeDepth)
+	{
+		// Cycles are blocked by the visited-set guard below, but a
+		// malicious font can still build a deeply nested acyclic chain.
+		// numGlyphs caps the visited set at 65535 entries, which is
+		// well past typical stack limits, so cap depth here too.
+		TRACE_LOG2("TrueTypeGlyphDependencies::CollectComponentGlyphs, composite depth %u exceeds cap %u, refusing to recurse further.",
+			inDepth, scMaxCompositeDepth);
 		return false;
 	}
 
@@ -48,7 +66,7 @@ bool TrueTypeGlyphDependencies::CollectComponentGlyphs(unsigned int inGlyphID,
 		// otherwise drive the call stack until it overflows. The set
 		// doubles as the visited marker for cycle detection.
 		if(ioComponents.insert(*itComponentGlyphs).second)
-			CollectComponentGlyphs(*itComponentGlyphs, inGlyfTable, inNumGlyphs, ioComponents);
+			CollectComponentGlyphs(*itComponentGlyphs, inGlyfTable, inNumGlyphs, ioComponents, inDepth + 1);
 	}
 	return true;
 }

--- a/PDFWriter/TrueTypeGlyphDependencies.cpp
+++ b/PDFWriter/TrueTypeGlyphDependencies.cpp
@@ -22,14 +22,14 @@
 
 #include "Trace.h"
 
-bool TrueTypeGlyphDependencies::WalkComponents(unsigned int inGlyphID,
+bool TrueTypeGlyphDependencies::CollectComponentGlyphs(unsigned int inGlyphID,
 	GlyphEntry* const* inGlyfTable,
 	unsigned int inNumGlyphs,
 	UIntSet& ioComponents)
 {
 	if(inGlyphID >= inNumGlyphs)
 	{
-		TRACE_LOG2("TrueTypeGlyphDependencies::WalkComponents, error, requested glyph index %u is larger than the maximum glyph index for this font which is %u.",
+		TRACE_LOG2("TrueTypeGlyphDependencies::CollectComponentGlyphs, error, requested glyph index %u is larger than the maximum glyph index for this font which is %u.",
 			inGlyphID, inNumGlyphs - 1);
 		return false;
 	}
@@ -48,7 +48,7 @@ bool TrueTypeGlyphDependencies::WalkComponents(unsigned int inGlyphID,
 		// otherwise drive the call stack until it overflows. The set
 		// doubles as the visited marker for cycle detection.
 		if(ioComponents.insert(*itComponentGlyphs).second)
-			WalkComponents(*itComponentGlyphs, inGlyfTable, inNumGlyphs, ioComponents);
+			CollectComponentGlyphs(*itComponentGlyphs, inGlyfTable, inNumGlyphs, ioComponents);
 	}
 	return true;
 }

--- a/PDFWriter/TrueTypeGlyphDependencies.h
+++ b/PDFWriter/TrueTypeGlyphDependencies.h
@@ -35,14 +35,23 @@ public:
 	// (and theirs, transitively) are. Returns true iff `inGlyphID` is
 	// itself composite (has any direct components).
 	//
-	// Recursion is guarded by the visited set: a component is recursed
-	// into only when it was newly inserted, so a self-reference or a
-	// cycle (glyph A -> B -> A) terminates instead of blowing the stack.
+	// Two recursion safeguards:
+	//   * Visited-set guard: a component is recursed into only when it
+	//     was newly inserted, so a self-reference or a cycle (glyph
+	//     A -> B -> A) terminates instead of blowing the stack.
+	//   * Depth cap: cuts off acyclic but very deep chains before they
+	//     overflow the call stack. NumGlyphs is uint16 (max 65535) and
+	//     a chain that long would still overflow typical stacks despite
+	//     the visited-set bound. The exact cap is a private detail of
+	//     the implementation.
 	//
 	// `inGlyfTable[i]` may be NULL for missing or zero-length glyphs.
 	// `inGlyphID >= inNumGlyphs` returns false without touching the set.
+	// `inDepth` is for internal recursion accounting — callers pass 0
+	// (the default).
 	static bool CollectComponentGlyphs(unsigned int inGlyphID,
 		GlyphEntry* const* inGlyfTable,
 		unsigned int inNumGlyphs,
-		UIntSet& ioComponents);
+		UIntSet& ioComponents,
+		unsigned int inDepth = 0);
 };

--- a/PDFWriter/TrueTypeGlyphDependencies.h
+++ b/PDFWriter/TrueTypeGlyphDependencies.h
@@ -1,0 +1,51 @@
+/*
+   Source File : TrueTypeGlyphDependencies.h
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+*/
+#pragma once
+
+#include "OpenTypeFileInput.h"
+
+#include <set>
+
+typedef std::set<unsigned int> UIntSet;
+
+// Stateless walker over the composite-glyph dependency graph extracted
+// from a TrueType `glyf` table. Pulled out of TrueTypeEmbeddedFontWriter
+// so the cycle-handling can be unit-tested without spinning up the full
+// embedded-font pipeline.
+class TrueTypeGlyphDependencies
+{
+public:
+	// Visit every transitive component referenced by `inGlyphID` and
+	// insert each into `ioComponents`. The initial glyph is NOT added;
+	// only its components (and theirs, transitively) are. Returns true
+	// iff `inGlyphID` is itself composite (has any direct components).
+	//
+	// Recursion is guarded by the visited set: a component is recursed
+	// into only when it was newly inserted, so a self-reference or a
+	// cycle (glyph A -> B -> A) terminates instead of blowing the stack.
+	//
+	// `inGlyfTable[i]` may be NULL for missing or zero-length glyphs.
+	// `inGlyphID >= inNumGlyphs` returns false without touching the set.
+	static bool WalkComponents(unsigned int inGlyphID,
+		GlyphEntry* const* inGlyfTable,
+		unsigned int inNumGlyphs,
+		UIntSet& ioComponents);
+};

--- a/PDFWriter/TrueTypeGlyphDependencies.h
+++ b/PDFWriter/TrueTypeGlyphDependencies.h
@@ -26,17 +26,14 @@
 
 typedef std::set<unsigned int> UIntSet;
 
-// Stateless walker over the composite-glyph dependency graph extracted
-// from a TrueType `glyf` table. Pulled out of TrueTypeEmbeddedFontWriter
-// so the cycle-handling can be unit-tested without spinning up the full
-// embedded-font pipeline.
+// Composite-glyph dependency utilities over a TrueType `glyf` table.
 class TrueTypeGlyphDependencies
 {
 public:
-	// Visit every transitive component referenced by `inGlyphID` and
-	// insert each into `ioComponents`. The initial glyph is NOT added;
-	// only its components (and theirs, transitively) are. Returns true
-	// iff `inGlyphID` is itself composite (has any direct components).
+	// Insert every transitive component referenced by `inGlyphID` into
+	// `ioComponents`. The initial glyph is NOT added; only its components
+	// (and theirs, transitively) are. Returns true iff `inGlyphID` is
+	// itself composite (has any direct components).
 	//
 	// Recursion is guarded by the visited set: a component is recursed
 	// into only when it was newly inserted, so a self-reference or a
@@ -44,7 +41,7 @@ public:
 	//
 	// `inGlyfTable[i]` may be NULL for missing or zero-length glyphs.
 	// `inGlyphID >= inNumGlyphs` returns false without touching the set.
-	static bool WalkComponents(unsigned int inGlyphID,
+	static bool CollectComponentGlyphs(unsigned int inGlyphID,
 		GlyphEntry* const* inGlyfTable,
 		unsigned int inNumGlyphs,
 		UIntSet& ioComponents);

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -79,6 +79,7 @@ create_test_sourcelist (Tests
   TiffSpecialsTest.cpp
   TimerTest.cpp
   TrueTypeAnsiWriteBug.cpp
+  TrueTypeGlyphDependenciesTest.cpp
   TrueTypeTest.cpp
   TTCTest.cpp
   Type1InputTest.cpp

--- a/PDFWriterTesting/TrueTypeGlyphDependenciesTest.cpp
+++ b/PDFWriterTesting/TrueTypeGlyphDependenciesTest.cpp
@@ -33,21 +33,28 @@
 #include "OpenTypeFileInput.h"
 #include "TrueTypeGlyphDependencies.h"
 
+#include <assert.h>
 #include <iostream>
 
 using namespace std;
 
 // Build a stack-only glyf table from caller-supplied component lists.
-// inComponents[i] is the list of component IDs for glyph i; pass NULL for
-// simple/zero-length glyphs. Stack-only construction (no new/delete) keeps
-// the tests obvious — every fixture lives in the test function frame.
+// Stack-only construction (no new/delete) keeps the tests obvious — every
+// fixture lives in the test function frame. Capacity is sized for the
+// deepest fixture (depth-cap test chain).
+static const unsigned int scStaticGlyfCapacity = 32;
+
 struct StaticGlyfTable {
-	GlyphEntry mEntries[8];
-	GlyphEntry* mTable[8];
+	GlyphEntry mEntries[scStaticGlyfCapacity];
+	GlyphEntry* mTable[scStaticGlyfCapacity];
 	unsigned int mNumGlyphs;
 };
 
 static void initGlyfTable(StaticGlyfTable& outTable, unsigned int inNumGlyphs) {
+	// Refuse silent OOB writes if a future test asks for more glyphs than
+	// the fixture's fixed-size arrays can hold. Bump scStaticGlyfCapacity
+	// rather than relying on this triggering at runtime.
+	assert(inNumGlyphs <= scStaticGlyfCapacity);
 	outTable.mNumGlyphs = inNumGlyphs;
 	for(unsigned int i = 0; i < inNumGlyphs; ++i)
 		outTable.mTable[i] = &outTable.mEntries[i];
@@ -188,7 +195,48 @@ static bool CollectComponentGlyphs_SimpleGlyph_ReturnsFalseAndLeavesSetEmpty() {
 	return true;
 }
 
-// Test 6: glyph ID at or beyond the table size returns false and leaves
+// Test 6: a long acyclic chain of composite glyphs must hit some depth
+// cap and stop, instead of recursing all the way down (which would
+// overflow the stack on a malicious font with thousands of nested
+// composites). Chain is sized comfortably longer than any reasonable
+// cap so the test doesn't break if the exact cap value is later tuned —
+// it just asserts that the tail of the chain wasn't reached.
+static bool CollectComponentGlyphs_DeepAcyclicChain_StopsBeforeChainEnd() {
+	const unsigned int chainLength = 30;             // > any plausible cap
+	const unsigned int numGlyphs = chainLength + 1;  // chain + glyph 0 (simple)
+
+	// Arrange: chain glyph 1 -> 2 -> ... -> chainLength.
+	StaticGlyfTable t;
+	initGlyfTable(t, numGlyphs);
+	for(unsigned int i = 1; i < chainLength; ++i)
+		t.mEntries[i].mComponentGlyphs.push_back(i + 1);
+	UIntSet result;
+
+	// Act
+	bool isComposite = TrueTypeGlyphDependencies::CollectComponentGlyphs(1, t.mTable, t.mNumGlyphs, result);
+
+	// Assert: the starting glyph is composite (so the walk did enter the
+	// chain), but the depth cap stopped descent before the tail was
+	// reached. Whatever the exact cap value is, glyph `chainLength`
+	// sits past it.
+	if(!isComposite) {
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::DeepAcyclicChain_StopsBeforeChainEnd]: expected composite, got simple" << endl;
+		return false;
+	}
+	if(result.find(chainLength) != result.end()) {
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::DeepAcyclicChain_StopsBeforeChainEnd]: tail glyph "
+		     << chainLength << " was reached despite depth cap" << endl;
+		return false;
+	}
+	if(result.size() >= chainLength - 1) {
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::DeepAcyclicChain_StopsBeforeChainEnd]: full chain (" << (chainLength - 1)
+		     << " components) was traversed; depth cap didn't fire" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Test 7: glyph ID at or beyond the table size returns false and leaves
 // the caller's set unchanged (this is the existing pre-V-018 guard, kept
 // as part of the contract).
 static bool CollectComponentGlyphs_GlyphIDBeyondTableSize_ReturnsFalse() {
@@ -213,11 +261,14 @@ static bool CollectComponentGlyphs_GlyphIDBeyondTableSize_ReturnsFalse() {
 }
 
 int TrueTypeGlyphDependenciesTest(int argc, char* argv[]) {
+	(void)argc;
+	(void)argv;
 	if(!CollectComponentGlyphs_SelfReferencingGlyph_TerminatesAndPopulatesSet()) return 1;
 	if(!CollectComponentGlyphs_TwoCycleGlyphs_TerminatesAndPopulatesSet()) return 1;
 	if(!CollectComponentGlyphs_LinearDependencyChain_GathersAllTransitive()) return 1;
 	if(!CollectComponentGlyphs_SharedComponentAcrossSiblings_DedupesViaVisitedSet()) return 1;
 	if(!CollectComponentGlyphs_SimpleGlyph_ReturnsFalseAndLeavesSetEmpty()) return 1;
+	if(!CollectComponentGlyphs_DeepAcyclicChain_StopsBeforeChainEnd()) return 1;
 	if(!CollectComponentGlyphs_GlyphIDBeyondTableSize_ReturnsFalse()) return 1;
 	return 0;
 }

--- a/PDFWriterTesting/TrueTypeGlyphDependenciesTest.cpp
+++ b/PDFWriterTesting/TrueTypeGlyphDependenciesTest.cpp
@@ -1,0 +1,223 @@
+/*
+   Source File : TrueTypeGlyphDependenciesTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression tests for TrueTypeGlyphDependencies::WalkComponents, the
+   composite-glyph dependency walker extracted from
+   TrueTypeEmbeddedFontWriter so its cycle handling can be tested without
+   a full font-embedding pipeline.
+
+   V-018: pre-fix the walker recursed on `mComponentGlyphs` without
+   tracking visited glyphs, so a malformed TrueType font with a
+   self-referencing composite glyph (or a 2-cycle) drove the call stack
+   until it overflowed. Same bug shape as the /Parent cycle bugs fixed
+   in PRs #346/#347/#348/#349 but on the font-subsetting side. Post-fix
+   the walker recurses only on first-seen components — the visited set
+   doubles as the dedup mechanism.
+*/
+#include "OpenTypeFileInput.h"
+#include "TrueTypeGlyphDependencies.h"
+
+#include <iostream>
+
+using namespace std;
+
+// Build a stack-only glyf table from caller-supplied component lists.
+// inComponents[i] is the list of component IDs for glyph i; pass NULL for
+// simple/zero-length glyphs. Stack-only construction (no new/delete) keeps
+// the tests obvious — every fixture lives in the test function frame.
+struct StaticGlyfTable {
+	GlyphEntry mEntries[8];
+	GlyphEntry* mTable[8];
+	unsigned int mNumGlyphs;
+};
+
+static void initGlyfTable(StaticGlyfTable& outTable, unsigned int inNumGlyphs) {
+	outTable.mNumGlyphs = inNumGlyphs;
+	for(unsigned int i = 0; i < inNumGlyphs; ++i)
+		outTable.mTable[i] = &outTable.mEntries[i];
+}
+
+// Test 1: glyph 1 references itself. Pre-fix the recursion descends into
+// glyph 1 forever; post-fix the second visit to glyph 1 is short-circuited
+// by the visited-set check.
+static bool WalkComponents_SelfReferencingGlyph_TerminatesAndPopulatesSet() {
+	// Arrange: 2 glyphs, glyph 0 simple, glyph 1 -> {1} (self).
+	StaticGlyfTable t;
+	initGlyfTable(t, 2);
+	t.mEntries[1].mComponentGlyphs.push_back(1);
+	UIntSet result;
+
+	// Act
+	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(1, t.mTable, t.mNumGlyphs, result);
+
+	// Assert
+	if(!isComposite) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SelfReferencingGlyph_TerminatesAndPopulatesSet]: expected composite, got simple" << endl;
+		return false;
+	}
+	if(result.size() != 1 || result.find(1) == result.end()) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SelfReferencingGlyph_TerminatesAndPopulatesSet]: expected {1}, got set of size "
+		     << result.size() << endl;
+		return false;
+	}
+	return true;
+}
+
+// Test 2: glyph 1 -> {2}, glyph 2 -> {1}. Pre-fix mutual recursion never
+// terminates; post-fix the back-edge to 1 is short-circuited.
+static bool WalkComponents_TwoCycleGlyphs_TerminatesAndPopulatesSet() {
+	// Arrange: 3 glyphs, glyph 0 simple, glyph 1 -> {2}, glyph 2 -> {1}.
+	StaticGlyfTable t;
+	initGlyfTable(t, 3);
+	t.mEntries[1].mComponentGlyphs.push_back(2);
+	t.mEntries[2].mComponentGlyphs.push_back(1);
+	UIntSet result;
+
+	// Act
+	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(1, t.mTable, t.mNumGlyphs, result);
+
+	// Assert
+	if(!isComposite) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::TwoCycleGlyphs_TerminatesAndPopulatesSet]: expected composite, got simple" << endl;
+		return false;
+	}
+	if(result.size() != 2 || result.find(1) == result.end() || result.find(2) == result.end()) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::TwoCycleGlyphs_TerminatesAndPopulatesSet]: expected {1, 2}, got set of size "
+		     << result.size() << endl;
+		return false;
+	}
+	return true;
+}
+
+// Test 3 (happy path): glyph 1 -> {2}, glyph 2 -> {3}, glyph 3 simple.
+// Proves the visited-set guard didn't accidentally drop the normal
+// transitive-component case (where every component IS new on first visit).
+static bool WalkComponents_LinearDependencyChain_GathersAllTransitive() {
+	// Arrange: 4 glyphs, 0 simple, 1 -> {2}, 2 -> {3}, 3 simple.
+	StaticGlyfTable t;
+	initGlyfTable(t, 4);
+	t.mEntries[1].mComponentGlyphs.push_back(2);
+	t.mEntries[2].mComponentGlyphs.push_back(3);
+	UIntSet result;
+
+	// Act
+	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(1, t.mTable, t.mNumGlyphs, result);
+
+	// Assert
+	if(!isComposite) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::LinearDependencyChain_GathersAllTransitive]: expected composite, got simple" << endl;
+		return false;
+	}
+	if(result.size() != 2 || result.find(2) == result.end() || result.find(3) == result.end()) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::LinearDependencyChain_GathersAllTransitive]: expected {2, 3}, got set of size "
+		     << result.size() << endl;
+		return false;
+	}
+	return true;
+}
+
+// Test 4 (happy path): glyph 1 -> {2, 3}, where both 2 and 3 reference
+// glyph 4. The dedup property of the visited set means glyph 4 should
+// appear once even though two siblings independently depend on it.
+static bool WalkComponents_SharedComponentAcrossSiblings_DedupesViaVisitedSet() {
+	// Arrange: 5 glyphs, 0 simple, 1 -> {2, 3}, 2 -> {4}, 3 -> {4}, 4 simple.
+	StaticGlyfTable t;
+	initGlyfTable(t, 5);
+	t.mEntries[1].mComponentGlyphs.push_back(2);
+	t.mEntries[1].mComponentGlyphs.push_back(3);
+	t.mEntries[2].mComponentGlyphs.push_back(4);
+	t.mEntries[3].mComponentGlyphs.push_back(4);
+	UIntSet result;
+
+	// Act
+	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(1, t.mTable, t.mNumGlyphs, result);
+
+	// Assert
+	if(!isComposite) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SharedComponentAcrossSiblings_DedupesViaVisitedSet]: expected composite, got simple" << endl;
+		return false;
+	}
+	if(result.size() != 3
+	   || result.find(2) == result.end()
+	   || result.find(3) == result.end()
+	   || result.find(4) == result.end()) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SharedComponentAcrossSiblings_DedupesViaVisitedSet]: expected {2, 3, 4}, got set of size "
+		     << result.size() << endl;
+		return false;
+	}
+	return true;
+}
+
+// Test 5: simple glyph (no components) returns false and leaves the
+// caller's set unchanged.
+static bool WalkComponents_SimpleGlyph_ReturnsFalseAndLeavesSetEmpty() {
+	// Arrange: 2 glyphs, both simple.
+	StaticGlyfTable t;
+	initGlyfTable(t, 2);
+	UIntSet result;
+
+	// Act
+	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(0, t.mTable, t.mNumGlyphs, result);
+
+	// Assert
+	if(isComposite) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SimpleGlyph_ReturnsFalseAndLeavesSetEmpty]: expected simple, got composite" << endl;
+		return false;
+	}
+	if(!result.empty()) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SimpleGlyph_ReturnsFalseAndLeavesSetEmpty]: expected empty set, got size "
+		     << result.size() << endl;
+		return false;
+	}
+	return true;
+}
+
+// Test 6: glyph ID at or beyond the table size returns false and leaves
+// the caller's set unchanged (this is the existing pre-V-018 guard, kept
+// as part of the contract).
+static bool WalkComponents_GlyphIDBeyondTableSize_ReturnsFalse() {
+	// Arrange: 2 glyphs, both simple.
+	StaticGlyfTable t;
+	initGlyfTable(t, 2);
+	UIntSet result;
+
+	// Act: ask for glyph 5 (table only holds 0..1).
+	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(5, t.mTable, t.mNumGlyphs, result);
+
+	// Assert
+	if(isComposite) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::GlyphIDBeyondTableSize_ReturnsFalse]: out-of-range glyph reported composite" << endl;
+		return false;
+	}
+	if(!result.empty()) {
+		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::GlyphIDBeyondTableSize_ReturnsFalse]: out-of-range glyph populated set" << endl;
+		return false;
+	}
+	return true;
+}
+
+int TrueTypeGlyphDependenciesTest(int argc, char* argv[]) {
+	if(!WalkComponents_SelfReferencingGlyph_TerminatesAndPopulatesSet()) return 1;
+	if(!WalkComponents_TwoCycleGlyphs_TerminatesAndPopulatesSet()) return 1;
+	if(!WalkComponents_LinearDependencyChain_GathersAllTransitive()) return 1;
+	if(!WalkComponents_SharedComponentAcrossSiblings_DedupesViaVisitedSet()) return 1;
+	if(!WalkComponents_SimpleGlyph_ReturnsFalseAndLeavesSetEmpty()) return 1;
+	if(!WalkComponents_GlyphIDBeyondTableSize_ReturnsFalse()) return 1;
+	return 0;
+}

--- a/PDFWriterTesting/TrueTypeGlyphDependenciesTest.cpp
+++ b/PDFWriterTesting/TrueTypeGlyphDependenciesTest.cpp
@@ -17,7 +17,7 @@
    limitations under the License.
 
 
-   Regression tests for TrueTypeGlyphDependencies::WalkComponents, the
+   Regression tests for TrueTypeGlyphDependencies::CollectComponentGlyphs, the
    composite-glyph dependency walker extracted from
    TrueTypeEmbeddedFontWriter so its cycle handling can be tested without
    a full font-embedding pipeline.
@@ -56,7 +56,7 @@ static void initGlyfTable(StaticGlyfTable& outTable, unsigned int inNumGlyphs) {
 // Test 1: glyph 1 references itself. Pre-fix the recursion descends into
 // glyph 1 forever; post-fix the second visit to glyph 1 is short-circuited
 // by the visited-set check.
-static bool WalkComponents_SelfReferencingGlyph_TerminatesAndPopulatesSet() {
+static bool CollectComponentGlyphs_SelfReferencingGlyph_TerminatesAndPopulatesSet() {
 	// Arrange: 2 glyphs, glyph 0 simple, glyph 1 -> {1} (self).
 	StaticGlyfTable t;
 	initGlyfTable(t, 2);
@@ -64,15 +64,15 @@ static bool WalkComponents_SelfReferencingGlyph_TerminatesAndPopulatesSet() {
 	UIntSet result;
 
 	// Act
-	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(1, t.mTable, t.mNumGlyphs, result);
+	bool isComposite = TrueTypeGlyphDependencies::CollectComponentGlyphs(1, t.mTable, t.mNumGlyphs, result);
 
 	// Assert
 	if(!isComposite) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SelfReferencingGlyph_TerminatesAndPopulatesSet]: expected composite, got simple" << endl;
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::SelfReferencingGlyph_TerminatesAndPopulatesSet]: expected composite, got simple" << endl;
 		return false;
 	}
 	if(result.size() != 1 || result.find(1) == result.end()) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SelfReferencingGlyph_TerminatesAndPopulatesSet]: expected {1}, got set of size "
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::SelfReferencingGlyph_TerminatesAndPopulatesSet]: expected {1}, got set of size "
 		     << result.size() << endl;
 		return false;
 	}
@@ -81,7 +81,7 @@ static bool WalkComponents_SelfReferencingGlyph_TerminatesAndPopulatesSet() {
 
 // Test 2: glyph 1 -> {2}, glyph 2 -> {1}. Pre-fix mutual recursion never
 // terminates; post-fix the back-edge to 1 is short-circuited.
-static bool WalkComponents_TwoCycleGlyphs_TerminatesAndPopulatesSet() {
+static bool CollectComponentGlyphs_TwoCycleGlyphs_TerminatesAndPopulatesSet() {
 	// Arrange: 3 glyphs, glyph 0 simple, glyph 1 -> {2}, glyph 2 -> {1}.
 	StaticGlyfTable t;
 	initGlyfTable(t, 3);
@@ -90,15 +90,15 @@ static bool WalkComponents_TwoCycleGlyphs_TerminatesAndPopulatesSet() {
 	UIntSet result;
 
 	// Act
-	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(1, t.mTable, t.mNumGlyphs, result);
+	bool isComposite = TrueTypeGlyphDependencies::CollectComponentGlyphs(1, t.mTable, t.mNumGlyphs, result);
 
 	// Assert
 	if(!isComposite) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::TwoCycleGlyphs_TerminatesAndPopulatesSet]: expected composite, got simple" << endl;
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::TwoCycleGlyphs_TerminatesAndPopulatesSet]: expected composite, got simple" << endl;
 		return false;
 	}
 	if(result.size() != 2 || result.find(1) == result.end() || result.find(2) == result.end()) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::TwoCycleGlyphs_TerminatesAndPopulatesSet]: expected {1, 2}, got set of size "
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::TwoCycleGlyphs_TerminatesAndPopulatesSet]: expected {1, 2}, got set of size "
 		     << result.size() << endl;
 		return false;
 	}
@@ -108,7 +108,7 @@ static bool WalkComponents_TwoCycleGlyphs_TerminatesAndPopulatesSet() {
 // Test 3 (happy path): glyph 1 -> {2}, glyph 2 -> {3}, glyph 3 simple.
 // Proves the visited-set guard didn't accidentally drop the normal
 // transitive-component case (where every component IS new on first visit).
-static bool WalkComponents_LinearDependencyChain_GathersAllTransitive() {
+static bool CollectComponentGlyphs_LinearDependencyChain_GathersAllTransitive() {
 	// Arrange: 4 glyphs, 0 simple, 1 -> {2}, 2 -> {3}, 3 simple.
 	StaticGlyfTable t;
 	initGlyfTable(t, 4);
@@ -117,15 +117,15 @@ static bool WalkComponents_LinearDependencyChain_GathersAllTransitive() {
 	UIntSet result;
 
 	// Act
-	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(1, t.mTable, t.mNumGlyphs, result);
+	bool isComposite = TrueTypeGlyphDependencies::CollectComponentGlyphs(1, t.mTable, t.mNumGlyphs, result);
 
 	// Assert
 	if(!isComposite) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::LinearDependencyChain_GathersAllTransitive]: expected composite, got simple" << endl;
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::LinearDependencyChain_GathersAllTransitive]: expected composite, got simple" << endl;
 		return false;
 	}
 	if(result.size() != 2 || result.find(2) == result.end() || result.find(3) == result.end()) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::LinearDependencyChain_GathersAllTransitive]: expected {2, 3}, got set of size "
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::LinearDependencyChain_GathersAllTransitive]: expected {2, 3}, got set of size "
 		     << result.size() << endl;
 		return false;
 	}
@@ -135,7 +135,7 @@ static bool WalkComponents_LinearDependencyChain_GathersAllTransitive() {
 // Test 4 (happy path): glyph 1 -> {2, 3}, where both 2 and 3 reference
 // glyph 4. The dedup property of the visited set means glyph 4 should
 // appear once even though two siblings independently depend on it.
-static bool WalkComponents_SharedComponentAcrossSiblings_DedupesViaVisitedSet() {
+static bool CollectComponentGlyphs_SharedComponentAcrossSiblings_DedupesViaVisitedSet() {
 	// Arrange: 5 glyphs, 0 simple, 1 -> {2, 3}, 2 -> {4}, 3 -> {4}, 4 simple.
 	StaticGlyfTable t;
 	initGlyfTable(t, 5);
@@ -146,18 +146,18 @@ static bool WalkComponents_SharedComponentAcrossSiblings_DedupesViaVisitedSet() 
 	UIntSet result;
 
 	// Act
-	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(1, t.mTable, t.mNumGlyphs, result);
+	bool isComposite = TrueTypeGlyphDependencies::CollectComponentGlyphs(1, t.mTable, t.mNumGlyphs, result);
 
 	// Assert
 	if(!isComposite) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SharedComponentAcrossSiblings_DedupesViaVisitedSet]: expected composite, got simple" << endl;
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::SharedComponentAcrossSiblings_DedupesViaVisitedSet]: expected composite, got simple" << endl;
 		return false;
 	}
 	if(result.size() != 3
 	   || result.find(2) == result.end()
 	   || result.find(3) == result.end()
 	   || result.find(4) == result.end()) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SharedComponentAcrossSiblings_DedupesViaVisitedSet]: expected {2, 3, 4}, got set of size "
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::SharedComponentAcrossSiblings_DedupesViaVisitedSet]: expected {2, 3, 4}, got set of size "
 		     << result.size() << endl;
 		return false;
 	}
@@ -166,22 +166,22 @@ static bool WalkComponents_SharedComponentAcrossSiblings_DedupesViaVisitedSet() 
 
 // Test 5: simple glyph (no components) returns false and leaves the
 // caller's set unchanged.
-static bool WalkComponents_SimpleGlyph_ReturnsFalseAndLeavesSetEmpty() {
+static bool CollectComponentGlyphs_SimpleGlyph_ReturnsFalseAndLeavesSetEmpty() {
 	// Arrange: 2 glyphs, both simple.
 	StaticGlyfTable t;
 	initGlyfTable(t, 2);
 	UIntSet result;
 
 	// Act
-	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(0, t.mTable, t.mNumGlyphs, result);
+	bool isComposite = TrueTypeGlyphDependencies::CollectComponentGlyphs(0, t.mTable, t.mNumGlyphs, result);
 
 	// Assert
 	if(isComposite) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SimpleGlyph_ReturnsFalseAndLeavesSetEmpty]: expected simple, got composite" << endl;
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::SimpleGlyph_ReturnsFalseAndLeavesSetEmpty]: expected simple, got composite" << endl;
 		return false;
 	}
 	if(!result.empty()) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::SimpleGlyph_ReturnsFalseAndLeavesSetEmpty]: expected empty set, got size "
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::SimpleGlyph_ReturnsFalseAndLeavesSetEmpty]: expected empty set, got size "
 		     << result.size() << endl;
 		return false;
 	}
@@ -191,33 +191,33 @@ static bool WalkComponents_SimpleGlyph_ReturnsFalseAndLeavesSetEmpty() {
 // Test 6: glyph ID at or beyond the table size returns false and leaves
 // the caller's set unchanged (this is the existing pre-V-018 guard, kept
 // as part of the contract).
-static bool WalkComponents_GlyphIDBeyondTableSize_ReturnsFalse() {
+static bool CollectComponentGlyphs_GlyphIDBeyondTableSize_ReturnsFalse() {
 	// Arrange: 2 glyphs, both simple.
 	StaticGlyfTable t;
 	initGlyfTable(t, 2);
 	UIntSet result;
 
 	// Act: ask for glyph 5 (table only holds 0..1).
-	bool isComposite = TrueTypeGlyphDependencies::WalkComponents(5, t.mTable, t.mNumGlyphs, result);
+	bool isComposite = TrueTypeGlyphDependencies::CollectComponentGlyphs(5, t.mTable, t.mNumGlyphs, result);
 
 	// Assert
 	if(isComposite) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::GlyphIDBeyondTableSize_ReturnsFalse]: out-of-range glyph reported composite" << endl;
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::GlyphIDBeyondTableSize_ReturnsFalse]: out-of-range glyph reported composite" << endl;
 		return false;
 	}
 	if(!result.empty()) {
-		cout << "TrueTypeGlyphDependenciesTest [WalkComponents::GlyphIDBeyondTableSize_ReturnsFalse]: out-of-range glyph populated set" << endl;
+		cout << "TrueTypeGlyphDependenciesTest [CollectComponentGlyphs::GlyphIDBeyondTableSize_ReturnsFalse]: out-of-range glyph populated set" << endl;
 		return false;
 	}
 	return true;
 }
 
 int TrueTypeGlyphDependenciesTest(int argc, char* argv[]) {
-	if(!WalkComponents_SelfReferencingGlyph_TerminatesAndPopulatesSet()) return 1;
-	if(!WalkComponents_TwoCycleGlyphs_TerminatesAndPopulatesSet()) return 1;
-	if(!WalkComponents_LinearDependencyChain_GathersAllTransitive()) return 1;
-	if(!WalkComponents_SharedComponentAcrossSiblings_DedupesViaVisitedSet()) return 1;
-	if(!WalkComponents_SimpleGlyph_ReturnsFalseAndLeavesSetEmpty()) return 1;
-	if(!WalkComponents_GlyphIDBeyondTableSize_ReturnsFalse()) return 1;
+	if(!CollectComponentGlyphs_SelfReferencingGlyph_TerminatesAndPopulatesSet()) return 1;
+	if(!CollectComponentGlyphs_TwoCycleGlyphs_TerminatesAndPopulatesSet()) return 1;
+	if(!CollectComponentGlyphs_LinearDependencyChain_GathersAllTransitive()) return 1;
+	if(!CollectComponentGlyphs_SharedComponentAcrossSiblings_DedupesViaVisitedSet()) return 1;
+	if(!CollectComponentGlyphs_SimpleGlyph_ReturnsFalseAndLeavesSetEmpty()) return 1;
+	if(!CollectComponentGlyphs_GlyphIDBeyondTableSize_ReturnsFalse()) return 1;
 	return 0;
 }


### PR DESCRIPTION
## Summary

`TrueTypeEmbeddedFontWriter::AddComponentGlyphs` recursed on each `GlyphEntry`'s `mComponentGlyphs` list without tracking which glyphs had already been visited. A malformed TrueType font with a self-referencing composite glyph (or a 2-cycle: glyph A references B, B references A) drove the call stack until it overflowed during font subsetting — reachable from any TrueType embedding path. Same bug shape as the `/Parent` cycle bugs fixed in PRs #346/#347/#348/#349 but on the font-subsetting side.

## Fix

Extracted the walk into a stateless `TrueTypeGlyphDependencies` helper class with a single static `CollectComponentGlyphs` method (per the project's "no friend classes; extract instead" convention — same shape as the `Type1PSTokens` extraction from PR #359). The class method `TrueTypeEmbeddedFontWriter::AddComponentGlyphs` is deleted; `AddDependentGlyphs` now calls `CollectComponentGlyphs` directly.

`CollectComponentGlyphs` recurses only when `ioComponents.insert(*it).second` is true — the visited set doubles as the dedup mechanism, so it also avoids redundant work on shared sub-components.

## Tests

`PDFWriterTesting/TrueTypeGlyphDependenciesTest.cpp` drives `CollectComponentGlyphs` with stack-built `GlyphEntry` arrays — no font fixtures required:

- `CollectComponentGlyphs_SelfReferencingGlyph_TerminatesAndPopulatesSet` — V-018 trigger (self-cycle)
- `CollectComponentGlyphs_TwoCycleGlyphs_TerminatesAndPopulatesSet` — V-018 trigger (2-cycle)
- `CollectComponentGlyphs_LinearDependencyChain_GathersAllTransitive` — happy path
- `CollectComponentGlyphs_SharedComponentAcrossSiblings_DedupesViaVisitedSet` — happy path proving the dedup property
- `CollectComponentGlyphs_SimpleGlyph_ReturnsFalseAndLeavesSetEmpty`
- `CollectComponentGlyphs_GlyphIDBeyondTableSize_ReturnsFalse` — preserves the existing pre-V-018 out-of-range guard

Pre-fix verification: temporarily reverted `CollectComponentGlyphs` to the old unguarded-recursion shape; the self-cycle case **segfaulted on stack overflow** before reaching the assertion (`***Exception: SegFault`). Post-fix all 95 tests pass.

## Note for follow-up

`CFFEmbeddedFontWriter::AddComponentGlyphs` and `Type1ToCFFEmbeddedFontWriter::AddComponentGlyphs` have the same unguarded-recursion shape on a different dependency container (CharString dependencies, not `mComponentGlyphs`). They're not flagged in FINDINGS.md, so I'm leaving them for a separate finding / PR rather than expanding scope here. Worth a look during the next CFF sweep.

## Test plan

- [x] `cmake --build build --config Release --target PDFWriterTesting`
- [x] `ctest --test-dir build -C Release` — 95/95 tests pass
- [x] Pre-fix verification: temporarily reverted to unguarded recursion, confirmed self-cycle segfault before assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)