### PR TITLE
fix: initialize FreeTypeFaceWrapper mCurrentGlyph (V-080)

### DIFF
--- a/PDFWriter/FreeTypeFaceWrapper.cpp
+++ b/PDFWriter/FreeTypeFaceWrapper.cpp
@@ -43,6 +43,7 @@ FreeTypeFaceWrapper::FreeTypeFaceWrapper(FT_Face inFace,const std::string& inFon
 	mFontIndex = inFontIndex;
 	mDoesOwn = inDoOwn;
 	mGlyphIsLoaded = false;
+	mCurrentGlyph = 0;
 	ResetPaletteSelectionState();
 	SetupFormatSpecificExtender(inFontFilePath, "");
 	SelectDefaultEncoding();
@@ -55,6 +56,7 @@ FreeTypeFaceWrapper::FreeTypeFaceWrapper(FT_Face inFace,const std::string& inFon
     mFontIndex = inFontIndex;
 	mDoesOwn = inDoOwn;
 	mGlyphIsLoaded = false;
+	mCurrentGlyph = 0;
 	ResetPaletteSelectionState();
 	std::string fileExtension = GetExtension(inPFMFilePath);
 	if (fileExtension == "PFM" || fileExtension == "pfm") // just don't bother if it's not PFM


### PR DESCRIPTION
## Cluster C4 — uninitialized members in default constructors (PR C: `FreeTypeFaceWrapper`)

Third of the C4 cluster PRs (one per file). Independent of #369 / #370. LOW severity, latent defense-in-depth (all 16 HIGH findings merged).

### Finding closed

**V-080** (LOW) — both `FreeTypeFaceWrapper` constructors set `mGlyphIsLoaded = false` but leave `mCurrentGlyph` indeterminate. `LoadGlyph` reads it in:

```cpp
if (!mGlyphIsLoaded || inGlyphIndex != mCurrentGlyph) {
```

Today the indeterminate read is **unreachable**: `mGlyphIsLoaded` is `true` only immediately after `mCurrentGlyph` is assigned (the single `mGlyphIsLoaded = true` site sets `mCurrentGlyph` on the very next line; every other path, including `GetYBearingForUnicodeChar`, sets `mGlyphIsLoaded = false`). So on the first `LoadGlyph` call the `!mGlyphIsLoaded` left-operand short-circuits before `mCurrentGlyph` is evaluated. The fix is defense-in-depth against a future reordering of that condition.

Initialize `mCurrentGlyph = 0` in both constructors (next to the existing `mGlyphIsLoaded = false`).

### Why no new regression test

The short-circuit invariant makes the uninitialized value **unobservable through any public API path** — a synthetic test (even placement-new over poisoned storage, as used for #370's V-062) would pass pre-fix too, i.e. a no-op that proves nothing. `mCurrentGlyph` is private with no getter, and white-boxing it would require a friend declaration, which this codebase deliberately avoids. This matches the cluster's framing of V-080 as latent. The existing `FreeTypeFaceWrapperTest` + full font/FreeType suite proves the constructors and `LoadGlyph` are not regressed.

Full suite: **98/98**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)