### PR TITLE
fix: bound SFNT recursion + validate name/loca table ranges (V-019/V-023/V-024/V-025)

### DIFF
--- a/PDFWriter/OpenTypeFileInput.cpp
+++ b/PDFWriter/OpenTypeFileInput.cpp
@@ -24,6 +24,11 @@
 
 using namespace PDFHummus;
 
+// Bounds the mutual recursion between ReadOpenTypeSFNT (ttcf chains) and
+// ReadOpenTypeSFNTFromDfont (mac resource-fork wrappers). Legitimate nesting
+// is at most a dfont wrapping a ttcf wrapping a font (depth ~3); 8 is generous.
+static const unsigned short scMaxSFNTRecursionDepth = 8;
+
 OpenTypeFileInput::OpenTypeFileInput(void)
 {
     mHeaderOffset = 0;
@@ -195,8 +200,8 @@ EStatusCode OpenTypeFileInput::ReadOpenTypeHeader()
 
 	do
 	{
-		status = ReadOpenTypeSFNT();
-        
+		status = ReadOpenTypeSFNT(0);
+
 		if(status != PDFHummus::eSuccess)
 		{
 			TRACE_LOG("OpenTypeFileInput::ReaderTrueTypeHeader, SFNT header not open type");
@@ -227,9 +232,15 @@ EStatusCode OpenTypeFileInput::ReadOpenTypeHeader()
 	return status;
 }
 
-EStatusCode OpenTypeFileInput::ReadOpenTypeSFNT()
+EStatusCode OpenTypeFileInput::ReadOpenTypeSFNT(unsigned short inRecursionDepth)
 {
 	unsigned long sfntVersion;
+
+	if(inRecursionDepth > scMaxSFNTRecursionDepth)
+	{
+		TRACE_LOG1("OpenTypeFileInput::ReadOpenTypeSFNT, SFNT nesting exceeded max depth %d", scMaxSFNTRecursionDepth);
+		return PDFHummus::eFailure;
+	}
 
     mPrimitivesReader.SetOffset(mHeaderOffset);
 	mPrimitivesReader.ReadULONG(sfntVersion);
@@ -260,10 +271,18 @@ EStatusCode OpenTypeFileInput::ReadOpenTypeSFNT()
         for (int i= 0; i<= mFaceIndex; ++i) {
             mPrimitivesReader.ReadULONG(offsetTable);
         }
-        
+
+        if(0 == offsetTable)
+        {
+            // mHeaderOffset would not advance, so the recursion would re-read
+            // this same ttcf header forever.
+            TRACE_LOG("OpenTypeFileInput::ReadOpenTypeSFNT, ttcf offset table entry is zero");
+            return PDFHummus::eFailure;
+        }
+
         mHeaderOffset = mHeaderOffset + offsetTable;
-        
-        return ReadOpenTypeSFNT();
+
+        return ReadOpenTypeSFNT(inRecursionDepth + 1);
     } else if((0x10000 == sfntVersion) || (0x74727565 /* true */ == sfntVersion))
 	{
 		mFontType = EOpenTypeTrueType;
@@ -274,7 +293,7 @@ EStatusCode OpenTypeFileInput::ReadOpenTypeSFNT()
 		mFontType = EOpenTypeCFF;
 		return PDFHummus::eSuccess;
 	}
-	else if ((ReadOpenTypeSFNTFromDfont() == PDFHummus::eSuccess))
+	else if ((ReadOpenTypeSFNTFromDfont(inRecursionDepth) == PDFHummus::eSuccess))
     {
 		return PDFHummus::eSuccess;
     }
@@ -282,7 +301,7 @@ EStatusCode OpenTypeFileInput::ReadOpenTypeSFNT()
 		return PDFHummus::eFailure;
 }
 
-EStatusCode OpenTypeFileInput::ReadOpenTypeSFNTFromDfont()
+EStatusCode OpenTypeFileInput::ReadOpenTypeSFNTFromDfont(unsigned short inRecursionDepth)
 {
 	EStatusCode status = eSuccess;
     // mac resource fork header parsing
@@ -436,7 +455,7 @@ EStatusCode OpenTypeFileInput::ReadOpenTypeSFNTFromDfont()
     }
 
 	if (status == eSuccess && foundSfnt)
-		return ReadOpenTypeSFNT();
+		return ReadOpenTypeSFNT(inRecursionDepth + 1);
 	else
 	    return PDFHummus::eFailure;
 }
@@ -689,6 +708,19 @@ EStatusCode OpenTypeFileInput::ReadName()
 
 	for(unsigned short i=0;i<mName.mNameEntriesCount;++i)
 	{
+		// String storage lives within the name table. An entry whose
+		// stringOffset+Offset+Length exceeds the table length would otherwise
+		// have bytes from an adjacent table read in and copied into the
+		// produced PDF; clamp such an entry to empty instead.
+		unsigned long stringEnd = (unsigned long)stringOffset + mName.mNameEntries[i].Offset + mName.mNameEntries[i].Length;
+		if(stringEnd > it->second.Length)
+		{
+			TRACE_LOG2("OpenTypeFileInput::ReadName, name entry %d string range escapes name table; clamping to empty (entry length %d)",
+				i, mName.mNameEntries[i].Length);
+			mName.mNameEntries[i].Length = 0;
+			mName.mNameEntries[i].String = new char[0];
+			continue;
+		}
 		mName.mNameEntries[i].String = new char[mName.mNameEntries[i].Length];
 		mPrimitivesReader.SetOffset(it->second.Offset + stringOffset + mName.mNameEntries[i].Offset);
 		mPrimitivesReader.Read((Byte*)(mName.mNameEntries[i].String),mName.mNameEntries[i].Length);
@@ -732,6 +764,24 @@ EStatusCode OpenTypeFileInput::ReadGlyfForDependencies()
 	if(it == mTables.end())
 	{
 		TRACE_LOG("OpenTypeFileInput::ReadGlyfForDependencies, could not find glyf table");
+		return PDFHummus::eFailure;
+	}
+
+	// loca offsets are used below as seek positions into the glyf table.
+	// They must be monotonically non-decreasing and stay within the table,
+	// otherwise a crafted loca would point glyph reads at arbitrary file
+	// offsets (cross-table data interpreted as glyph contours/components).
+	for(unsigned short i=0; i < mMaxp.NumGlyphs; ++i)
+	{
+		if(mLoca[i+1] < mLoca[i])
+		{
+			TRACE_LOG1("OpenTypeFileInput::ReadGlyfForDependencies, loca offsets not monotonic at glyph %d", i);
+			return PDFHummus::eFailure;
+		}
+	}
+	if(mLoca[mMaxp.NumGlyphs] > it->second.Length)
+	{
+		TRACE_LOG("OpenTypeFileInput::ReadGlyfForDependencies, loca final offset exceeds glyf table length");
 		return PDFHummus::eFailure;
 	}
 

--- a/PDFWriter/OpenTypeFileInput.h
+++ b/PDFWriter/OpenTypeFileInput.h
@@ -244,8 +244,8 @@ private:
 										 // technique some producers use
 
 	PDFHummus::EStatusCode ReadOpenTypeHeader();
-	PDFHummus::EStatusCode ReadOpenTypeSFNT();
-    PDFHummus::EStatusCode ReadOpenTypeSFNTFromDfont();
+	PDFHummus::EStatusCode ReadOpenTypeSFNT(unsigned short inRecursionDepth);
+    PDFHummus::EStatusCode ReadOpenTypeSFNTFromDfont(unsigned short inRecursionDepth);
 	PDFHummus::EStatusCode ReadHead();
 	PDFHummus::EStatusCode ReadMaxP();
 	PDFHummus::EStatusCode ReadHHea();

--- a/PDFWriterTesting/OpenTypeFileInputTest.cpp
+++ b/PDFWriterTesting/OpenTypeFileInputTest.cpp
@@ -80,6 +80,155 @@ static size_t findTableOffset(const string& inFont, const char* inTag) {
 	return (size_t)-1;
 }
 
+static unsigned short readU16BE(const string& inBuf, size_t inPos) {
+	return (unsigned short)(((Byte)inBuf[inPos] << 8) | (Byte)inBuf[inPos+1]);
+}
+
+// Length field of an SFNT table directory entry (entry+12, big-endian u32).
+// Returns (size_t)-1 on missing table or malformed directory.
+static size_t findTableLength(const string& inFont, const char* inTag) {
+	if(inFont.size() < 12)
+		return (size_t)-1;
+	const Byte* p = (const Byte*)inFont.data();
+	unsigned short numTables = (unsigned short)((p[4] << 8) | p[5]);
+	if(inFont.size() < 12u + (size_t)numTables * 16u)
+		return (size_t)-1;
+	for(unsigned short i = 0; i < numTables; ++i) {
+		size_t entry = 12u + (size_t)i * 16u;
+		if(p[entry+0] == (Byte)inTag[0] && p[entry+1] == (Byte)inTag[1]
+		&& p[entry+2] == (Byte)inTag[2] && p[entry+3] == (Byte)inTag[3]) {
+			return ((size_t)p[entry+12] << 24) | ((size_t)p[entry+13] << 16)
+			     | ((size_t)p[entry+14] << 8) | (size_t)p[entry+15];
+		}
+	}
+	return (size_t)-1;
+}
+
+// Pre-fix: ReadOpenTypeSFNT's ttcf branch did mHeaderOffset += offsetTable then
+// recursed unconditionally. An offset-table entry of 0 leaves mHeaderOffset
+// unchanged, so the recursion re-reads the same ttcf header forever until the
+// stack is exhausted. The buffer below is a minimal ttcf header whose single
+// font offset is 0. Post-fix the zero entry is rejected before recursing, so
+// the call returns eFailure instead of crashing. Reaching the assertion at all
+// proves the unbounded recursion is gone.
+static bool ReadOpenTypeSFNT_TtcfZeroOffsetTable_ReturnsFailure(char* argv[]) {
+	(void)argv;
+	// Arrange — 'ttcf', version 1.0, numFonts 1, offsetTable[0] = 0
+	const Byte ttc[16] = {
+		0x74,0x74,0x63,0x66,  0x00,0x01,0x00,0x00,
+		0x00,0x00,0x00,0x01,  0x00,0x00,0x00,0x00
+	};
+
+	// Act
+	InputByteArrayStream stream((Byte*)ttc, (LongFilePositionType)sizeof(ttc));
+	OpenTypeFileInput openType;
+	EStatusCode status = openType.ReadOpenTypeFile(&stream, 0);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "OpenTypeFileInputTest: zero ttcf offset table was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Pre-fix: ReadName allocated new char[Length] and Read Length bytes from
+// nameOffset + stringOffset + entryOffset with no check that the range stays
+// inside the name table, so a crafted Length pulled bytes out of an adjacent
+// table into the entry's String (and from there into the produced PDF).
+// Patching name entry 0's Length to 0xFFFF makes its range escape the table.
+// Post-fix that entry is clamped to empty (Length 0) and parsing still
+// succeeds (a malformed sub-entry must not reject the whole font).
+static bool ReadName_StringRangeEscapesNameTable_ClampsEntry(char* argv[]) {
+	// Arrange
+	string font;
+	if(!readFileBytes(BuildRelativeInputPath(argv, "fonts/arial.ttf"), font)) {
+		cout << "OpenTypeFileInputTest: failed to read arial.ttf" << endl;
+		return false;
+	}
+	size_t nameOffset = findTableOffset(font, "name");
+	if(nameOffset == (size_t)-1 || nameOffset + 14 + 2 > font.size()) {
+		cout << "OpenTypeFileInputTest: arial.ttf name table missing or truncated" << endl;
+		return false;
+	}
+	// Header: format(2) count(2) stringOffset(2); entry 0 Length is the 5th
+	// USHORT of the first 6-USHORT record (offset 6 + 8).
+	font[nameOffset + 14] = (char)0xFF;
+	font[nameOffset + 15] = (char)0xFF;
+
+	// Act
+	InputByteArrayStream stream((Byte*)&font[0], (LongFilePositionType)font.size());
+	OpenTypeFileInput* openType = new OpenTypeFileInput();
+	EStatusCode status = openType->ReadOpenTypeFile(&stream, 0);
+
+	// Assert
+	bool ok = false;
+	do {
+		if(status != eSuccess) {
+			cout << "OpenTypeFileInputTest: a single out-of-range name entry rejected the whole font" << endl;
+			break;
+		}
+		if(openType->mName.mNameEntries[0].Length != 0) {
+			cout << "OpenTypeFileInputTest: out-of-range name entry 0 not clamped (Length "
+			     << openType->mName.mNameEntries[0].Length << ")" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	delete openType;
+	return ok;
+}
+
+// Pre-fix: ReadGlyfForDependencies used loca offsets as glyf seek positions
+// with no monotonicity / in-table check. The last loca entry is not itself a
+// seek base, so zeroing it leaves a pristine pre-fix parse succeeding while
+// making loca[NumGlyphs] < loca[NumGlyphs-1]. Post-fix the non-monotonic loca
+// is rejected.
+static bool ReadGlyfForDependencies_LocaNotMonotonic_ReturnsFailure(char* argv[]) {
+	// Arrange
+	string font;
+	if(!readFileBytes(BuildRelativeInputPath(argv, "fonts/arial.ttf"), font)) {
+		cout << "OpenTypeFileInputTest: failed to read arial.ttf" << endl;
+		return false;
+	}
+	size_t headOffset = findTableOffset(font, "head");
+	size_t maxpOffset = findTableOffset(font, "maxp");
+	size_t locaOffset = findTableOffset(font, "loca");
+	size_t locaLength = findTableLength(font, "loca");
+	if(headOffset == (size_t)-1 || maxpOffset == (size_t)-1
+	|| locaOffset == (size_t)-1 || locaLength == (size_t)-1
+	|| headOffset + 52 > font.size() || maxpOffset + 6 > font.size()) {
+		cout << "OpenTypeFileInputTest: arial.ttf head/maxp/loca tables missing or truncated" << endl;
+		return false;
+	}
+	unsigned short indexToLocFormat = readU16BE(font, headOffset + 50);
+	unsigned short numGlyphs = readU16BE(font, maxpOffset + 4);
+	// Last loca entry is at index numGlyphs; width 2 (short) or 4 (long).
+	size_t lastEntry = (indexToLocFormat == 0)
+		? locaOffset + (size_t)numGlyphs * 2
+		: locaOffset + (size_t)numGlyphs * 4;
+	size_t entryWidth = (indexToLocFormat == 0) ? 2u : 4u;
+	if(lastEntry + entryWidth > locaOffset + locaLength || lastEntry + entryWidth > font.size()) {
+		cout << "OpenTypeFileInputTest: computed loca last-entry position out of range" << endl;
+		return false;
+	}
+	for(size_t b = 0; b < entryWidth; ++b)
+		font[lastEntry + b] = 0;
+
+	// Act
+	InputByteArrayStream stream((Byte*)&font[0], (LongFilePositionType)font.size());
+	OpenTypeFileInput openType;
+	EStatusCode status = openType.ReadOpenTypeFile(&stream, 0);
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "OpenTypeFileInputTest: non-monotonic loca was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
 // Pre-fix: the existing > NumGlyphs guard accepted numberOfHMetrics == 0,
 // then the second loop indexed mHMtx[NumberOfHMetrics-1]. (unsigned short)0
 // minus int 1 promotes to int -1, so the access reads one HMtxTableEntry
@@ -224,6 +373,9 @@ static bool ReadName_ArialTtf_PopulatesNameEntries(char* argv[]) {
 int OpenTypeFileInputTest(int argc, char* argv[]) {
 	(void)argc;
 	if(!ReadHMtx_NumberOfHMetricsZero_ReturnsFailure(argv)) return 1;
+	if(!ReadOpenTypeSFNT_TtcfZeroOffsetTable_ReturnsFailure(argv)) return 1;
+	if(!ReadName_StringRangeEscapesNameTable_ClampsEntry(argv)) return 1;
+	if(!ReadGlyfForDependencies_LocaNotMonotonic_ReturnsFailure(argv)) return 1;
 	if(!ReadOpenTypeFile_ArialTtf_PopulatesHheaMaxp(argv)) return 1;
 	if(!ReadName_ArialTtf_PopulatesNameEntries(argv)) return 1;
 	return 0;

--- a/PDFWriterTesting/OpenTypeFileInputTest.cpp
+++ b/PDFWriterTesting/OpenTypeFileInputTest.cpp
@@ -114,13 +114,14 @@ static size_t findTableLength(const string& inFont, const char* inTag) {
 static bool ReadOpenTypeSFNT_TtcfZeroOffsetTable_ReturnsFailure(char* argv[]) {
 	(void)argv;
 	// Arrange — 'ttcf', version 1.0, numFonts 1, offsetTable[0] = 0
-	const Byte ttc[16] = {
+	// (non-const to match InputByteArrayStream's mutable-pointer constructor)
+	Byte ttc[16] = {
 		0x74,0x74,0x63,0x66,  0x00,0x01,0x00,0x00,
 		0x00,0x00,0x00,0x01,  0x00,0x00,0x00,0x00
 	};
 
 	// Act
-	InputByteArrayStream stream((Byte*)ttc, (LongFilePositionType)sizeof(ttc));
+	InputByteArrayStream stream(ttc, (LongFilePositionType)sizeof(ttc));
 	OpenTypeFileInput openType;
 	EStatusCode status = openType.ReadOpenTypeFile(&stream, 0);
 


### PR DESCRIPTION
Part of the Phase-2 font-parsing hardening (C8 grind, by-file batch). All four findings live in \`OpenTypeFileInput.cpp\`.

## Findings

- **V-019 (MED)** — `ReadOpenTypeSFNT` ttcf branch did `mHeaderOffset += offsetTable` then recursed unconditionally. An offset-table entry of `0` leaves `mHeaderOffset` unchanged, so the recursion re-reads the same ttcf header until the stack is exhausted. Fix: reject the zero entry, and bound the `ReadOpenTypeSFNT` ↔ `ReadOpenTypeSFNTFromDfont` mutual recursion with a depth parameter (`scMaxSFNTRecursionDepth = 8`; legitimate dfont→ttcf→font nesting is depth ~3).
- **V-025 (LOW)** — same mutual recursion is reachable via dfont → sfnt → ttcf chains; the new depth bound caps it. The commented-out mac resource-fork header validation is **left as-is intentionally** (lenient parsing of real-world dfonts — correctness, not memory-safety; consistent with the project's hardening-scope rule).
- **V-023 (MED)** — `ReadName` allocated `new char[Length]` and read `Length` bytes from `nameOffset + stringOffset + entryOffset` with no check that the range stayed inside the `name` table, bleeding bytes from an adjacent table into the entry string (and into the produced PDF). Out-of-range entries are clamped to empty; the font still parses (a malformed sub-entry must not reject the whole font).
- **V-024 (LOW)** — `ReadGlyfForDependencies` used `loca` offsets as `glyf` seek positions with no sanity check (chains into the V-017 composite-glyph path). Enforce monotonic non-decreasing `loca` bounded by the `glyf` table length.

## Tests

`OpenTypeFileInputTest` gains three cases (existing arial.ttf happy-path cases retained as exact-value regression guards):

- `ReadOpenTypeSFNT_TtcfZeroOffsetTable_ReturnsFailure` — synthetic 16-byte ttcf with `offsetTable[0] == 0`. **Stash-verified: SEGFAULT pre-fix (infinite recursion), eFailure post-fix.**
- `ReadName_StringRangeEscapesNameTable_ClampsEntry` — patches arial.ttf name entry 0 `Length` to `0xFFFF`; asserts the entry is clamped (`Length == 0`) and the font still parses.
- `ReadGlyfForDependencies_LocaNotMonotonic_ReturnsFailure` — zeroes the last `loca` entry (not itself a seek base, so a pristine pre-fix parse succeeds); asserts post-fix rejection.

Full suite 98/98 green post-fix.

## Out of scope

Nothing deferred from this file in the C8 triage. (The DoS-cap-class and pure-correctness C8 items live in other files / the deferred memory-budget-cap decision.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)