### PR TITLE
fix: initialize OpenTypeFileInput uninit members (V-020/V-022)

### DIFF
--- a/PDFWriter/OpenTypeFileInput.cpp
+++ b/PDFWriter/OpenTypeFileInput.cpp
@@ -28,7 +28,9 @@ OpenTypeFileInput::OpenTypeFileInput(void)
 {
     mHeaderOffset = 0;
     mTableOffset = 0;
+	mTablesCount = 0;
 	mHMtx = NULL;
+	mName.mNameEntriesCount = 0;
 	mName.mNameEntries = NULL;
 	mLoca = NULL;
 	mGlyf = NULL;
@@ -188,7 +190,7 @@ EStatusCode OpenTypeFileInput::ReadOpenTypeFile(IByteReaderWithPosition* inTrueT
 EStatusCode OpenTypeFileInput::ReadOpenTypeHeader()
 {
 	EStatusCode status;
-	TableEntry tableEntry;
+	TableEntry tableEntry = {0};
 	unsigned long tableTag;
 
 	do
@@ -669,7 +671,7 @@ EStatusCode OpenTypeFileInput::ReadName()
 	mPrimitivesReader.SetOffset(it->second.Offset);	
 	mPrimitivesReader.Skip(2);
 	mPrimitivesReader.ReadUSHORT(mName.mNameEntriesCount);
-	mName.mNameEntries = new NameTableEntry[mName.mNameEntriesCount];
+	mName.mNameEntries = new NameTableEntry[mName.mNameEntriesCount]();
 	
 	unsigned short stringOffset;
 	

--- a/PDFWriterTesting/OpenTypeFileInputTest.cpp
+++ b/PDFWriterTesting/OpenTypeFileInputTest.cpp
@@ -39,6 +39,7 @@
 
 #include <iostream>
 #include <string>
+#include <cstring>
 
 using namespace std;
 using namespace PDFHummus;
@@ -156,9 +157,74 @@ static bool ReadOpenTypeFile_ArialTtf_PopulatesHheaMaxp(char* argv[]) {
 	return ok;
 }
 
+// Exercises the name-table path: ReadName allocates mNameEntries with
+// new NameTableEntry[count](), populates every entry, and FreeTables walks
+// mNameEntriesCount deleting each .String. Value-initializing the array means
+// .String is NULL before the populate loop assigns it, so the delete-walk is
+// safe even if a future change leaves an entry unpopulated; the constructor
+// now also zeroes mNameEntriesCount so the FreeTables loop bound is never an
+// indeterminate value. Parse happens on a heap object that is deleted inside
+// the test so the destructor's delete-walk runs under the test, not at
+// process teardown. Asserts exact values (arial.ttf has 58 name entries;
+// entry 1 is the family name "Arial" in UTF-16BE) so a regression that
+// mispopulates the table surfaces rather than a bounds check passing.
+static bool ReadName_ArialTtf_PopulatesNameEntries(char* argv[]) {
+	// Arrange
+	string font;
+	if(!readFileBytes(BuildRelativeInputPath(argv, "fonts/arial.ttf"), font)) {
+		cout << "OpenTypeFileInputTest: failed to read arial.ttf" << endl;
+		return false;
+	}
+
+	// Act
+	InputByteArrayStream stream((Byte*)&font[0], (LongFilePositionType)font.size());
+	OpenTypeFileInput* openType = new OpenTypeFileInput();
+	EStatusCode status = openType->ReadOpenTypeFile(&stream, 0);
+
+	// Assert
+	bool ok = false;
+	do {
+		if(status != eSuccess) {
+			cout << "OpenTypeFileInputTest: ReadOpenTypeFile rejected pristine arial.ttf" << endl;
+			break;
+		}
+		if(openType->mName.mNameEntriesCount != 58) {
+			cout << "OpenTypeFileInputTest: expected 58 name entries, got " << openType->mName.mNameEntriesCount << endl;
+			break;
+		}
+		bool entriesOk = true;
+		for(unsigned short i = 0; i < openType->mName.mNameEntriesCount; ++i) {
+			if(openType->mName.mNameEntries[i].String == NULL) {
+				cout << "OpenTypeFileInputTest: name entry " << i << " has NULL String" << endl;
+				entriesOk = false;
+				break;
+			}
+		}
+		if(!entriesOk)
+			break;
+		const NameTableEntry& family = openType->mName.mNameEntries[1];
+		if(family.PlatformID != 0 || family.EncodingID != 3 || family.NameID != 1 || family.Length != 10) {
+			cout << "OpenTypeFileInputTest: name entry 1 header mismatch (plat " << family.PlatformID
+			     << " enc " << family.EncodingID << " name " << family.NameID
+			     << " len " << family.Length << ")" << endl;
+			break;
+		}
+		const char expectedArial[10] = {0,'A',0,'r',0,'i',0,'a',0,'l'};
+		if(memcmp(family.String, expectedArial, 10) != 0) {
+			cout << "OpenTypeFileInputTest: name entry 1 is not UTF-16BE \"Arial\"" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	delete openType;
+	return ok;
+}
+
 int OpenTypeFileInputTest(int argc, char* argv[]) {
 	(void)argc;
 	if(!ReadHMtx_NumberOfHMetricsZero_ReturnsFailure(argv)) return 1;
 	if(!ReadOpenTypeFile_ArialTtf_PopulatesHheaMaxp(argv)) return 1;
+	if(!ReadName_ArialTtf_PopulatesNameEntries(argv)) return 1;
 	return 0;
 }


### PR DESCRIPTION
## Cluster C4 — uninitialized members in default constructors (PR A: `OpenTypeFileInput`)

First of the C4 cluster PRs (one per file). All 16 HIGH findings are merged; this is MED defense-in-depth.

### Findings closed

**V-020** (MED) — `mName.mNameEntriesCount` uninitialized in the constructor. It is the loop bound `FreeTables` uses to `delete[]` each `mNameEntries[i].String`. Today this is latent: the delete-walk is guarded by a NULL `mNameEntries` (which the ctor *does* set) and the value is only otherwise read after `ReadUSHORT` writes it. The uninitialized member is still a wild-pointer-deref footgun and the fix is a one-line ctor init.

Paired with V-020: `ReadName` allocated the entry array with `new NameTableEntry[count]` (no value-init), so every `.String` is indeterminate until the populate loop assigns it. Changed to `new NameTableEntry[count]()` so the `FreeTables` delete-walk is safe even if an entry is ever left unpopulated. This is the same fix shape as in-cluster **V-066** (`new Type1CharString[N]`, merged in #353).

**V-022** (MED, C4 portion) — `mTablesCount` uninitialized in the constructor, and `ReadOpenTypeHeader`'s local `TableEntry` was reused across loop iterations without initialization. The **C1 portion** of V-022 (primitive reader leaving fields stale on read failure) was already closed structurally in #360; this PR finishes the C4 portion.

### Why no negative/crash test

Post-#360 the OpenType primitive reader initializes its out-params to 0 on failure, so a truncated `name`/header no longer leaves these values indeterminate through the public API — there is no deterministic crash-reproducing input. Same situation as V-040's "(latent)" tag and the V-050/#361 "closed structurally" precedent. These are constructor/initializer hardening fixes, exactly the C4 cluster remit.

### Test

`ReadName_ArialTtf_PopulatesNameEntries` (added to the existing `OpenTypeFileInputTest.cpp`) parses `arial.ttf` through a **heap** `OpenTypeFileInput` that is `delete`d inside the test, so the destructor's `FreeTables` delete-walk runs under the test (catchable by ASan/heap-checker) rather than at process teardown. Asserts exact values: 58 name entries, every `.String` non-NULL, entry 1 is the family name `"Arial"` in UTF-16BE. Exercises the exact `new NameTableEntry[N]()` / populate / free path V-020 concerns and proves the value-init does not regress real font parsing.

Full suite: 97/97 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)