### PR TITLE
fix: cross PFB segment boundaries in the tokenizer (V-090)

### DIFF
--- a/PDFWriter/InputPFBDecodeStream.cpp
+++ b/PDFWriter/InputPFBDecodeStream.cpp
@@ -506,9 +506,11 @@ void InputPFBDecodeStream::SaveTokenBuffer(Byte inToSave)
 
 bool InputPFBDecodeStream::HasMoreInput()
 {
-	// True while another byte may still be obtained, possibly from a later
-	// PFB segment (GetNextByteForToken crosses segment boundaries); false
-	// only at a genuine end of input.
+	// Input-framing availability only: true while more bytes remain in the
+	// PFB stream (current or a later segment -- GetNextByteForToken crosses
+	// boundaries), false at the end of that stream. Decoder health is a
+	// separate concern, gated by callers via mInternalState (as NotEnded()
+	// is, e.g. in Read()).
 	return mHasTokenBuffer || NotEnded();
 }
 

--- a/PDFWriter/InputPFBDecodeStream.cpp
+++ b/PDFWriter/InputPFBDecodeStream.cpp
@@ -292,8 +292,11 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 				while(HasMoreInput())
 				{
 					if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
-					{	
-						result.first = false;
+					{
+						// a comment is self-delimiting: end of data ends it
+						// cleanly. only a decoder failure is a failed read.
+						if(mInternalState != PDFHummus::eSuccess)
+							result.first = false;
 						break;
 					}
 					if(0xD == buffer|| 0xA == buffer)
@@ -439,8 +442,12 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 				while(HasMoreInput())
 				{
 					if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
-					{	
-						result.first = false;
+					{
+						// a regular token is self-delimiting: end of data is a
+						// valid terminator, the bytes read are a complete
+						// token. only a decoder failure is a failed read.
+						if(mInternalState != PDFHummus::eSuccess)
+							result.first = false;
 						break;
 					}
 					if(IsPostScriptWhiteSpace(buffer))

--- a/PDFWriter/InputPFBDecodeStream.cpp
+++ b/PDFWriter/InputPFBDecodeStream.cpp
@@ -260,9 +260,6 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 		return result;
 	}
 
-	// Segment advancing (and the per-segment decode-mode switch) is now owned
-	// by GetNextByteForToken, so the tokenizer never has to peek across a
-	// boundary itself.
 	result.first = true;
 
 	do
@@ -270,7 +267,7 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 		// skip till token
 		SkipTillToken();
 
-		// if segment ended, mark as no token read
+		// end of data reached before any token byte: no token to return
 		if(!HasMoreInput())
 		{
 			result.first = false;
@@ -476,13 +473,12 @@ EStatusCode InputPFBDecodeStream::GetNextByteForToken(Byte& outByte)
 		return PDFHummus::eSuccess;
 	}
 
-	// A PFB segment boundary is transport framing, not a token boundary.
-	// Cross it transparently -- the same way Read() does for binary data --
-	// so a token, or whitespace between tokens, can span segments produced
-	// by fixed-size PFB chunkers. Only a genuine end of input or a decoder
-	// failure yields no byte. InitializeStreamSegment performs the
-	// per-segment decode-mode switch (plaintext / eexec / EOF), so looping
-	// over it preserves those transitions.
+	// A PFB segment boundary is transport framing, not a token boundary:
+	// advance past an exhausted segment so a token or inter-token whitespace
+	// can span chunked segments. InitializeStreamSegment carries the
+	// per-segment decode-mode switch (plaintext / eexec / EOF), so crossing
+	// segments here keeps that intact. No byte is available only at a
+	// genuine end of input or a decoder failure.
 	while(mInSegmentReadIndex >= mSegmentSize && NotEnded() && mInternalState == PDFHummus::eSuccess)
 		mInternalState = InitializeStreamSegment();
 
@@ -503,10 +499,9 @@ void InputPFBDecodeStream::SaveTokenBuffer(Byte inToSave)
 
 bool InputPFBDecodeStream::HasMoreInput()
 {
-	// True while another byte may still be obtained, including from a later
-	// PFB segment -- GetNextByteForToken crosses segment boundaries. False
-	// only at genuine end of input. (Distinct from "current segment has
-	// bytes left", which is no longer the tokenizer's concern.)
+	// True while another byte may still be obtained, possibly from a later
+	// PFB segment (GetNextByteForToken crosses segment boundaries); false
+	// only at a genuine end of input.
 	return mHasTokenBuffer || NotEnded();
 }
 

--- a/PDFWriter/InputPFBDecodeStream.cpp
+++ b/PDFWriter/InputPFBDecodeStream.cpp
@@ -260,18 +260,9 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 		return result;
 	}
 
-	// At previous segment end, try a new one
-	if(!IsSegmentNotEnded())
-	{
-		mInternalState = InitializeStreamSegment();
-		// new segment brought to end...mark as no token
-		if(mInternalState != PDFHummus::eSuccess || !NotEnded())
-		{
-			result.first = false;
-			return result;
-		}
-	}
-
+	// Segment advancing (and the per-segment decode-mode switch) is now owned
+	// by GetNextByteForToken, so the tokenizer never has to peek across a
+	// boundary itself.
 	result.first = true;
 
 	do
@@ -280,7 +271,7 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 		SkipTillToken();
 
 		// if segment ended, mark as no token read
-		if(!IsSegmentNotEnded())
+		if(!HasMoreInput())
 		{
 			result.first = false;
 			break;
@@ -301,7 +292,7 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 			case '%':
 			{
 				// for a comment, the token goes on till the end of line marker [not including]
-				while(IsSegmentNotEnded())
+				while(HasMoreInput())
 				{
 					if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
 					{	
@@ -321,7 +312,7 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 				// for a string, the token goes on until the balanced-closing right paranthesis
 				int balanceLevel = 1;
 				bool backSlashEncountered = false;
-				while(balanceLevel > 0 && IsSegmentNotEnded())
+				while(balanceLevel > 0 && HasMoreInput())
 				{
 					if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
 					{	
@@ -336,7 +327,7 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 						{
 							// ignore backslash and newline. might also need to read extra
 							// for cr-ln
-							if(0xD == buffer && IsSegmentNotEnded())
+							if(0xD == buffer && HasMoreInput())
 							{
 								if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
 								{
@@ -374,7 +365,7 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 
 			case '<':
 			{
-				if(!IsSegmentNotEnded())
+				if(!HasMoreInput())
 				{
 					result.second = tokenBuffer.ToString();
 					break;
@@ -394,7 +385,7 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 				if('~' == buffer)
 				{
 					// ASCII 85 string, read all till '~>'
-					while(IsSegmentNotEnded())
+					while(HasMoreInput())
 					{
 						if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
 						{	
@@ -405,7 +396,7 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 						tokenBuffer.Write(&buffer,1);
 						if('~' == buffer)
 						{
-							if(!IsSegmentNotEnded())
+							if(!HasMoreInput())
 								break;
 							if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
 							{	
@@ -422,7 +413,7 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 				else
 				{
 					// regular ascii, read anything till '>' skipping white spaces
-					while(IsSegmentNotEnded())
+					while(HasMoreInput())
 					{
 						if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
 						{	
@@ -448,7 +439,7 @@ BoolAndString InputPFBDecodeStream::GetNextToken()
 
 			default: // regular token. read till next breaker or whitespace
 			{
-				while(IsSegmentNotEnded())
+				while(HasMoreInput())
 				{
 					if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
 					{	
@@ -484,8 +475,21 @@ EStatusCode InputPFBDecodeStream::GetNextByteForToken(Byte& outByte)
 		mHasTokenBuffer = false;
 		return PDFHummus::eSuccess;
 	}
-	else
-		return mDecodeMethod(this,outByte);
+
+	// A PFB segment boundary is transport framing, not a token boundary.
+	// Cross it transparently -- the same way Read() does for binary data --
+	// so a token, or whitespace between tokens, can span segments produced
+	// by fixed-size PFB chunkers. Only a genuine end of input or a decoder
+	// failure yields no byte. InitializeStreamSegment performs the
+	// per-segment decode-mode switch (plaintext / eexec / EOF), so looping
+	// over it preserves those transitions.
+	while(mInSegmentReadIndex >= mSegmentSize && NotEnded() && mInternalState == PDFHummus::eSuccess)
+		mInternalState = InitializeStreamSegment();
+
+	if(mInSegmentReadIndex >= mSegmentSize || !NotEnded() || mInternalState != PDFHummus::eSuccess)
+		return PDFHummus::eFailure;
+
+	return mDecodeMethod(this,outByte);
 }
 
 
@@ -497,9 +501,13 @@ void InputPFBDecodeStream::SaveTokenBuffer(Byte inToSave)
 }
 
 
-bool InputPFBDecodeStream::IsSegmentNotEnded()
+bool InputPFBDecodeStream::HasMoreInput()
 {
-	return mHasTokenBuffer || (mInSegmentReadIndex < mSegmentSize && mStreamToDecode->NotEnded());
+	// True while another byte may still be obtained, including from a later
+	// PFB segment -- GetNextByteForToken crosses segment boundaries. False
+	// only at genuine end of input. (Distinct from "current segment has
+	// bytes left", which is no longer the tokenizer's concern.)
+	return mHasTokenBuffer || NotEnded();
 }
 
 
@@ -511,7 +519,7 @@ void InputPFBDecodeStream::SkipTillToken()
 		return;
 
 	// skip till hitting first non space, or segment end
-	while(IsSegmentNotEnded())
+	while(HasMoreInput())
 	{
 		if(GetNextByteForToken(buffer) != PDFHummus::eSuccess)
 			break;

--- a/PDFWriter/InputPFBDecodeStream.h
+++ b/PDFWriter/InputPFBDecodeStream.h
@@ -94,7 +94,7 @@ private:
 	PDFHummus::EStatusCode StoreSegmentLength();
 	PDFHummus::EStatusCode FlushBinarySectionTrailingCode();
 	bool IsPostScriptWhiteSpace(Byte inCharacter);
-	bool IsSegmentNotEnded();
+	bool HasMoreInput();
 	void SaveTokenBuffer(Byte inToSave);
 	bool IsPostScriptEntityBreaker(Byte inCharacter);
 	PDFHummus::EStatusCode InitializeBinaryDecode();

--- a/PDFWriter/InputPFBDecodeStream.h
+++ b/PDFWriter/InputPFBDecodeStream.h
@@ -59,13 +59,17 @@ public:
 
 	// token actions
 
-	// get the next avialable postscript token. return result returns whether
-	// token retreive was successful and the token (if it was).
-	// note that segment end automatically cuts of a token
+	// Get the next PostScript token. The pair's bool is whether a token was
+	// retrieved; the string is the token when so. PFB segment boundaries are
+	// crossed transparently -- a token, and the whitespace between tokens,
+	// may span segments. A false result means a genuine end of data or a
+	// decoder failure (use GetInternalState() to tell which), not a segment
+	// break.
 	BoolAndString GetNextToken();
 
-	// skip white spaces till token or EOF. note that end of segment 
-	// will stop tokenizer as well
+	// Skip whitespace until the next token byte or a genuine end of data,
+	// crossing PFB segment boundaries. The token byte is pushed back for the
+	// following read.
 	void SkipTillToken();
 
 	PDFHummus::EStatusCode GetInternalState();

--- a/PDFWriter/Type1Input.cpp
+++ b/PDFWriter/Type1Input.cpp
@@ -201,28 +201,13 @@ EStatusCode Type1Input::ReadType1File(IByteReaderWithPosition* inType1)
 
 bool Type1Input::ReadNextTokenValue(std::string& outValue,EStatusCode& outStatus)
 {
-	// GetNextToken returns {false,""} at a PFB segment boundary too, not only
-	// when a value is genuinely missing: a segment whose tail is whitespace
-	// yields no token while the next segment still carries data (the decoder
-	// loads it on the following call). Retry across such benign boundaries;
-	// only a decoder failure or a real end-of-stream means the value is
-	// actually absent.
-	for(;;)
-	{
-		BoolAndString token = mPFBDecoder.GetNextToken();
-		if(token.first)
-		{
-			outValue = token.second;
-			outStatus = eSuccess;
-			return true;
-		}
-		if(mPFBDecoder.GetInternalState() != eSuccess || !mPFBDecoder.NotEnded())
-		{
-			outValue.clear();
-			outStatus = eFailure;
-			return false;
-		}
-	}
+	// GetNextToken now crosses PFB segment boundaries internally, so a
+	// {false} result means the value token is genuinely absent (end of input
+	// or decoder failure), not merely a segment break.
+	BoolAndString token = mPFBDecoder.GetNextToken();
+	outValue = token.second;
+	outStatus = token.first ? eSuccess : eFailure;
+	return token.first;
 }
 
 EStatusCode Type1Input::ReadFontDictionary()

--- a/PDFWriter/Type1Input.cpp
+++ b/PDFWriter/Type1Input.cpp
@@ -201,9 +201,6 @@ EStatusCode Type1Input::ReadType1File(IByteReaderWithPosition* inType1)
 
 bool Type1Input::ReadNextTokenValue(std::string& outValue,EStatusCode& outStatus)
 {
-	// GetNextToken now crosses PFB segment boundaries internally, so a
-	// {false} result means the value token is genuinely absent (end of input
-	// or decoder failure), not merely a segment break.
 	BoolAndString token = mPFBDecoder.GetNextToken();
 	outValue = token.second;
 	outStatus = token.first ? eSuccess : eFailure;

--- a/PDFWriterTesting/Type1InputTest.cpp
+++ b/PDFWriterTesting/Type1InputTest.cpp
@@ -252,11 +252,12 @@ static bool RunAddDependentGlyphsCases() {
 // converter yielded 0 / empty and parsing reported eSuccess. Now a missing
 // value token flags failure and the parse returns non-eSuccess.
 
-// Each case feeds a raw ASCII segment ending in a dangling key (no value
-// token, segment then ends) and expects the parse to fail rather than
-// silently accept. The two rows enter the fix through the two top-level
-// dictionary entry points: "begin" -> ReadFontDictionary, "/Private" ->
-// ReadPrivateDictionary.
+// Each case feeds a raw ASCII segment ending in a dangling key (the key is a
+// well-formed token -- terminated by a newline, as real PFB segments are --
+// but no value token follows before the segment ends) and expects the parse
+// to fail rather than silently accept. The two rows enter the fix through
+// the two top-level dictionary entry points: "begin" -> ReadFontDictionary,
+// "/Private" -> ReadPrivateDictionary.
 struct MissingValueTokenCase {
 	const char* label;       // <Condition>_<Result>
 	const char* ascii;       // raw ASCII segment, dangling key last
@@ -264,8 +265,8 @@ struct MissingValueTokenCase {
 };
 
 static const MissingValueTokenCase scMissingValueTokenCases[] = {
-	{"FontDictionaryPath_Fails",    "12 dict begin\n/PaintType",        "/PaintType"},
-	{"PrivateDictionaryPath_Fails", "/Private 5 dict dup begin\n/lenIV", "/lenIV"},
+	{"FontDictionaryPath_Fails",    "12 dict begin\n/PaintType\n",        "/PaintType"},
+	{"PrivateDictionaryPath_Fails", "/Private 5 dict dup begin\n/lenIV\n", "/lenIV"},
 };
 
 static bool RunMissingValueTokenCases() {
@@ -351,49 +352,79 @@ static bool Reset_OmittedFontDictMetrics_DefaultsApplied() {
 // newline makes the value-read's GetNextToken hit the no-token boundary
 // path); its value "7" is the first token of segment 2. The parse must
 // succeed and PaintType must read as 7.
-static bool ReadNextTokenValue_ValueAcrossSegmentBoundary_Succeeds() {
-	// Arrange
-	vector<string> headerSegments;
-	headerSegments.push_back(
-		"%!PS-AdobeFont-1.0: Synth 001.000\n"
-		"12 dict begin\n"
-		"/FontInfo 4 dict dup begin\n"
-		"/version (001.000) readonly def\n"
-		"/FullName (Synth) readonly def\n"
-		"/FamilyName (Synth) readonly def\n"
-		"/Weight (Regular) readonly def\n"
-		"end readonly def\n"
-		"/FontName /Synth def\n"
-		"/FontType 1 def\n"
-		"/FontMatrix [0.001 0 0 0.001 0 0] readonly def\n"
-		"/FontBBox {0 0 1000 1000} readonly def\n"
-		"/Encoding StandardEncoding def\n"
-		"/PaintType\n\n");                     // key + one consumed terminator
-		                                       // + one leftover whitespace, so
-		                                       // the value-read GetNextToken
-		                                       // hits the segment-end no-token
-		                                       // path; value is in segment 2
-	headerSegments.push_back(
-		"7 def\n"
-		"currentdict end\n"
-		"currentfile eexec\n");
-	vector<Type1SyntheticBuilder::NamedCharString> noGlyphs;
-	string pfb = Type1SyntheticBuilder::WithCharStrings(noGlyphs, headerSegments);
+// V-090: GetNextToken now crosses PFB segment boundaries, so a value, a whole
+// token, or inter-token whitespace spanning segments produced by a fixed-size
+// PFB chunker parses correctly instead of being rejected / truncated. Each
+// case splits the font dictionary into multiple type-1 segments at an awkward
+// point; the shared prefix below is prepended to the first segment. All
+// expect the parse to succeed with /PaintType read as 5.
+//
+// Pre-root-fix outcomes (stash-verify): ValueInNextSegment ->
+// ReadNextTokenValue's old retry loop masked it; KeyTokenSplitAcrossSegments
+// -> "/PaintType" tokenized as "/Pai"+"ntType", key never matched, PaintType
+// stays at the Reset() default 0; WhitespaceOnlySegmentBetween -> value read
+// returns no token, parse rejected.
+static const char* const scSplitHeaderPrefix =
+	"%!PS-AdobeFont-1.0: Synth 001.000\n"
+	"12 dict begin\n"
+	"/FontInfo 4 dict dup begin\n"
+	"/version (001.000) readonly def\n"
+	"/FullName (Synth) readonly def\n"
+	"/FamilyName (Synth) readonly def\n"
+	"/Weight (Regular) readonly def\n"
+	"end readonly def\n"
+	"/FontName /Synth def\n"
+	"/FontType 1 def\n"
+	"/FontMatrix [0.001 0 0 0.001 0 0] readonly def\n"
+	"/FontBBox {0 0 1000 1000} readonly def\n"
+	"/Encoding StandardEncoding def\n";
 
-	Type1Input type1;
-	// Act
-	EStatusCode status = Type1SyntheticBuilder::ParseAsType1(pfb, type1);
+struct SegmentSplitCase {
+	const char* label;     // <Condition>_<Result>
+	const char* seg1Tail;  // appended after scSplitHeaderPrefix in segment 1
+	const char* seg2;
+	const char* seg3;      // "" => omitted
+};
 
-	// Assert
-	if(status != eSuccess) {
-		cout << "Type1InputTest [ReadNextTokenValue::ValueAcrossSegmentBoundary_Succeeds]: "
-		        "valid font with /PaintType value in the next segment was rejected" << endl;
-		return false;
-	}
-	if(type1.mFontDictionary.PaintType != 7) {
-		cout << "Type1InputTest [ReadNextTokenValue::ValueAcrossSegmentBoundary_Succeeds]: "
-		        "PaintType " << type1.mFontDictionary.PaintType << ", expected 7" << endl;
-		return false;
+static const SegmentSplitCase scSegmentSplitCases[] = {
+	// value token begins in segment 2 (one leftover whitespace in seg 1)
+	{"ValueInNextSegment_Succeeds",          "/PaintType\n\n", "5 def\ncurrentdict end\ncurrentfile eexec\n", ""},
+	// the "/PaintType" token itself straddles the segment boundary
+	{"KeyTokenSplitAcrossSegments_Succeeds", "/Pai",           "ntType 5 def\ncurrentdict end\ncurrentfile eexec\n", ""},
+	// an entirely whitespace segment sits between key and value
+	{"WhitespaceOnlySegmentBetween_Succeeds","/PaintType\n",   "   \n  ", "5 def\ncurrentdict end\ncurrentfile eexec\n"},
+};
+
+static bool RunSegmentSplitCases() {
+	const size_t count = sizeof(scSegmentSplitCases) / sizeof(scSegmentSplitCases[0]);
+	for(size_t i = 0; i < count; ++i) {
+		const SegmentSplitCase& testCase = scSegmentSplitCases[i];
+
+		// Arrange
+		vector<string> headerSegments;
+		headerSegments.push_back(string(scSplitHeaderPrefix) + testCase.seg1Tail);
+		headerSegments.push_back(testCase.seg2);
+		if(testCase.seg3[0] != '\0')
+			headerSegments.push_back(testCase.seg3);
+		vector<Type1SyntheticBuilder::NamedCharString> noGlyphs;
+		string pfb = Type1SyntheticBuilder::WithCharStrings(noGlyphs, headerSegments);
+
+		// Act
+		Type1Input type1;
+		EStatusCode status = Type1SyntheticBuilder::ParseAsType1(pfb, type1);
+
+		// Assert
+		if(status != eSuccess) {
+			cout << "Type1InputTest [SegmentSplit::" << testCase.label
+			     << "]: valid font split across PFB segments was rejected" << endl;
+			return false;
+		}
+		if(type1.mFontDictionary.PaintType != 5) {
+			cout << "Type1InputTest [SegmentSplit::" << testCase.label
+			     << "]: PaintType " << type1.mFontDictionary.PaintType
+			     << ", expected 5 (token/value not reassembled across segments)" << endl;
+			return false;
+		}
 	}
 	return true;
 }
@@ -403,7 +434,7 @@ int Type1InputTest(int argc, char* argv[]) {
 	if(!ReadType1File_RealPFB_ParsesFontInfoStrings(argv)) return 1;
 	if(!RunAddDependentGlyphsCases()) return 1;
 	if(!RunMissingValueTokenCases()) return 1;
-	if(!ReadNextTokenValue_ValueAcrossSegmentBoundary_Succeeds()) return 1;
+	if(!RunSegmentSplitCases()) return 1;
 	if(!Reset_OmittedFontDictMetrics_DefaultsApplied()) return 1;
 	return 0;
 }

--- a/PDFWriterTesting/Type1InputTest.cpp
+++ b/PDFWriterTesting/Type1InputTest.cpp
@@ -345,13 +345,6 @@ static bool Reset_OmittedFontDictMetrics_DefaultsApplied() {
 	return true;
 }
 
-// V-072 regression guard: GetNextToken returns {false,""} at a PFB segment
-// boundary (segment tail is whitespace) even though the next segment carries
-// data. ReadNextTokenValue must retry across such a boundary, not reject the
-// font. Here /PaintType is the last token of ASCII segment 1 (a trailing
-// newline makes the value-read's GetNextToken hit the no-token boundary
-// path); its value "7" is the first token of segment 2. The parse must
-// succeed and PaintType must read as 7.
 // V-090: GetNextToken now crosses PFB segment boundaries, so a value, a whole
 // token, or inter-token whitespace spanning segments produced by a fixed-size
 // PFB chunker parses correctly instead of being rejected / truncated. Each

--- a/PDFWriterTesting/Type1InputTest.cpp
+++ b/PDFWriterTesting/Type1InputTest.cpp
@@ -429,12 +429,41 @@ static bool RunSegmentSplitCases() {
 	return true;
 }
 
+// A regular token is self-delimiting: when its bytes are the literal last
+// content with no trailing whitespace -- the value "7" here ends exactly at
+// the type-3 EOF segment -- GetNextToken must still return it (end of data is
+// a valid token terminator), not report a failed read. Guards against the
+// tokenizer becoming stricter than it was about unterminated trailing tokens.
+static bool GetNextToken_RegularTokenEndedByEndOfData_TokenReturned() {
+	// Arrange: "7" is the final byte, immediately followed by the EOF segment.
+	string pfb = Type1SyntheticBuilder::RawPFBFromAsciiSegment(
+		"12 dict begin\n/PaintType 7");
+
+	// Act
+	Type1Input type1;
+	EStatusCode status = Type1SyntheticBuilder::ParseAsType1(pfb, type1);
+
+	// Assert
+	if(status != eSuccess) {
+		cout << "Type1InputTest [GetNextToken::RegularTokenEndedByEndOfData_TokenReturned]: "
+		        "value token ended by end-of-data was treated as a failed read" << endl;
+		return false;
+	}
+	if(type1.mFontDictionary.PaintType != 7) {
+		cout << "Type1InputTest [GetNextToken::RegularTokenEndedByEndOfData_TokenReturned]: "
+		        "PaintType " << type1.mFontDictionary.PaintType << ", expected 7" << endl;
+		return false;
+	}
+	return true;
+}
+
 int Type1InputTest(int argc, char* argv[]) {
 	(void) argc;
 	if(!ReadType1File_RealPFB_ParsesFontInfoStrings(argv)) return 1;
 	if(!RunAddDependentGlyphsCases()) return 1;
 	if(!RunMissingValueTokenCases()) return 1;
 	if(!RunSegmentSplitCases()) return 1;
+	if(!GetNextToken_RegularTokenEndedByEndOfData_TokenReturned()) return 1;
 	if(!Reset_OmittedFontDictMetrics_DefaultsApplied()) return 1;
 	return 0;
 }


### PR DESCRIPTION
## What

Closes **V-090** at the root.

`GetNextToken()` leaked PFB segment framing (a transport detail) to callers: when a segment's tail was whitespace it returned `{false,""}` with `mInternalState==eSuccess` even though the next segment still held data. Every value-reading parser had to re-implement a retry loop, and most got it wrong:

- `ParseDoubleArray` (`/FontMatrix`, `/FontBBox`), `ParseEncoding` → **valid font rejected**
- `ParseIntVector` / `ParseDoubleVector` (`/BlueValues`, `/StemSnap*`) → **array silently truncated**
- a token whose bytes straddle a chunk boundary (`/Font` | `Matrix`) → **returned truncated**

Reachable with fixed-size-chunked PFB producers (t1utils-style).

## Root cause & fix

`InputPFBDecodeStream::Read()` (the binary charstring path) **already** crosses segments transparently — outer loop calls `InitializeStreamSegment()` on exhaustion. `GetNextToken()` did not. This makes the tokenizer consistent with that proven, suite-tested path:

- **`GetNextByteForToken`** advances to the next segment when the current is exhausted (same shape as `Read()`); returns failure only on genuine end-of-input or a decoder error. The per-segment decode-mode switch (plaintext / eexec / EOF) stays inside `InitializeStreamSegment()`, so those transitions are preserved.
- **`IsSegmentNotEnded()`** (per-current-segment) → **`HasMoreInput()`** (`mHasTokenBuffer || NotEnded()`) as the loop/peek guard; the now-redundant pre-advance block in `GetNextToken` removed.
- **`ReadNextTokenValue`** simplified back to single-call (folded from #374's review) — `GetNextToken` no longer returns spurious `{false}`, so `{false}` means the value is genuinely absent; V-072's missing-value-at-EOF semantics are preserved.

`ParseDoubleArray`/`ParseEncoding`/`ParseIntVector`/`ParseDoubleVector` are correct with **no change to them**, and the token-split corruption is fixed too (the per-caller-loop approach we'd sketched could not have fixed that).

## Testing

- `Type1SyntheticBuilder`'s `vector<string>` `WithCharStrings` overload drives a `SegmentSplit` table: value-in-next-segment, key-token split across segments, whitespace-only segment between key and value — all assert parse success with `/PaintType` read as 5.
- **Stash-verified**: reverting only `InputPFBDecodeStream.*` fails these cases (*"valid font split across PFB segments was rejected"* / token not reassembled) while the rest of the suite stays green — proving they guard the root behavior.
- `MissingValueToken` cases now terminate the dangling key with a newline (real PFB segments end tokens with whitespace before the boundary) so they still test a genuinely-absent value, not a token glued to the EOF segment.
- Full suite **98/98**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)