### PR TITLE
fix: initialize InputPFBDecodeStream uninit ctor members (V-062)

### DIFF
--- a/PDFWriter/InputPFBDecodeStream.cpp
+++ b/PDFWriter/InputPFBDecodeStream.cpp
@@ -29,6 +29,13 @@ InputPFBDecodeStream::InputPFBDecodeStream(void)
 	mStreamToDecode = NULL;
 	mDecodeMethod = NULL;
 	mInternalState = PDFHummus::eFailure;
+	mInSegmentReadIndex = 0;
+	mSegmentSize = 0;
+	mCurrentType = 0;
+	mHasTokenBuffer = false;
+	mTokenBuffer = 0;
+	mRandomizer = 0;
+	mFoundEOF = false;
 }
 
 InputPFBDecodeStream::~InputPFBDecodeStream(void)

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -41,6 +41,7 @@ create_test_sourcelist (Tests
   InputCharStringDecodeStreamTest.cpp
   InputFlateDecodeTester.cpp
   InputImagesAsStreamsTest.cpp
+  InputPFBDecodeStreamTest.cpp
   JpegLibTest.cpp
   JPGImageTest.cpp
   LinksTest.cpp

--- a/PDFWriterTesting/InputPFBDecodeStreamTest.cpp
+++ b/PDFWriterTesting/InputPFBDecodeStreamTest.cpp
@@ -1,0 +1,91 @@
+/*
+   Source File : InputPFBDecodeStreamTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression test for the InputPFBDecodeStream constructor leaving
+   mInSegmentReadIndex / mSegmentSize / mCurrentType / mHasTokenBuffer /
+   mTokenBuffer / mRandomizer / mFoundEOF uninitialized. Only Assign() (via
+   ResetReadStatus) sets most of them, so a freshly constructed stream used
+   without a successful Assign reads indeterminate values. In particular
+   Read() tests mHasTokenBuffer first and, if it is non-zero, copies the
+   indeterminate mTokenBuffer into the caller's buffer and returns 1 — an
+   uninitialized-memory disclosure plus a wrong byte count.
+
+   The object is constructed into storage pre-filled with 0xFF so a missing
+   constructor initializer is deterministically observable (a plain stack
+   object's uninitialized members are often incidentally zero on a given
+   build, masking the bug). Post-fix the constructor zeroes every member, so
+   Read() on the un-Assigned stream returns 0 and writes nothing.
+*/
+#include "InputPFBDecodeStream.h"
+#include "EStatusCode.h"
+
+#include <iostream>
+#include <new>
+#include <cstring>
+
+using namespace std;
+using namespace PDFHummus;
+using namespace IOBasicTypes;
+
+static bool Read_FreshlyConstructedWithoutAssign_ReturnsZeroAndDisclosesNothing(char* /*argv*/[]) {
+	// Arrange: construct over 0xFF-poisoned storage so any member the
+	// constructor fails to initialize stays 0xFF rather than incidental zero.
+	void* storage = ::operator new(sizeof(InputPFBDecodeStream));
+	memset(storage, 0xFF, sizeof(InputPFBDecodeStream));
+	InputPFBDecodeStream* stream = new (storage) InputPFBDecodeStream();
+
+	const Byte sentinel = 0xAB;
+	Byte out[4];
+	memset(out, sentinel, sizeof(out));
+
+	// Act: Read with no successful Assign. Pre-fix, the indeterminate
+	// mHasTokenBuffer (0xFF -> true) makes Read emit the indeterminate
+	// mTokenBuffer and return 1.
+	LongBufferSizeType got = stream->Read(out, sizeof(out));
+
+	// Assert
+	bool ok = true;
+	if(got != 0) {
+		cout << "InputPFBDecodeStreamTest: fresh Read returned " << got << " bytes, expected 0" << endl;
+		ok = false;
+	}
+	if(out[0] != sentinel) {
+		cout << "InputPFBDecodeStreamTest: fresh Read overwrote caller buffer with 0x"
+		     << hex << (unsigned int)out[0] << dec << " (uninitialized-memory disclosure)" << endl;
+		ok = false;
+	}
+	if(stream->NotEnded()) {
+		cout << "InputPFBDecodeStreamTest: fresh NotEnded() is true, expected false" << endl;
+		ok = false;
+	}
+	if(stream->GetInternalState() != eFailure) {
+		cout << "InputPFBDecodeStreamTest: fresh GetInternalState() is not eFailure" << endl;
+		ok = false;
+	}
+
+	stream->~InputPFBDecodeStream();
+	::operator delete(storage);
+	return ok;
+}
+
+int InputPFBDecodeStreamTest(int argc, char* argv[]) {
+	(void)argc;
+	if(!Read_FreshlyConstructedWithoutAssign_ReturnsZeroAndDisclosesNothing(argv)) return 1;
+	return 0;
+}


### PR DESCRIPTION
## Cluster C4 — uninitialized members in default constructors (PR B: `InputPFBDecodeStream`)

Second of the C4 cluster PRs (one per file). Independent of #369. MED defense-in-depth (all 16 HIGH findings are merged).

### Finding closed

**V-062** (MED) — the constructor initialized only `mStreamToDecode`, `mDecodeMethod`, `mInternalState`. `mInSegmentReadIndex`, `mSegmentSize`, `mCurrentType`, `mHasTokenBuffer`, `mTokenBuffer`, `mRandomizer`, `mFoundEOF` were left indeterminate. `ResetReadStatus` (the other initializer of most of these) runs only inside a *successful* `Assign`, so a freshly constructed stream used without a successful `Assign` reads indeterminate state.

The sharpest consequence is in `Read()`:

```cpp
if(mHasTokenBuffer && inBufferSize > 0)   // mHasTokenBuffer indeterminate
{
    inBuffer[0] = mTokenBuffer;            // indeterminate -> disclosed to caller
    mHasTokenBuffer = false;
    ++bufferIndex;                         // returns 1 instead of 0
}
```

i.e. an uninitialized-memory disclosure plus a wrong byte count.

Fix: initialize all seven members in the constructor. `ResetReadStatus` is left unchanged (it already zeroes the five it owns; `mTokenBuffer` is guarded by `mHasTokenBuffer`, `mRandomizer` is set by `InitializeBinaryDecode` before use — the gap is purely the default-constructed state, which is exactly the C4 remit).

### Test

New `InputPFBDecodeStreamTest.cpp` (conventionally named; the old end-to-end `PFBStreamTest.cpp` is left as-is per the no-retroactive-rename convention). `Read_FreshlyConstructedWithoutAssign_ReturnsZeroAndDisclosesNothing` constructs the object into **0xFF-poisoned storage via placement new**, so a missing initializer is *deterministic* rather than incidentally zero (a plain stack object's uninitialized members are often zero on a given build, masking the bug). Then it `Read`s without `Assign`.

Verified by stash+rebuild:
- **Pre-fix:** `Read` returns 1 and overwrites the caller buffer with `0xff` → test FAILS (reproduces the disclosure).
- **Post-fix:** `Read` returns 0, caller buffer untouched → test PASSES.

Full suite: **98/98**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)