### PR TITLE
fix: FreeType wrapper return-code handling (V-076/077/078/082/083)

### DIFF
--- a/PDFWriter/FreeTypeFaceWrapper.cpp
+++ b/PDFWriter/FreeTypeFaceWrapper.cpp
@@ -68,8 +68,6 @@ void FreeTypeFaceWrapper::ResetPaletteSelectionState() {
 	mPaletteSet = false;
 	mPalette = NULL;
 	mPaletteStatus = FT_Err_Ok;
-	// FT_Palette_Data_Get leaves mPaletteData untouched on failure; zero it so
-	// num_palette_entries is a deterministic 0 rather than an uninitialized read
 	mPaletteData = FT_Palette_Data();
 }
 
@@ -581,10 +579,8 @@ std::string FreeTypeFaceWrapper::GetGlyphName(unsigned int inGlyphIndex, bool sa
     {
         if(inGlyphIndex < (unsigned int)mFace->num_glyphs)
         {
-            // FT_Get_Glyph_Name does not guarantee buffer is written or NUL-
-            // terminated on failure (e.g. no post table / post format 3 /
-            // CFF/color fonts); zero-init and fall back to .notdef on error
-            // so an uninitialized stack buffer is never leaked into the PDF
+            // FT_Get_Glyph_Name may leave buffer unwritten or not NUL-terminated
+            // when the font carries no usable glyph names (e.g. post format 3)
             char buffer[100] = {0};
             if(FT_Get_Glyph_Name(mFace,inGlyphIndex,buffer,100) != FT_Err_Ok || buffer[0] == 0)
                 return NotDefGlyphName();
@@ -752,10 +748,8 @@ bool FreeTypeFaceWrapper::GetGlyphOutline(unsigned int inGlyphIndex, FreeTypeFac
 	if ( !(mFace->face_flags & FT_FACE_FLAG_TRICKY) ) //scaled-font implementation would be needed for 'tricky' fonts
 	{
 		if (!LoadGlyph(inGlyphIndex)) {
-			// glyph->format reflects whichever glyph was last loaded into the
-			// face's shared slot, so it is only meaningful after LoadGlyph -
-			// testing it earlier would gate on a stale (or never-set) format
-			// and could feed non-outline slot bytes to FT_Outline_Decompose
+			// glyph->format is the format of the glyph in the face's shared
+			// slot, so it must be read after the glyph is loaded
 			if (mFace->glyph->format == FT_GLYPH_FORMAT_OUTLINE) {
 				FT_Outline_Funcs callbacks = { IOutlineEnumerator::outline_moveto,
 				                               IOutlineEnumerator::outline_lineto,
@@ -790,21 +784,13 @@ FT_Error FreeTypeFaceWrapper::LoadGlyph(FT_UInt inGlyphIndex, FT_Int32 inFlags)
 
 FT_Error FreeTypeFaceWrapper::SelectDefaultPalette(FT_Color** outPalette, unsigned short* outPaletteSize) {
 	if(!mPaletteSet) {
-		// FT_Palette_Data_Get / FT_Palette_Select return FT_Error: 0 (FT_Err_Ok)
-		// on success, nonzero on failure. A failing call leaves its output
-		// untouched, so any single failure makes the palette state unusable and
-		// must be treated as total failure (propagating the first error code).
-		FT_Error errDataGet = FT_Palette_Data_Get(mFace, &mPaletteData);
-		FT_Error errSelect = FT_Palette_Select(mFace, 0, &mPalette);
-
-		if(errDataGet != FT_Err_Ok)
-			mPaletteStatus = errDataGet;
-		else if(errSelect != FT_Err_Ok)
-			mPaletteStatus = errSelect;
-		else
-			mPaletteStatus = FT_Err_Ok;
-
 		mPaletteSet = true;
+		do {
+			mPaletteStatus = FT_Palette_Data_Get(mFace, &mPaletteData);
+			if(mPaletteStatus != FT_Err_Ok)
+				break;
+			mPaletteStatus = FT_Palette_Select(mFace, 0, &mPalette);
+		} while(false);
 	}
 
 	if(mPaletteStatus != FT_Err_Ok) {

--- a/PDFWriter/FreeTypeFaceWrapper.cpp
+++ b/PDFWriter/FreeTypeFaceWrapper.cpp
@@ -68,6 +68,9 @@ void FreeTypeFaceWrapper::ResetPaletteSelectionState() {
 	mPaletteSet = false;
 	mPalette = NULL;
 	mPaletteStatus = FT_Err_Ok;
+	// FT_Palette_Data_Get leaves mPaletteData untouched on failure; zero it so
+	// num_palette_entries is a deterministic 0 rather than an uninitialized read
+	mPaletteData = FT_Palette_Data();
 }
 
 void FreeTypeFaceWrapper::SelectDefaultEncoding() {
@@ -578,8 +581,13 @@ std::string FreeTypeFaceWrapper::GetGlyphName(unsigned int inGlyphIndex, bool sa
     {
         if(inGlyphIndex < (unsigned int)mFace->num_glyphs)
         {
-            char buffer[100];
-            FT_Get_Glyph_Name(mFace,inGlyphIndex,buffer,100);
+            // FT_Get_Glyph_Name does not guarantee buffer is written or NUL-
+            // terminated on failure (e.g. no post table / post format 3 /
+            // CFF/color fonts); zero-init and fall back to .notdef on error
+            // so an uninitialized stack buffer is never leaked into the PDF
+            char buffer[100] = {0};
+            if(FT_Get_Glyph_Name(mFace,inGlyphIndex,buffer,100) != FT_Err_Ok || buffer[0] == 0)
+                return NotDefGlyphName();
             return std::string(buffer);
         }
         else
@@ -741,18 +749,23 @@ unsigned int FreeTypeFaceWrapper::GetGlyphIndexInFreeTypeIndexes(unsigned int in
 bool FreeTypeFaceWrapper::GetGlyphOutline(unsigned int inGlyphIndex, FreeTypeFaceWrapper::IOutlineEnumerator& inEnumerator)
 {
 	bool status = false;
-	if ( mFace->glyph->format == FT_GLYPH_FORMAT_OUTLINE && !(mFace->face_flags & FT_FACE_FLAG_TRICKY) ) //scaled-font implementation would be needed for 'tricky' fonts
+	if ( !(mFace->face_flags & FT_FACE_FLAG_TRICKY) ) //scaled-font implementation would be needed for 'tricky' fonts
 	{
 		if (!LoadGlyph(inGlyphIndex)) {
-			FT_Outline_Funcs callbacks = { IOutlineEnumerator::outline_moveto,
-			                               IOutlineEnumerator::outline_lineto,
-										   IOutlineEnumerator::outline_conicto,
-										   IOutlineEnumerator::outline_cubicto,
-										   0, 0 }; //0 shift & delta
-			inEnumerator.FTBegin(mFace->units_per_EM);
-			status = ( 0 == FT_Outline_Decompose(&mFace->glyph->outline, &callbacks, &inEnumerator) );
-			inEnumerator.FTEnd();
-			status = true;
+			// glyph->format reflects whichever glyph was last loaded into the
+			// face's shared slot, so it is only meaningful after LoadGlyph -
+			// testing it earlier would gate on a stale (or never-set) format
+			// and could feed non-outline slot bytes to FT_Outline_Decompose
+			if (mFace->glyph->format == FT_GLYPH_FORMAT_OUTLINE) {
+				FT_Outline_Funcs callbacks = { IOutlineEnumerator::outline_moveto,
+				                               IOutlineEnumerator::outline_lineto,
+											   IOutlineEnumerator::outline_conicto,
+											   IOutlineEnumerator::outline_cubicto,
+											   0, 0 }; //0 shift & delta
+				inEnumerator.FTBegin(mFace->units_per_EM);
+				status = ( 0 == FT_Outline_Decompose(&mFace->glyph->outline, &callbacks, &inEnumerator) );
+				inEnumerator.FTEnd();
+			}
 		}
 	}
 	return status;
@@ -777,16 +790,31 @@ FT_Error FreeTypeFaceWrapper::LoadGlyph(FT_UInt inGlyphIndex, FT_Int32 inFlags)
 
 FT_Error FreeTypeFaceWrapper::SelectDefaultPalette(FT_Color** outPalette, unsigned short* outPaletteSize) {
 	if(!mPaletteSet) {
-		bool statusDataGet = FT_Palette_Data_Get(mFace, &mPaletteData);
-		bool statusSelect = FT_Palette_Select( mFace, 0, &mPalette);
+		// FT_Palette_Data_Get / FT_Palette_Select return FT_Error: 0 (FT_Err_Ok)
+		// on success, nonzero on failure. A failing call leaves its output
+		// untouched, so any single failure makes the palette state unusable and
+		// must be treated as total failure (propagating the first error code).
+		FT_Error errDataGet = FT_Palette_Data_Get(mFace, &mPaletteData);
+		FT_Error errSelect = FT_Palette_Select(mFace, 0, &mPalette);
 
-		mPaletteStatus = statusDataGet && statusSelect;
+		if(errDataGet != FT_Err_Ok)
+			mPaletteStatus = errDataGet;
+		else if(errSelect != FT_Err_Ok)
+			mPaletteStatus = errSelect;
+		else
+			mPaletteStatus = FT_Err_Ok;
 
-		mPaletteSet = true;		
+		mPaletteSet = true;
 	}
 
-	*outPalette = mPalette;
-	*outPaletteSize = mPaletteData.num_palette_entries;
+	if(mPaletteStatus != FT_Err_Ok) {
+		*outPalette = NULL;
+		*outPaletteSize = 0;
+	}
+	else {
+		*outPalette = mPalette;
+		*outPaletteSize = mPaletteData.num_palette_entries;
+	}
 	return mPaletteStatus;
 }
 

--- a/PDFWriter/FreeTypeType1Wrapper.cpp
+++ b/PDFWriter/FreeTypeType1Wrapper.cpp
@@ -43,13 +43,11 @@ FreeTypeType1Wrapper::FreeTypeType1Wrapper(FT_Face inFace,const std::string& inF
 	else
 		mPSPrivateAvailable = true;
     
-    // FT_Get_PS_Font_Value returns the number of bytes read (<= 0 on error) and
-    // does not guarantee encodingType is written on failure. Default to NONE so
-    // a failed read does not route glyph lookups through the private Type1 path.
+    // FT_Get_PS_Font_Value returns the byte count read, <= 0 on error, and need
+    // not write encodingType when it fails
     T1_EncodingType encodingType = T1_ENCODING_TYPE_NONE;
-    if(FT_Get_PS_Font_Value(inFace, PS_DICT_ENCODING_TYPE, 0, (void*)&encodingType, sizeof(encodingType)) <= 0)
-        encodingType = T1_ENCODING_TYPE_NONE;
-    mIsCustomEncoding = encodingType == T1_ENCODING_TYPE_ARRAY;
+    FT_Long encodingTypeRead = FT_Get_PS_Font_Value(inFace, PS_DICT_ENCODING_TYPE, 0, (void*)&encodingType, sizeof(encodingType));
+    mIsCustomEncoding = (encodingTypeRead > 0) && (encodingType == T1_ENCODING_TYPE_ARRAY);
 
 	mPFMFileInfoRelevant = 
 		(inPFMFilePath.size() != 0 && mPFMReader.Read(inPFMFilePath) != PDFHummus::eFailure);
@@ -149,8 +147,7 @@ unsigned int FreeTypeType1Wrapper::GetGlyphForUnicodeChar(unsigned long inChar)
 
 std::string FreeTypeType1Wrapper::GetPrivateGlyphName(unsigned int inGlyphIndex)
 {
-    // if the type 1 file never loaded, mType1File holds indeterminate state -
-    // return .notdef rather than read glyph names out of it
+    // mType1File is only meaningful when the type 1 file actually loaded
     if(!mType1Loaded)
         return ".notdef";
     return mType1File.GetGlyphCharStringName(inGlyphIndex);

--- a/PDFWriter/FreeTypeType1Wrapper.cpp
+++ b/PDFWriter/FreeTypeType1Wrapper.cpp
@@ -43,22 +43,30 @@ FreeTypeType1Wrapper::FreeTypeType1Wrapper(FT_Face inFace,const std::string& inF
 	else
 		mPSPrivateAvailable = true;
     
-    T1_EncodingType encodingType;
-    FT_Get_PS_Font_Value(inFace, PS_DICT_ENCODING_TYPE, 0, (void*)&encodingType, sizeof(encodingType));
+    // FT_Get_PS_Font_Value returns the number of bytes read (<= 0 on error) and
+    // does not guarantee encodingType is written on failure. Default to NONE so
+    // a failed read does not route glyph lookups through the private Type1 path.
+    T1_EncodingType encodingType = T1_ENCODING_TYPE_NONE;
+    if(FT_Get_PS_Font_Value(inFace, PS_DICT_ENCODING_TYPE, 0, (void*)&encodingType, sizeof(encodingType)) <= 0)
+        encodingType = T1_ENCODING_TYPE_NONE;
     mIsCustomEncoding = encodingType == T1_ENCODING_TYPE_ARRAY;
 
 	mPFMFileInfoRelevant = 
 		(inPFMFilePath.size() != 0 && mPFMReader.Read(inPFMFilePath) != PDFHummus::eFailure);
     
     // parse type 1 input file (my own parsing), to get extra info about encoding
+    mType1Loaded = false;
     if(inFontFilePath.size() != 0)
     {
         InputFile type1File;
-    
-        type1File.OpenFile(inFontFilePath);
-        mType1File.ReadType1File(type1File.GetInputStream());
-    
-        type1File.CloseFile();
+
+        if(type1File.OpenFile(inFontFilePath) == PDFHummus::eSuccess)
+        {
+            mType1Loaded = (mType1File.ReadType1File(type1File.GetInputStream()) == PDFHummus::eSuccess);
+            type1File.CloseFile();
+        }
+        else
+            TRACE_LOG("FreeTypeType1Wrapper::FreeTypeType1Wrapper, unable to open the type 1 font file for private encoding parsing");
     }
     
     mFace = inFace;
@@ -141,6 +149,10 @@ unsigned int FreeTypeType1Wrapper::GetGlyphForUnicodeChar(unsigned long inChar)
 
 std::string FreeTypeType1Wrapper::GetPrivateGlyphName(unsigned int inGlyphIndex)
 {
+    // if the type 1 file never loaded, mType1File holds indeterminate state -
+    // return .notdef rather than read glyph names out of it
+    if(!mType1Loaded)
+        return ".notdef";
     return mType1File.GetGlyphCharStringName(inGlyphIndex);
 }
 

--- a/PDFWriter/FreeTypeType1Wrapper.h
+++ b/PDFWriter/FreeTypeType1Wrapper.h
@@ -58,4 +58,5 @@ private:
 	bool mPSPrivateAvailable;
     bool mIsCustomEncoding;
     Type1Input mType1File;
+    bool mType1Loaded;
 };

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -32,7 +32,9 @@ create_test_sourcelist (Tests
   FlateEncryptionTest.cpp
   FlateObjectDecodeTest.cpp
   FormXObjectTest.cpp
+  FreeTypeFaceWrapperTest.cpp
   FreeTypeInitializationTest.cpp
+  FreeTypeType1WrapperTest.cpp
   HighLevelContentContext.cpp
   HighLevelImages.cpp
   ImagesAndFormsForwardReferenceTest.cpp

--- a/PDFWriterTesting/FreeTypeFaceWrapperTest.cpp
+++ b/PDFWriterTesting/FreeTypeFaceWrapperTest.cpp
@@ -1,0 +1,271 @@
+/*
+   Source File : FreeTypeFaceWrapperTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression tests for FreeTypeFaceWrapper's FreeType return-code handling:
+
+     * V-076: SelectDefaultPalette assigned FT_Error to bool and ANDed the
+       two results, so a single failing FT_Palette_* call reported success;
+       it then read num_palette_entries out of an uninitialized
+       FT_Palette_Data and handed a garbage palette size to the caller.
+     * V-077: GetGlyphOutline tested mFace->glyph->format BEFORE LoadGlyph
+       (gating on the stale shared slot - a fresh face returns false for a
+       perfectly valid outline glyph) and then unconditionally overwrote the
+       FT_Outline_Decompose result with status = true.
+     * V-078: GetGlyphName built std::string(buffer) from an uninitialized
+       char[100] when FT_Get_Glyph_Name failed (no post table / post format
+       3 / color fonts), leaking stack bytes into the PDF.
+*/
+#include "FreeTypeFaceWrapper.h"
+#include "FreeTypeWrapper.h"
+
+#include "testing/TestIO.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace PDFHummus;
+
+// Counts the path callbacks FreeTypeFaceWrapper::GetGlyphOutline drives
+// through FT_Outline_Decompose. Subclasses the wrapper's enumerator
+// interface; the protected overrides are reached via the static FT
+// trampolines that GetGlyphOutline is friended to.
+class CountingOutlineEnumerator : public FreeTypeFaceWrapper::IOutlineEnumerator {
+public:
+	CountingOutlineEnumerator() : mMoveto(0), mLineto(0), mCurveto(0), mClose(0) {}
+	unsigned int mMoveto;
+	unsigned int mLineto;
+	unsigned int mCurveto;
+	unsigned int mClose;
+protected:
+	virtual bool Moveto(FT_Short, FT_Short) { ++mMoveto; return true; }
+	virtual bool Lineto(FT_Short, FT_Short) { ++mLineto; return true; }
+	virtual bool Curveto(FT_Short, FT_Short, FT_Short, FT_Short, FT_Short, FT_Short) { ++mCurveto; return true; }
+	virtual bool Close() { ++mClose; return true; }
+};
+
+// V-077: build a wrapper on a brand-new face (no glyph ever loaded into the
+// shared slot) and ask for a valid outline glyph as the very first
+// operation. Pre-fix the format gate ran before LoadGlyph and saw
+// FT_GLYPH_FORMAT_NONE, so this returned false for a real glyph; the
+// unconditional status = true also masked any decompose failure. Post-fix
+// it loads, sees FT_GLYPH_FORMAT_OUTLINE, decomposes, and reports the real
+// result - a valid 'A' must yield true and emit at least one contour.
+static bool GetGlyphOutline_FreshFaceValidOutlineGlyph_ReturnsTrueAndEmitsPath(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"), 0);
+	do {
+		// Arrange
+		if(!face) {
+			cout << "FreeTypeFaceWrapperTest [GetGlyphOutline::FreshFaceValidOutlineGlyph_ReturnsTrueAndEmitsPath]: failed to load arial.ttf" << endl;
+			break;
+		}
+		FreeTypeFaceWrapper wrapper(face, "", 0, false);
+		FT_UInt glyphIndex = FT_Get_Char_Index(face, 'A');
+		if(glyphIndex == 0) {
+			cout << "FreeTypeFaceWrapperTest [GetGlyphOutline::FreshFaceValidOutlineGlyph_ReturnsTrueAndEmitsPath]: no glyph for 'A'" << endl;
+			break;
+		}
+		CountingOutlineEnumerator enumerator;
+
+		// Act
+		bool status = wrapper.GetGlyphOutline(glyphIndex, enumerator);
+
+		// Assert
+		if(!status) {
+			cout << "FreeTypeFaceWrapperTest [GetGlyphOutline::FreshFaceValidOutlineGlyph_ReturnsTrueAndEmitsPath]: returned false for a valid outline glyph on a fresh face" << endl;
+			break;
+		}
+		if(enumerator.mMoveto == 0) {
+			cout << "FreeTypeFaceWrapperTest [GetGlyphOutline::FreshFaceValidOutlineGlyph_ReturnsTrueAndEmitsPath]: no Moveto emitted - the outline was not decomposed" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	ft.DoneFace(face);
+	return ok;
+}
+
+// V-078 happy path: a font with a real post table (arial.ttf, post format
+// 2) must still return the correct glyph name. Locks in that the added
+// return-value check did not regress the success path.
+static bool GetGlyphName_FontWithGlyphNames_ReturnsExactName(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"), 0);
+	do {
+		// Arrange
+		if(!face) {
+			cout << "FreeTypeFaceWrapperTest [GetGlyphName::FontWithGlyphNames_ReturnsExactName]: failed to load arial.ttf" << endl;
+			break;
+		}
+		FreeTypeFaceWrapper wrapper(face, "", 0, false);
+		FT_UInt glyphIndex = FT_Get_Char_Index(face, 'A');
+		if(glyphIndex == 0) {
+			cout << "FreeTypeFaceWrapperTest [GetGlyphName::FontWithGlyphNames_ReturnsExactName]: no glyph for 'A'" << endl;
+			break;
+		}
+
+		// Act
+		string name = wrapper.GetGlyphName(glyphIndex);
+
+		// Assert
+		if(name != "A") {
+			cout << "FreeTypeFaceWrapperTest [GetGlyphName::FontWithGlyphNames_ReturnsExactName]: expected \"A\", got \"" << name << "\"" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	ft.DoneFace(face);
+	return ok;
+}
+
+// V-078 regression: noto-glyf_colr_1.ttf has post format 3, so it carries
+// no glyph names and FT_Get_Glyph_Name fails for every glyph. Pre-fix the
+// ignored return value left buffer[100] uninitialized and std::string()
+// walked it (nondeterministic stack leak). Post-fix the failure is detected
+// and GetGlyphName falls back to the deterministic .notdef name.
+static bool GetGlyphName_FontWithoutGlyphNames_ReturnsNotDef(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/noto-glyf_colr_1.ttf"), 0);
+	do {
+		// Arrange
+		if(!face) {
+			cout << "FreeTypeFaceWrapperTest [GetGlyphName::FontWithoutGlyphNames_ReturnsNotDef]: failed to load noto-glyf_colr_1.ttf" << endl;
+			break;
+		}
+		FreeTypeFaceWrapper wrapper(face, "", 0, false);
+		if(face->num_glyphs < 2) {
+			cout << "FreeTypeFaceWrapperTest [GetGlyphName::FontWithoutGlyphNames_ReturnsNotDef]: unexpected glyph count" << endl;
+			break;
+		}
+
+		// Act
+		// glyph index 1 is in range (num_glyphs > 1) but the font has no
+		// names, so FT_Get_Glyph_Name fails for it
+		string name = wrapper.GetGlyphName(1);
+
+		// Assert
+		if(name != ".notdef") {
+			cout << "FreeTypeFaceWrapperTest [GetGlyphName::FontWithoutGlyphNames_ReturnsNotDef]: expected \".notdef\", got \"" << name << "\"" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	ft.DoneFace(face);
+	return ok;
+}
+
+// V-076 regression: arial.ttf has no CPAL table, so FT_Palette_Data_Get
+// fails. Pre-fix *outPaletteSize was read from an uninitialized
+// FT_Palette_Data member (nondeterministic). Post-fix a failed palette
+// selection returns a nonzero FT_Error and zeroes both outputs.
+static bool SelectDefaultPalette_FontWithoutPalette_ReturnsErrorAndZeroedOutputs(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"), 0);
+	do {
+		// Arrange
+		if(!face) {
+			cout << "FreeTypeFaceWrapperTest [SelectDefaultPalette::FontWithoutPalette_ReturnsErrorAndZeroedOutputs]: failed to load arial.ttf" << endl;
+			break;
+		}
+		FreeTypeFaceWrapper wrapper(face, "", 0, false);
+		FT_Color* palette = (FT_Color*)0x1; // poison: must be overwritten to NULL
+		unsigned short paletteSize = 0xBEEF; // poison: must be overwritten to 0
+
+		// Act
+		FT_Error error = wrapper.SelectDefaultPalette(&palette, &paletteSize);
+
+		// Assert
+		if(error == FT_Err_Ok) {
+			cout << "FreeTypeFaceWrapperTest [SelectDefaultPalette::FontWithoutPalette_ReturnsErrorAndZeroedOutputs]: expected a nonzero FT_Error for a font without a CPAL table" << endl;
+			break;
+		}
+		if(palette != NULL) {
+			cout << "FreeTypeFaceWrapperTest [SelectDefaultPalette::FontWithoutPalette_ReturnsErrorAndZeroedOutputs]: outPalette not nulled on failure" << endl;
+			break;
+		}
+		if(paletteSize != 0) {
+			cout << "FreeTypeFaceWrapperTest [SelectDefaultPalette::FontWithoutPalette_ReturnsErrorAndZeroedOutputs]: outPaletteSize not zeroed on failure, got " << paletteSize << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	ft.DoneFace(face);
+	return ok;
+}
+
+// V-076 happy path: noto-glyf_colr_1.ttf carries a CPAL table with exactly
+// 5879 palette entries. Both FT_Palette_* calls succeed, so the wrapper
+// returns FT_Err_Ok with a non-NULL palette and the exact entry count -
+// proving the corrected error semantics didn't break the success path.
+static bool SelectDefaultPalette_FontWithPalette_ReturnsOkAndExactEntryCount(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/noto-glyf_colr_1.ttf"), 0);
+	do {
+		// Arrange
+		if(!face) {
+			cout << "FreeTypeFaceWrapperTest [SelectDefaultPalette::FontWithPalette_ReturnsOkAndExactEntryCount]: failed to load noto-glyf_colr_1.ttf" << endl;
+			break;
+		}
+		FreeTypeFaceWrapper wrapper(face, "", 0, false);
+		FT_Color* palette = NULL;
+		unsigned short paletteSize = 0;
+
+		// Act
+		FT_Error error = wrapper.SelectDefaultPalette(&palette, &paletteSize);
+
+		// Assert
+		if(error != FT_Err_Ok) {
+			cout << "FreeTypeFaceWrapperTest [SelectDefaultPalette::FontWithPalette_ReturnsOkAndExactEntryCount]: expected FT_Err_Ok for a CPAL font, got " << error << endl;
+			break;
+		}
+		if(palette == NULL) {
+			cout << "FreeTypeFaceWrapperTest [SelectDefaultPalette::FontWithPalette_ReturnsOkAndExactEntryCount]: outPalette is NULL on success" << endl;
+			break;
+		}
+		if(paletteSize != 5879) {
+			cout << "FreeTypeFaceWrapperTest [SelectDefaultPalette::FontWithPalette_ReturnsOkAndExactEntryCount]: expected 5879 palette entries, got " << paletteSize << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	ft.DoneFace(face);
+	return ok;
+}
+
+int FreeTypeFaceWrapperTest(int argc, char* argv[]) {
+	(void)argc;
+
+	if(!GetGlyphOutline_FreshFaceValidOutlineGlyph_ReturnsTrueAndEmitsPath(argv)) return 1;
+	if(!GetGlyphName_FontWithGlyphNames_ReturnsExactName(argv)) return 1;
+	if(!GetGlyphName_FontWithoutGlyphNames_ReturnsNotDef(argv)) return 1;
+	if(!SelectDefaultPalette_FontWithoutPalette_ReturnsErrorAndZeroedOutputs(argv)) return 1;
+	if(!SelectDefaultPalette_FontWithPalette_ReturnsOkAndExactEntryCount(argv)) return 1;
+	return 0;
+}

--- a/PDFWriterTesting/FreeTypeType1WrapperTest.cpp
+++ b/PDFWriterTesting/FreeTypeType1WrapperTest.cpp
@@ -1,0 +1,99 @@
+/*
+   Source File : FreeTypeType1WrapperTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression tests for FreeTypeType1Wrapper's FreeType return-code handling:
+
+     * V-082: FT_Get_PS_Font_Value's return value was ignored and
+       T1_EncodingType was left uninitialized, so mIsCustomEncoding (which
+       routes every glyph lookup) could be derived from a stack-garbage
+       value.
+     * V-083: InputFile::OpenFile's return value was ignored; ReadType1File
+       ran against an unopened stream and glyph-name lookups then read out
+       of an indeterminate Type1Input. The fix gates GetPrivateGlyphName on
+       a load-succeeded flag.
+
+   The pure failure branches (OpenFile failing while FreeType still loads
+   the same face from the same path; FT_Get_PS_Font_Value failing on an
+   otherwise valid Type 1 font) are not reproducible with a static fixture.
+   This test therefore locks in that the defensive changes do not regress
+   the valid-Type1 embedding path that the wrapper is built for.
+*/
+#include "FreeTypeFaceWrapper.h"
+#include "FreeTypeWrapper.h"
+
+#include "testing/TestIO.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace PDFHummus;
+
+// Loading HLB_____.PFB through FreeTypeFaceWrapper with its real font/PFM
+// paths constructs a FreeTypeType1Wrapper that (a) reads PS_DICT_ENCODING_TYPE
+// (V-082 init + return check) and (b) opens the PFB and parses it
+// (V-083 OpenFile return check + mType1Loaded gate). A correct glyph name
+// for 'A' proves the load path still works end to end.
+static bool Construct_RealType1Font_ResolvesGlyphName(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/HLB_____.PFB"),
+	                          BuildRelativeInputPath(argv, "fonts/HLB_____.PFM"),
+	                          0);
+	do {
+		// Arrange
+		if(!face) {
+			cout << "FreeTypeType1WrapperTest [Construct::RealType1Font_ResolvesGlyphName]: failed to load HLB_____.PFB" << endl;
+			break;
+		}
+		FreeTypeFaceWrapper wrapper(face,
+		                            BuildRelativeInputPath(argv, "fonts/HLB_____.PFB"),
+		                            BuildRelativeInputPath(argv, "fonts/HLB_____.PFM"),
+		                            0, false);
+		if(!wrapper.IsValid()) {
+			cout << "FreeTypeType1WrapperTest [Construct::RealType1Font_ResolvesGlyphName]: wrapper not valid" << endl;
+			break;
+		}
+		FT_UInt glyphIndex = FT_Get_Char_Index(face, 'A');
+		if(glyphIndex == 0) {
+			cout << "FreeTypeType1WrapperTest [Construct::RealType1Font_ResolvesGlyphName]: no glyph for 'A'" << endl;
+			break;
+		}
+
+		// Act
+		string name = wrapper.GetGlyphName(glyphIndex);
+
+		// Assert
+		if(name != "A") {
+			cout << "FreeTypeType1WrapperTest [Construct::RealType1Font_ResolvesGlyphName]: expected \"A\", got \"" << name << "\"" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	ft.DoneFace(face);
+	return ok;
+}
+
+int FreeTypeType1WrapperTest(int argc, char* argv[]) {
+	(void)argc;
+
+	if(!Construct_RealType1Font_ResolvesGlyphName(argv)) return 1;
+	return 0;
+}

--- a/PDFWriterTesting/FreeTypeType1WrapperTest.cpp
+++ b/PDFWriterTesting/FreeTypeType1WrapperTest.cpp
@@ -28,13 +28,19 @@
        of an indeterminate Type1Input. The fix gates GetPrivateGlyphName on
        a load-succeeded flag.
 
-   The pure failure branches (OpenFile failing while FreeType still loads
-   the same face from the same path; FT_Get_PS_Font_Value failing on an
-   otherwise valid Type 1 font) are not reproducible with a static fixture.
-   This test therefore locks in that the defensive changes do not regress
-   the valid-Type1 embedding path that the wrapper is built for.
+   FreeTypeType1Wrapper is public and its FT_Face and font path are
+   independent inputs, so both failure branches are reachable by
+   constructing it directly with adversarial inputs (a valid face + a bad
+   path for V-083; a non-PostScript face for V-082). These are contract
+   lock-ins, not loud pre-fix failers: the downstream Type1Input is itself
+   defensive (V-083's observable can coincide pre/post) and V-082's pre-fix
+   bug only bites when the uninitialized stack holds exactly the array-
+   encoding enum value. They assert the deterministic post-fix invariant
+   and exercise the real defensive branch. The first case additionally
+   locks in that the changes do not regress valid Type 1 embedding.
 */
 #include "FreeTypeFaceWrapper.h"
+#include "FreeTypeType1Wrapper.h"
 #include "FreeTypeWrapper.h"
 
 #include "testing/TestIO.h"
@@ -91,9 +97,76 @@ static bool Construct_RealType1Font_ResolvesGlyphName(char* argv[]) {
 	return ok;
 }
 
+// V-083: a valid Type 1 FT_Face with a bad font-file path - OpenFile fails
+// while the face is still usable (the race / permission scenario the
+// finding describes). Post-fix mType1Loaded stays false and
+// GetPrivateGlyphName returns .notdef instead of reading an indeterminate
+// Type1Input.
+static bool Construct_BadFontPath_PrivateGlyphNameIsNotDef(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/HLB_____.PFB"),
+	                          BuildRelativeInputPath(argv, "fonts/HLB_____.PFM"),
+	                          0);
+	do {
+		// Arrange
+		if(!face) {
+			cout << "FreeTypeType1WrapperTest [Construct::BadFontPath_PrivateGlyphNameIsNotDef]: failed to load HLB_____.PFB" << endl;
+			break;
+		}
+		FreeTypeType1Wrapper wrapper(face, "/no/such/type1/font.pfb", "");
+
+		// Act
+		string name = wrapper.GetPrivateGlyphName(0);
+
+		// Assert
+		if(name != ".notdef") {
+			cout << "FreeTypeType1WrapperTest [Construct::BadFontPath_PrivateGlyphNameIsNotDef]: expected \".notdef\", got \"" << name << "\"" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	ft.DoneFace(face);
+	return ok;
+}
+
+// V-082: a non-PostScript face (arial.ttf) makes FT_Get_PS_Font_Value fail.
+// Post-fix encodingType stays T1_ENCODING_TYPE_NONE and the read-count
+// check keeps mIsCustomEncoding false, so HasPrivateEncoding is false
+// rather than derived from an uninitialized stack value.
+static bool Construct_NonPostScriptFace_HasPrivateEncodingIsFalse(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"), 0);
+	do {
+		// Arrange
+		if(!face) {
+			cout << "FreeTypeType1WrapperTest [Construct::NonPostScriptFace_HasPrivateEncodingIsFalse]: failed to load arial.ttf" << endl;
+			break;
+		}
+		FreeTypeType1Wrapper wrapper(face, "", "");
+
+		// Act
+		bool hasPrivateEncoding = wrapper.HasPrivateEncoding();
+
+		// Assert
+		if(hasPrivateEncoding) {
+			cout << "FreeTypeType1WrapperTest [Construct::NonPostScriptFace_HasPrivateEncodingIsFalse]: HasPrivateEncoding true for a non-PostScript face" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	ft.DoneFace(face);
+	return ok;
+}
+
 int FreeTypeType1WrapperTest(int argc, char* argv[]) {
 	(void)argc;
 
 	if(!Construct_RealType1Font_ResolvesGlyphName(argv)) return 1;
+	if(!Construct_BadFontPath_PrivateGlyphNameIsNotDef(argv)) return 1;
+	if(!Construct_NonPostScriptFace_HasPrivateEncodingIsFalse(argv)) return 1;
 	return 0;
 }


### PR DESCRIPTION
## Summary

Cluster **C7** — FreeType return-code mishandling. Five findings, one coherent root cause: capture and respect FreeType return codes, and initialize fallback values on failure. Spans the two FreeType wrappers.

### FreeTypeFaceWrapper
- **V-076** `SelectDefaultPalette` assigned `FT_Error` to `bool` and `&&`-ed the two results, so a *partial* failure (exactly one of `FT_Palette_Data_Get` / `FT_Palette_Select` failing) collapsed to `false` = `FT_Err_Ok` and the caller saw success with a `num_palette_entries` read out of an **uninitialized** `FT_Palette_Data`. Now propagates the first nonzero `FT_Error`, zero-inits `mPaletteData` in `ResetPaletteSelectionState`, and returns `NULL` / size `0` on failure.
- **V-077** `GetGlyphOutline` tested `mFace->glyph->format` **before** `LoadGlyph`, gating on the stale shared slot — a fresh face returned `false` for a perfectly valid outline glyph, and a multi-glyph workflow could feed non-outline slot bytes to `FT_Outline_Decompose`. It then unconditionally overwrote the decompose result with `status = true`. Format is now tested after `LoadGlyph`; the real decompose status is returned.
- **V-078** `GetGlyphName` built a `std::string` from an uninitialized `char[100]` when `FT_Get_Glyph_Name` failed (no `post` table / post format 3 / CFF / color fonts), leaking stack bytes into the PDF (`/Differences`, `ToUnicode`, …). Buffer is zero-initialized and the return value checked; falls back to `.notdef` on failure.

### FreeTypeType1Wrapper
- **V-082** `FT_Get_PS_Font_Value`'s return was ignored and `T1_EncodingType` left uninitialized, so `mIsCustomEncoding` — which routes *every* glyph-name/index lookup — could derive from stack garbage. Initialized to `T1_ENCODING_TYPE_NONE`; the read result is checked.
- **V-083** `InputFile::OpenFile`'s return was ignored; `ReadType1File` ran against an unopened stream. `OpenFile` is now checked, an `mType1Loaded` flag tracks success, and `GetPrivateGlyphName` returns `.notdef` rather than read an indeterminate `Type1Input`.

## Test plan
- **`FreeTypeFaceWrapperTest`** (new, 5 cases). V-076/077/078 each **fail deterministically pre-fix** — verified by reverting only the production source and rebuilding:
  - `GetGlyphOutline::FreshFaceValidOutlineGlyph` → pre-fix returns `false` for a valid glyph (V-077, logic bug).
  - `GetGlyphName::FontWithoutGlyphNames` (`noto-glyf_colr_1.ttf`, post fmt 3) → pre-fix returns uninitialized-buffer contents instead of `.notdef` (V-078).
  - `SelectDefaultPalette::FontWithoutPalette` (`arial.ttf`, no CPAL) → pre-fix returns `FT_Err_Ok` for an unusable palette (V-076, the actual `&&` inversion).
  - Happy-path guards: `GetGlyphName` exact name `"A"` on `arial.ttf`; `SelectDefaultPalette` exact `5879` palette entries on `noto-glyf_colr_1.ttf`.
- **`FreeTypeType1WrapperTest`** (new, 1 case). Locks in that the V-082/083 defensive changes don't regress valid Type 1 embedding (`HLB_____.PFB`). The pure failure branches — `OpenFile` failing while FreeType still loads the same face, or `FT_Get_PS_Font_Value` failing on an otherwise-valid Type 1 — are not reproducible with a static fixture; documented in the test header.
- Full suite: **97/97 pass** (`ctest -C Release`), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)