### PR TITLE
fix: guard CharString interpreter operand misuse (V-029/V-059)

### DIFF
--- a/PDFWriter/CharStringType1Interpreter.cpp
+++ b/PDFWriter/CharStringType1Interpreter.cpp
@@ -22,6 +22,8 @@
 #include "InputByteArrayStream.h"
 #include "Trace.h"
 
+#include <limits.h>
+
 
 using namespace PDFHummus;
 
@@ -512,6 +514,12 @@ EStatusCode CharStringType1Interpreter::InterpretDiv()
 	mOperandStack.pop_back();
 	valueA = mOperandStack.back();
 	mOperandStack.pop_back();
+
+	if(valueB == 0 || (valueA == LONG_MIN && valueB == -1)) {
+		TRACE_LOG2("CharStringType1Interpreter::InterpretDiv, undefined division (numerator %ld, denominator %ld). Aborting", valueA, valueB);
+		return eFailure;
+	}
+
 	mOperandStack.push_back(valueA/valueB);
 	return eSuccess;
 }

--- a/PDFWriter/CharStringType2Interpreter.cpp
+++ b/PDFWriter/CharStringType2Interpreter.cpp
@@ -487,7 +487,8 @@ Byte* CharStringType2Interpreter::InterpretCallSubr(Byte* inProgramCounter, Long
 	}
 
 
-	aCharString = mImplementationHelper->GetLocalSubr(mOperandStack.back().IntegerValue);
+	CharStringOperand subrIndex = mOperandStack.back();
+	aCharString = mImplementationHelper->GetLocalSubr(subrIndex.IsInteger ? subrIndex.IntegerValue : (long)subrIndex.RealValue);
 	mOperandStack.pop_back();
 
 	if(aCharString != NULL)
@@ -678,7 +679,8 @@ Byte* CharStringType2Interpreter::InterpretCallGSubr(Byte* inProgramCounter, Lon
 	}
 
 
-	aCharString = mImplementationHelper->GetGlobalSubr(mOperandStack.back().IntegerValue);
+	CharStringOperand subrIndex = mOperandStack.back();
+	aCharString = mImplementationHelper->GetGlobalSubr(subrIndex.IsInteger ? subrIndex.IntegerValue : (long)subrIndex.RealValue);
 	mOperandStack.pop_back();
 
 	if(aCharString != NULL)

--- a/PDFWriterTesting/CharStringType1InterpreterTest.cpp
+++ b/PDFWriterTesting/CharStringType1InterpreterTest.cpp
@@ -25,6 +25,20 @@
    prove the bounds checks didn't turn the operators into no-ops by
    exercising the same code paths with valid operands.
 
+   V-059: InterpretDiv divided without guarding the denominator. A
+   charstring of `<x> 0 div` triggers integer divide-by-zero (SIGFPE,
+   a deterministic process kill), and `<LONG_MIN> -1 div` is
+   signed-overflow UB. The fix rejects both before the division.
+
+   Charstring numbers are at most 32-bit (the 0xFF form reads four
+   bytes), so the overflow guard's LONG_MIN sentinel is only reachable
+   from input where long is 32-bit -- ILP32, or LLP64 such as 64-bit
+   Windows: there INT_MIN == LONG_MIN and INT_MIN/-1 overflows, so the
+   guard must reject it. Where long is 64-bit (LP64) the same operand
+   is -2147483648, INT_MIN/-1 == 2147483648 is representable, no
+   overflow occurs, and the division must succeed. The regression case
+   asserts the correct outcome for the running platform's long width.
+
    Charstrings are synthesised in-process: plaintext opcode/operand
    sequences are encoded through the eexec cipher (mirroring
    InputCharStringDecodeStream::DecodeByte) before being handed to the
@@ -241,6 +255,84 @@ static bool DefaultCallOtherSubr_ValidArgumentsCount_ReturnsSuccess() {
 	return true;
 }
 
+// `5 0 div`: denominator 0. Pre-fix this reached `valueA/valueB` with
+// valueB == 0 -> SIGFPE, killing the process. Post-fix InterpretDiv
+// rejects it with eFailure.
+//
+// Plaintext bytes:
+//   0x90       push 5  (5 = 0x90 - 139)
+//   0x8B       push 0  (0 = 0x8B - 139)
+//   0x0C 0x0C  div
+static bool InterpretDiv_DivisionByZero_ReturnsFailure() {
+	// Arrange + Act
+	Type1TestHelper helper;
+	EStatusCode status = INTERPRET_PLAIN(&helper, "\x90\x8B\x0C\x0C");
+
+	// Assert
+	if(status == eSuccess) {
+		cout << "CharStringType1InterpreterTest: div by zero was accepted" << endl;
+		return false;
+	}
+	return true;
+}
+
+// `-2147483648 -1 div`: INT_MIN / -1. Both operands use the 5-byte
+// signed-32 number form (0xFF b1 b2 b3 b4). The expected outcome
+// depends on the platform's long width (see the file header): where
+// long is 32-bit the division overflows and the guard must reject it;
+// where long is 64-bit the result 2147483648 is representable and the
+// division must succeed.
+//
+// Plaintext bytes:
+//   0xFF 0x80 0x00 0x00 0x00   push -2147483648
+//   0xFF 0xFF 0xFF 0xFF 0xFF   push -1
+//   0x0C 0x0C                  div
+//   0x0E                       endchar (clean terminate on the success path)
+static bool InterpretDiv_IntMinOverNegativeOne_HandledPerLongWidth() {
+	// Arrange + Act
+	Type1TestHelper helper;
+	EStatusCode status = INTERPRET_PLAIN(&helper, "\xFF\x80\x00\x00\x00\xFF\xFF\xFF\xFF\xFF\x0C\x0C\x0E");
+
+	// Assert
+	if(sizeof(long) == 4) {
+		// INT_MIN == LONG_MIN here: INT_MIN / -1 is signed-overflow UB,
+		// the guard must reject it.
+		if(status == eSuccess) {
+			cout << "CharStringType1InterpreterTest: INT_MIN / -1 accepted where long is 32-bit (overflow UB)" << endl;
+			return false;
+		}
+	} else {
+		// long is 64-bit: -2147483648 / -1 == 2147483648 is in range,
+		// no overflow, the guard must not fire and the division succeeds.
+		if(status != eSuccess) {
+			cout << "CharStringType1InterpreterTest: valid INT_MIN / -1 (64-bit long) was rejected" << endl;
+			return false;
+		}
+	}
+	return true;
+}
+
+// Happy path: `10 2 div` leaves 5 on the stack and endchar terminates
+// cleanly. Confirms the denominator guard still admits valid division.
+//
+// Plaintext bytes:
+//   0x95       push 10  (10 = 0x95 - 139)
+//   0x8D       push 2   (2 = 0x8D - 139)
+//   0x0C 0x0C  div
+//   0x0E       endchar
+static bool InterpretDiv_ValidDivision_ReturnsSuccess() {
+	// Arrange + Act
+	Type1TestHelper helper;
+	EStatusCode status = INTERPRET_PLAIN(&helper, "\x95\x8D\x0C\x0C\x0E");
+
+	// Assert
+	if(status != eSuccess) {
+		cout << "CharStringType1InterpreterTest: legitimate `10 2 div` was rejected" << endl;
+		return false;
+	}
+	return true;
+}
+
 int CharStringType1InterpreterTest(int argc, char* argv[]) {
 	(void) argc;
 	(void) argv;
@@ -250,5 +342,8 @@ int CharStringType1InterpreterTest(int argc, char* argv[]) {
 	if(!DefaultCallOtherSubr_NegativeArgumentsCount_ReturnsFailure()) return 1;
 	if(!InterpretCallOtherSubr_ValidArgumentsCount_ReturnsSuccess()) return 1;
 	if(!DefaultCallOtherSubr_ValidArgumentsCount_ReturnsSuccess()) return 1;
+	if(!InterpretDiv_DivisionByZero_ReturnsFailure()) return 1;
+	if(!InterpretDiv_IntMinOverNegativeOne_HandledPerLongWidth()) return 1;
+	if(!InterpretDiv_ValidDivision_ReturnsSuccess()) return 1;
 	return 0;
 }

--- a/PDFWriterTesting/CharStringType2InterpreterTest.cpp
+++ b/PDFWriterTesting/CharStringType2InterpreterTest.cpp
@@ -24,6 +24,17 @@
    happy-path cases prove the fix didn't turn the operators into no-ops,
    exercising the same code paths with valid operands.
 
+   V-029: InterpretCallSubr / InterpretCallGSubr read .IntegerValue from
+   the CharStringOperand union without checking IsInteger. When the
+   subroutine-index operand was pushed as a real (the 0xFF 16.16
+   fixed-point opcode), .IntegerValue reinterprets the IEEE-754 double's
+   bits as a long, handing the implementation an attacker-controlled
+   junk index. The fix coerces a real operand with (long)RealValue, the
+   same idiom every other operator in this file already uses. The
+   regression cases push a real 5.0 as the subr index and assert the
+   implementation receives exactly 5 (pre-fix it received the
+   reinterpreted bit pattern, a large non-5 value).
+
    Charstrings are synthesised in-process via a minimal
    IType2InterpreterImplementation harness, no font fixtures required.
 */
@@ -153,6 +164,134 @@ static bool InterpretPut_ValidSlotRoundTrip_ReturnsSuccess() {
 	return true;
 }
 
+// Records the index the interpreter passes to GetLocalSubr /
+// GetGlobalSubr so the test can assert the operand was coerced to the
+// integer the charstring actually encoded, not the bit-reinterpretation
+// of a real. Overrides ReadCharString to hand back the synthetic
+// program: Intepret pulls the bytes through ReadCharString, not from
+// the CharString span, so without this the interpreter would never see
+// the program and never reach the subr lookup. Returning NULL from the
+// lookup aborts interpretation right after the recording, which is all
+// the assertion needs.
+class SubrIndexRecorder : public Type2InterpreterImplementationAdapter {
+public:
+	SubrIndexRecorder() : mBytes(NULL), mLen(0),
+	                      mLocalIndex(0), mGlobalIndex(0),
+	                      mLocalCalled(false), mGlobalCalled(false) {}
+	void SetProgram(const char* inBytes, size_t inLen) {
+		mBytes = inBytes;
+		mLen = inLen;
+	}
+	virtual EStatusCode ReadCharString(LongFilePositionType inStart,
+	                                   LongFilePositionType inEnd,
+	                                   Byte** outCharString) {
+		(void) inStart;
+		(void) inEnd;
+		Byte* buf = new Byte[mLen];
+		memcpy(buf, mBytes, mLen);
+		*outCharString = buf;
+		return eSuccess;
+	}
+	virtual CharString* GetLocalSubr(long inSubrIndex) {
+		mLocalIndex = inSubrIndex;
+		mLocalCalled = true;
+		return NULL;
+	}
+	virtual CharString* GetGlobalSubr(long inSubrIndex) {
+		mGlobalIndex = inSubrIndex;
+		mGlobalCalled = true;
+		return NULL;
+	}
+	const char* mBytes;
+	size_t mLen;
+	long mLocalIndex;
+	long mGlobalIndex;
+	bool mLocalCalled;
+	bool mGlobalCalled;
+};
+
+static EStatusCode interpretBytesWith(SubrIndexRecorder& inHelper,
+                                      const char* inBytes, size_t inLen) {
+	inHelper.SetProgram(inBytes, inLen);
+	CharString cs;
+	cs.mStartPosition = 0;
+	cs.mEndPosition = (LongFilePositionType)inLen;
+	CharStringType2Interpreter interp;
+	return interp.Intepret(cs, &inHelper);
+}
+
+#define INTERPRET_WITH(helper, bytes) interpretBytesWith((helper), (bytes), sizeof(bytes) - 1)
+
+// `0xFF 00 05 00 00` pushes the 16.16 real 5.0. `callsubr` (opcode 10)
+// then uses it as the local-subr index. Pre-fix the union's
+// .IntegerValue read reinterpreted 5.0's IEEE-754 bits as a long,
+// handing GetLocalSubr a huge junk value. Post-fix the real is coerced
+// with (long)RealValue, so GetLocalSubr must receive exactly 5.
+static bool InterpretCallSubr_RealIndexOperand_CoercesToInteger() {
+	// Arrange
+	SubrIndexRecorder helper;
+
+	// Act
+	INTERPRET_WITH(helper, "\xFF\x00\x05\x00\x00\x0A");
+
+	// Assert
+	if(!helper.mLocalCalled) {
+		cout << "CharStringType2InterpreterTest: GetLocalSubr was never called" << endl;
+		return false;
+	}
+	if(helper.mLocalIndex != 5) {
+		cout << "CharStringType2InterpreterTest: real subr index not coerced; GetLocalSubr got "
+		     << helper.mLocalIndex << " expected 5" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Same as above but `callgsubr` (opcode 29) routes through
+// GetGlobalSubr.
+static bool InterpretCallGSubr_RealIndexOperand_CoercesToInteger() {
+	// Arrange
+	SubrIndexRecorder helper;
+
+	// Act
+	INTERPRET_WITH(helper, "\xFF\x00\x05\x00\x00\x1D");
+
+	// Assert
+	if(!helper.mGlobalCalled) {
+		cout << "CharStringType2InterpreterTest: GetGlobalSubr was never called" << endl;
+		return false;
+	}
+	if(helper.mGlobalIndex != 5) {
+		cout << "CharStringType2InterpreterTest: real subr index not coerced; GetGlobalSubr got "
+		     << helper.mGlobalIndex << " expected 5" << endl;
+		return false;
+	}
+	return true;
+}
+
+// Happy path: an integer subr-index operand (byte 0x90 = 5 + 139) must
+// still reach GetLocalSubr unchanged. Confirms the coercion didn't
+// disturb the common integer path.
+static bool InterpretCallSubr_IntegerIndexOperand_PassesThrough() {
+	// Arrange
+	SubrIndexRecorder helper;
+
+	// Act
+	INTERPRET_WITH(helper, "\x90\x0A");
+
+	// Assert
+	if(!helper.mLocalCalled) {
+		cout << "CharStringType2InterpreterTest: GetLocalSubr was never called" << endl;
+		return false;
+	}
+	if(helper.mLocalIndex != 5) {
+		cout << "CharStringType2InterpreterTest: integer subr index altered; GetLocalSubr got "
+		     << helper.mLocalIndex << " expected 5" << endl;
+		return false;
+	}
+	return true;
+}
+
 int CharStringType2InterpreterTest(int argc, char* argv[]) {
 	(void) argc;
 	(void) argv;
@@ -160,5 +299,8 @@ int CharStringType2InterpreterTest(int argc, char* argv[]) {
 	if(!InterpretPut_SlotOutOfRange_ReturnsFailure()) return 1;
 	if(!InterpretIndex_ValidOperand_ReturnsSuccess()) return 1;
 	if(!InterpretPut_ValidSlotRoundTrip_ReturnsSuccess()) return 1;
+	if(!InterpretCallSubr_RealIndexOperand_CoercesToInteger()) return 1;
+	if(!InterpretCallGSubr_RealIndexOperand_CoercesToInteger()) return 1;
+	if(!InterpretCallSubr_IntegerIndexOperand_PassesThrough()) return 1;
 	return 0;
 }


### PR DESCRIPTION
Part of the Phase-2 C8 by-file grind (PR 3/7). Two standalone CharString-interpreter memory-safety findings, one production file each, regression tests included.

## V-029 — CharStringType2Interpreter union type confusion
`InterpretCallSubr` / `InterpretCallGSubr` read `mOperandStack.back().IntegerValue` from the `CharStringOperand` union without checking `IsInteger`. When the subroutine-index operand is pushed as a real (the `0xFF` 16.16 fixed-point number opcode), `.IntegerValue` reinterprets the IEEE-754 double's bits as a `long`, handing the implementation an attacker-controlled junk subr index. Fix coerces a real operand with `(long)RealValue` — the idiom every other operator in the file already uses.

Regression: a charstring pushing the real `5.0` as the subr index must reach `GetLocalSubr`/`GetGlobalSubr` with exactly `5`. Pre-fix it received `4617315517961601024` (the bit-reinterpretation of `5.0`).

## V-059 — CharStringType1Interpreter::InterpretDiv unguarded division
`<x> 0 div` is integer divide-by-zero — SIGFPE (deterministic process kill) on x86, silently-wrong (returns 0) on ARM. `<LONG_MIN> -1 div` is signed-overflow UB. Fix rejects both with `eFailure` before the division.

Regression: div-by-zero must return `eFailure` (pre-fix the result was silently accepted on this ARM build). The `INT_MIN/-1` case is asserted per the platform's `long` width — charstring numbers are ≤32-bit, so the `LONG_MIN` sentinel is only reachable from input where `long` is 32-bit (ILP32 / LLP64); on LP64 the same operand divides to a representable `2147483648` and must succeed.

## Verification
- `cmake --build` + full `ctest`: 98/98 green.
- Pre-fix stash-verify: both regression tests fail pre-fix (V-059 "div by zero was accepted"; V-029 "GetLocalSubr got 4617315517961601024 expected 5") and pass post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)