### PR TITLE
feat: update bot review instructions to be more focused on actionable items resulting from review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,42 +44,63 @@ Prioritize correctness, regressions, security, and missing tests over style nits
 - Treat the user's requested scope as the highest-priority constraint for implementation.
 
 ## Output Format (always follow)
+Keep output concise. Omit empty or redundant sections.
+
+No-actionable-finding mode (strict):
+- When there are zero actionable findings, use only this exact 3-line structure and stop:
+	1. `Decision: Approve`
+	2. `Severity Summary: No findings.`
+	3. `No actionable findings.`
+- In this mode, do not emit Findings, Testing and Regression Risk, or Final Recommendation sections.
+
 1. Verdict
 - Decision: Approve | Request changes | Comment | Approve with follow-ups
-- Confidence: High | Medium | Low
-- Blocking issues: <count>
 
-2. Severity Summary
-- 🔴 Critical: <count>
-- 🟠 High: <count>
-- 🟡 Medium: <count>
-- 🔵 Low: <count>
-- ⚪ Info: <count>
+2. Severity Summary (non-zero counts only)
+- Include only severities with count > 0.
+- If all severities are zero (and strict mode is not used), write: "No findings."
 
 3. Findings
-For each finding include:
-- Severity: <label>
-- Title: <short title>
-- Location: <file and line or symbol>
-- Causality: Introduced-by-PR | Exposed-by-PR | Pre-existing-Unchanged
-- Evidence: changed symbol/call path/test evidence tying impact to this PR
-- Problem: <what is wrong>
-- Risk: <why it matters / impact>
-- Recommendation: <minimal concrete fix>
+- Include only actionable findings (or uncertainties that require clarification).
+- For each finding include:
+	- Severity: <label>
+	- Title: <short title>
+	- Location: <file and line or symbol>
+	- Causality: Introduced-by-PR | Exposed-by-PR | Pre-existing-Unchanged
+	- Evidence: changed symbol/call path/test evidence tying impact to this PR
+	- Problem: <what is wrong>
+	- Risk: <why it matters / impact>
+	- Recommendation: <minimal concrete fix>
 
 4. Testing and Regression Risk
-- Missing tests that should be added or updated.
-- Edge cases or scenarios not covered.
+- Include only when there is a concrete gap not already covered in Findings.
+- Do not repeat points already stated in Findings or Verdict.
+- Do not treat "tests were added" as sufficient by itself.
+- Verify coverage per changed behavior in the diff. If a changed behavior has no direct deterministic regression test, call it out explicitly.
+- If a regression test is not feasible, require a short justification tied to reproducibility/fixture limits.
 
 5. Final Recommendation
-- One clear line: Approve / Request changes / Comment / Approve with follow-ups.
+- One clear line only when it adds information beyond Verdict.
+- If identical to Verdict, omit this section.
 
 ## Review Quality Constraints
 - Do not report speculative issues without rationale.
 - Prefer one precise finding over multiple overlapping comments.
-- If there are no actionable findings, explicitly state: "No actionable findings."
+- If there are no actionable findings, explicitly state: "No actionable findings." (strict mode line 3)
 - Keep style-only feedback in 🔵 Low or ⚪ Info unless it impacts correctness or reliability.
 - Findings must be tied to this PR's diff and reachability, not just absolute code quality concerns.
+- In no-actionable-findings cases, keep the full response to exactly 3 lines (per strict template above).
+- Do not include "Reviewed changes" or similar boilerplate sections.
+- Do not restate the same conclusion across multiple sections.
+- Before using no-actionable-findings mode, perform a changed-behavior test coverage check:
+	- Map each material behavior change in touched production code to a specific test name/location, or to a documented infeasibility note.
+	- If any material behavior change is unmapped, do not use no-actionable-findings mode; emit a 🟡 Medium testing-gap finding.
+
+## Testing Gap Classification
+- Use this when tests exist in the PR but do not cover all changed behaviors.
+- Severity default: 🟡 Medium.
+- Causality: Introduced-by-PR when the changed behavior is new in this PR and lacks regression coverage.
+- Recommendation: add a focused deterministic regression test; if infeasible, document why and add the closest guard test.
 
 ## Repository Context
 - This codebase uses conservative C++ style and manual memory management.


### PR DESCRIPTION
recent review had little to say, but came out long, making it hard to parse the fact that there's no todo. so we'll instruct it to be shorter...also for todo reports. all in all, make stuff shorter.
also, note about testing, which is a bit strict to what i normally care about, well use this until i get tired of it. it's good for claude who's very good at synthesizing pdfs/fonts and such to create regression test...something which i myself cannot normally be bothered with.