### PR TITLE
fix: initialize CFFFileInput mFontsCount/mStringsCount (V-040)

### DIFF
--- a/PDFWriter/CFFFileInput.cpp
+++ b/PDFWriter/CFFFileInput.cpp
@@ -130,6 +130,8 @@ static const unsigned short scDefaultCharsetsSizes[3] =
 
 CFFFileInput::CFFFileInput(void)
 {
+	mFontsCount = 0;
+	mStringsCount = 0;
 	mTopDictIndex = NULL;
 	mStrings = NULL;
 	mGlobalSubrs.mCharStringsIndex = NULL;


### PR DESCRIPTION
## Cluster C4 — uninitialized members in default constructors (PR D: `CFFFileInput`)

Final C4 cluster PR (one per file). Independent of #369 / #370 / #371. LOW severity, latent defense-in-depth (all 16 HIGH findings merged).

### Finding closed

**V-040** (LOW) — the constructor set every owned pointer to `NULL` but left `mFontsCount` and `mStringsCount` indeterminate. `FreeData` uses them as `delete[]`-walk bounds (`mTopDictIndex` / `mCharStrings` over `mFontsCount`, `mStrings` over `mStringsCount`).

Latent today: each `FreeData` loop is gated on its pointer being non-NULL; the constructor sets those NULL; and every parse path sets the count (via `ReadIndexHeader`) *before* allocating the matching array — so a non-NULL pointer never coincides with an indeterminate count. Initializing both counts in the constructor closes the footgun.

### Why no new regression test

Same latent shape as V-080 (#371). The NULL-pointer gating the constructor establishes makes the indeterminate count **unobservable through any public API path** — a synthetic test (even placement-new over poisoned storage, as used for #370's V-062) would pass pre-fix too, i.e. a no-op. This matches the cluster's explicit "(latent — `FreeData` is gated on null pointers)" classification of V-040. The existing `CFFFileInputTest` + full CFF/font suite proves no regression.

Full suite: **97/97**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)