### PR TITLE
fix: CFF charset OOB write + ReadCharString double-free (V-044/V-047/V-048)

### DIFF
--- a/PDFWriter/CFFFileInput.cpp
+++ b/PDFWriter/CFFFileInput.cpp
@@ -137,6 +137,11 @@ CFFFileInput::CFFFileInput(void)
 	mGlobalSubrs.mCharStringsIndex = NULL;
 	mCharStrings = NULL;
 	mPrivateDicts = NULL;
+	// Set only by PrepareForGlyphIntepretation; the dependency walkers and
+	// GetCharacterFromStandardEncoding rely on NULL meaning "no active
+	// interpretation flow".
+	mCurrentCharsetInfo = NULL;
+	mCurrentDependencies = NULL;
 }
 
 CFFFileInput::~CFFFileInput(void)
@@ -1007,7 +1012,10 @@ EStatusCode CFFFileInput::ReadFormat0Charset(bool inIsCID,
 	if(!inIsCID)
 		ioGlyphMap.insert(UShortToCharStringMap::value_type(0,inCharStrings.mCharStringsIndex));
 	*inSIDArray = new unsigned short[inCharStrings.mCharStringsCount];
-	(*inSIDArray)[0] = 0;
+	// element 0 is in range only when the CharStrings INDEX is non-empty;
+	// new unsigned short[0] is a zero-length buffer.
+	if(inCharStrings.mCharStringsCount > 0)
+		(*inSIDArray)[0] = 0;
 
 	if(inIsCID)
 	{
@@ -1036,7 +1044,10 @@ EStatusCode CFFFileInput::ReadFormat1Charset(bool inIsCID,
 	if(!inIsCID)
 		ioGlyphMap.insert(UShortToCharStringMap::value_type(0,inCharStrings.mCharStringsIndex));
 	*inSIDArray = new unsigned short[inCharStrings.mCharStringsCount];
-	(*inSIDArray)[0] = 0;
+	// element 0 is in range only when the CharStrings INDEX is non-empty;
+	// new unsigned short[0] is a zero-length buffer.
+	if(inCharStrings.mCharStringsCount > 0)
+		(*inSIDArray)[0] = 0;
 	unsigned long glyphIndex = 1;
 	unsigned short sid;
 	Byte left;
@@ -1076,7 +1087,10 @@ EStatusCode CFFFileInput::ReadFormat2Charset(bool inIsCID,
 	if(!inIsCID)
 		ioGlyphMap.insert(UShortToCharStringMap::value_type(0,inCharStrings.mCharStringsIndex));
 	*inSIDArray = new unsigned short[inCharStrings.mCharStringsCount];
-	(*inSIDArray)[0] = 0;
+	// element 0 is in range only when the CharStrings INDEX is non-empty;
+	// new unsigned short[0] is a zero-length buffer.
+	if(inCharStrings.mCharStringsCount > 0)
+		(*inSIDArray)[0] = 0;
 	unsigned short glyphIndex = 1;
 	unsigned short sid;
 	unsigned short left;
@@ -1296,7 +1310,10 @@ EStatusCode CFFFileInput::ReadCharString(	LongFilePositionType inCharStringStart
 	}while(false);
 
 	if(status != PDFHummus::eSuccess && *outCharString)
+	{
 		delete[] *outCharString;
+		*outCharString = NULL;
+	}
 
 	return status;
 }
@@ -1377,6 +1394,9 @@ EStatusCode CFFFileInput::Type2Endchar(const CharStringOperandList& inOperandLis
 
 CharString* CFFFileInput::GetCharacterFromStandardEncoding(Byte inCharacterCode)
 {
+	if(mCurrentCharsetInfo == NULL)
+		return NULL;
+
 	StandardEncoding standardEncoding;
 	const char* glyphName = standardEncoding.GetEncodedGlyphName(inCharacterCode);
 	CharPToUShortMap::iterator itStringToSID = 	mStringToSID.find(glyphName);

--- a/PDFWriterTesting/CFFFileInputTest.cpp
+++ b/PDFWriterTesting/CFFFileInputTest.cpp
@@ -37,6 +37,22 @@
        Type 2 seac (4-arg endchar) dependency graph without a visited-set
        guard or a depth cap, so a self-referencing or cyclic seac chain
        drove the call stack until it overflowed.
+     * V-044: the three charset format readers wrote (*inSIDArray)[0] = 0
+       unconditionally, but a font that omits /CharStrings has
+       mCharStringsCount == 0, making *inSIDArray a new unsigned short[0]
+       zero-length buffer — element 0 is an out-of-bounds heap write.
+     * V-048: ReadCharString deleted the charstring buffer on a failed read
+       but left *outCharString dangling; every Type 2 interpreter call site
+       then ran an unconditional delete[] on the same pointer (double-free)
+       when the charstring data was truncated past the stream end.
+
+   (V-046 — the format-0 encoding loop's Byte counter — was structurally
+   closed by #364's V-031 widening, which rewrote that loop to use an
+   unsigned short counter; no separate change or case here. V-047 —
+   latent stale mCurrentCharsetInfo deref in Type2Endchar — is a
+   constructor-init + NULL-guard hardening with no attacker-reachable
+   trigger today, so it follows the latent-fix principle: no synthetic
+   no-op case, covered by the existing suite.)
 
    Cases are grouped by the function they exercise (sc<Function>Cases) and
    driven by Run<Function>Cases runners. Each row's label states
@@ -555,11 +571,120 @@ static bool RunAddDependentGlyphsCases() {
 	return true;
 }
 
+// V-044: each charset format reader did (*inSIDArray)[0] = 0 before
+// checking mCharStringsCount. A font that omits /CharStrings has
+// mCharStringsCount == 0, so *inSIDArray is a new unsigned short[0]
+// zero-length buffer and element 0 is an out-of-bounds heap write.
+// WithCharset builds exactly that font (custom /charset, no /CharStrings);
+// the only payload needed is the one-byte charset format selector, since
+// with zero glyphs the per-glyph fill loops never iterate. Post-fix the
+// parse still succeeds (an empty CharStrings INDEX is valid CFF) and a
+// custom charset object is recorded.
+struct CharsetFormatCase {
+	const char* mLabel;
+	const char* mPayload;
+	size_t mPayloadLen;
+};
+
+static const CharsetFormatCase scReadCharsetCases[] = {
+	{"Format0EmptyCharStrings_ParsesWithoutOOBWrite", CFF_BYTES("\x00")},
+	{"Format1EmptyCharStrings_ParsesWithoutOOBWrite", CFF_BYTES("\x01")},
+	{"Format2EmptyCharStrings_ParsesWithoutOOBWrite", CFF_BYTES("\x02")},
+};
+
+static bool RunReadCharsetCases() {
+	bool ok = true;
+	const size_t caseCount = sizeof(scReadCharsetCases) / sizeof(scReadCharsetCases[0]);
+	for(size_t i = 0; i < caseCount; ++i) {
+		const CharsetFormatCase& c = scReadCharsetCases[i];
+
+		// Arrange
+		CFFFileInput cff;
+		string bytes = CFFSyntheticBuilder::WithCharset(c.mPayload, c.mPayloadLen);
+
+		// Act
+		EStatusCode status = CFFSyntheticBuilder::ParseAsCFF(bytes, cff);
+
+		// Assert
+		if(status != eSuccess) {
+			cout << "CFFFileInputTest [ReadCharset::" << c.mLabel
+			     << "]: parse failed; empty-CharStrings custom charset is valid CFF" << endl;
+			ok = false;
+			continue;
+		}
+		if(cff.GetCharStringsCount(0) != 0) {
+			cout << "CFFFileInputTest [ReadCharset::" << c.mLabel
+			     << "]: precondition broken — charstrings count = "
+			     << cff.GetCharStringsCount(0) << ", expected 0" << endl;
+			ok = false;
+			continue;
+		}
+		const CharSetInfo* charSet = cff.mTopDictIndex[0].mCharSet;
+		if(charSet == NULL || charSet->mType != eCharSetCustom) {
+			cout << "CFFFileInputTest [ReadCharset::" << c.mLabel
+			     << "]: custom charset not recorded" << endl;
+			ok = false;
+		}
+	}
+	return ok;
+}
+
+// V-048: ReadCharString allocated *outCharString, and on a failed read
+// deleted it but left the caller's pointer dangling. Every Type 2
+// interpreter call site (CharStringType2Interpreter::Intepret /
+// InterpretCallSubr / InterpretCallGSubr) then ran an unconditional
+// delete[] on that same pointer -> double-free. The CharStrings INDEX
+// offset table is parsed up front but the charstring bytes are read
+// lazily during interpretation, so a buffer truncated after the offset
+// table still parses, then fails the read inside ReadCharString.
+static bool ReadCharString_TruncatedCharStringData_NoDoubleFree() {
+	// Arrange: one glyph with a 4-byte CharString, then drop the last 2
+	// bytes. The offset table still claims 4 bytes for glyph 1, so the
+	// snapshot positions are intact but the data is short by 2.
+	std::vector<std::string> charStrings;
+	charStrings.push_back(string("\x8B\x8B\x8B\x0E", 4));
+	string bytes = CFFSyntheticBuilder::WithCharStrings(charStrings);
+	if(bytes.size() < 2) {
+		cout << "CFFFileInputTest [ReadCharString::TruncatedCharStringData_NoDoubleFree]: builder produced empty CFF" << endl;
+		return false;
+	}
+	bytes.resize(bytes.size() - 2);
+
+	InputByteArrayStream stream;
+	CFFFileInput cff;
+	if(ParseKeepingStream(bytes, stream, cff) != eSuccess) {
+		cout << "CFFFileInputTest [ReadCharString::TruncatedCharStringData_NoDoubleFree]: truncated CFF unexpectedly rejected at parse time" << endl;
+		return false;
+	}
+
+	// Act: interpreting glyph 1 reads its (truncated) charstring; pre-fix
+	// this double-freed the buffer and aborted the process.
+	std::vector<unsigned int> subset;
+	subset.push_back(1);
+	EStatusCode status = cff.AddDependentGlyphs(subset);
+
+	// Assert: the read failure must surface as eFailure, and reaching this
+	// line at all means there was no double-free abort.
+	if(status == eSuccess) {
+		cout << "CFFFileInputTest [ReadCharString::TruncatedCharStringData_NoDoubleFree]: "
+		        "truncated charstring read reported success" << endl;
+		return false;
+	}
+	return true;
+}
+
+static bool RunReadCharStringCases() {
+	if(!ReadCharString_TruncatedCharStringData_NoDoubleFree()) return false;
+	return true;
+}
+
 int CFFFileInputTest(int argc, char* argv[]) {
 	if(!RunGetSingleIntegerValueFromDictCases()) return 1;
 	if(!RunReadPrivateDictCases()) return 1;
 	if(!RunReadEncodingCases()) return 1;
 	if(!RunReadFDSelectCases()) return 1;
+	if(!RunReadCharsetCases()) return 1;
+	if(!RunReadCharStringCases()) return 1;
 	if(!RunAddDependentGlyphsCases()) return 1;
 	if(!ReadCFFFile_BrushScriptStd_PopulatesPrivateDict(argv)) return 1;
 	return 0;

--- a/PDFWriterTesting/CFFSyntheticBuilder.cpp
+++ b/PDFWriterTesting/CFFSyntheticBuilder.cpp
@@ -199,6 +199,31 @@ string CFFSyntheticBuilder::WithCharStrings(const std::vector<std::string>& inGl
     return cff;
 }
 
+string CFFSyntheticBuilder::WithCharset(const char* inCharsetBytes, size_t inCharsetLen)
+{
+    string cff;
+    cff.append(scCFFHeader, scCFFHeaderSize);
+
+    // Name INDEX
+    cff.append("\x00\x01\x01\x01\x02\x41", 6);
+
+    // Top DICT INDEX: count=1, offSize=1, offsets=[1, 5], 4-byte body.
+    // Body: <short-int 23> 0x0F (/charset @ offset 23). No /CharStrings key,
+    // so GetCharStringsPosition returns 0 and mCharStringsCount stays 0.
+    //   header(4) + Name(6) + TopDictIndex(9) + String(2) + GlobalSubrs(2) = 23
+    const unsigned short charsetOffset = 23;
+    cff.append("\x00\x01\x01\x01\x05", 5);
+    AppendShortIntDictOperand(cff, charsetOffset);
+    cff.push_back('\x0F');
+
+    // Empty String / Global Subrs INDEXes.
+    cff.append(scEmptyIndex, scEmptyIndexSize);
+    cff.append(scEmptyIndex, scEmptyIndexSize);
+
+    cff.append(inCharsetBytes, inCharsetLen);
+    return cff;
+}
+
 EStatusCode CFFSyntheticBuilder::ParseAsCFF(const string& inCFFBytes, CFFFileInput& outCFF)
 {
     // data() is well-defined for empty buffers; &str[0] would be UB pre-C++11.

--- a/PDFWriterTesting/CFFSyntheticBuilder.h
+++ b/PDFWriterTesting/CFFSyntheticBuilder.h
@@ -53,6 +53,13 @@ public:
     // CFFFileInput::AddDependentGlyphs.
     static std::string WithCharStrings(const std::vector<std::string>& inGlyphCharStrings);
 
+    // Non-CID CFF whose Top DICT references /charset (key 15 -> caller payload
+    // at offset 23) but omits /CharStrings, so GetCharStringsPosition returns 0
+    // and mCharStringsCount stays 0. The charset format readers then run
+    // against an empty CharStrings INDEX. The caller payload is the charset
+    // format byte followed by any format body.
+    static std::string WithCharset(const char* inCharsetBytes, size_t inCharsetLen);
+
     // ReadCFFFile shim wrapping the synthesized buffer in an
     // InputByteArrayStream and returning the parser's status.
     static PDFHummus::EStatusCode ParseAsCFF(const std::string& inCFFBytes, CFFFileInput& outCFF);


### PR DESCRIPTION
C8 grind PR 2 of 7 (`CFFFileInput.cpp`). Three memory-safety findings fixed; one reconciled.

### V-044 (MED) — OOB heap write in charset format readers
`ReadFormat0Charset` / `ReadFormat1Charset` / `ReadFormat2Charset` wrote `(*inSIDArray)[0] = 0` unconditionally. A font that omits `/CharStrings` has `mCharStringsCount == 0`, so `*inSIDArray` is `new unsigned short[0]` — a zero-length buffer — and element 0 is a 2-byte out-of-bounds heap write. The per-glyph fill loops were already count-bounded; only the element-0 seed was unguarded. Fixed by gating that write on a non-empty CharStrings INDEX.

### V-048 (LOW) — double-free on truncated charstring
`ReadCharString` allocated `*outCharString`, and on a failed `Read` deleted it but left the caller's pointer dangling. All three Type 2 interpreter call sites (`CharStringType2Interpreter::Intepret` / `InterpretCallSubr` / `InterpretCallGSubr`) then run an unconditional `delete[]` on that same pointer → double-free, reachable when a CharStrings INDEX offset table claims more bytes than the stream actually contains (offsets are parsed up front; data is read lazily during interpretation). Fixed by nulling `*outCharString` after the failure-path `delete[]`, matching `ReadIndexHeader`'s idempotent-cleanup contract (caller's symmetric delete becomes a harmless NULL re-delete).

### V-047 (LOW) — latent uninitialized `mCurrentCharsetInfo`
`mCurrentCharsetInfo` and its sibling `mCurrentDependencies` were never initialized in the constructor — only set by `PrepareForGlyphIntepretation`. `GetCharacterFromStandardEncoding` dereferences `mCurrentCharsetInfo` unconditionally; the dependency walkers test `mCurrentDependencies` for NULL. Both are safe today only by call-graph invariant. Initialized both to NULL in the ctor and added a NULL-guard at the deref. Latent (no attacker-reachable trigger today), so no synthetic case per the latent-fix principle — covered by the existing suite.

### V-046 — reconciled, no change
The format-0 encoding `for(Byte i ...)` loop counter flagged by V-046 was structurally closed by #364's V-031 fix, which widened `mEncodingsCount` and rewrote that loop to use an `unsigned short` counter. No separate change.

### Tests
`PDFWriterTesting/CFFFileInputTest.cpp`: new `CFFSyntheticBuilder::WithCharset` shape (custom `/charset`, no `/CharStrings`) drives all three charset format readers against an empty CharStrings INDEX (V-044, 3 cases); a truncated-charstring case drives `AddDependentGlyphs` into the failed `ReadCharString` / double-free path (V-048). Both verified to abort under AddressSanitizer **pre-fix** (heap-buffer-overflow at `ReadFormat0Charset`; double-free at `Intepret`, pointer first freed in `ReadCharString`) and pass clean **post-fix**. Full suite 98/98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)