### PR TITLE
fix: harden Type1Input charstring parsing + null guards (V-067/V-068/V-069)

### DIFF
--- a/PDFWriter/Type1Input.cpp
+++ b/PDFWriter/Type1Input.cpp
@@ -136,8 +136,6 @@ void Type1Input::Reset()
 	mPrivateDictionary.StemSnapH.clear();
 	mPrivateDictionary.StemSnapV.clear();
 	mPrivateDictionary.UniqueID = -1;
-
-	Type1PrivateDictionary mPrivateDictionary;
 }
 
 EStatusCode Type1Input::ReadType1File(IByteReaderWithPosition* inType1)
@@ -892,6 +890,7 @@ EStatusCode Type1Input::ParseCharstrings()
 				status = eFailure;
 				break;
 			}
+
 			charString.CodeLength = (int)codeLength;
 
 			charString.Code = new Byte[charString.CodeLength];
@@ -899,8 +898,16 @@ EStatusCode Type1Input::ParseCharstrings()
 			// skip the RD token (will also skip space)
 			mPFBDecoder.GetNextToken();
 
-
-			mPFBDecoder.Read(charString.Code,charString.CodeLength);
+			// Reject a short read: the unwritten tail of Code would
+			// otherwise reach the charstring interpreter as indeterminate data.
+			if(mPFBDecoder.Read(charString.Code,charString.CodeLength) != (LongBufferSizeType)charString.CodeLength)
+			{
+				TRACE_LOG1("Type1Input::ParseCharstrings, truncated charstring data for %s",characterName.c_str());
+				delete[] charString.Code;
+				charString.Code = NULL;
+				status = eFailure;
+				break;
+			}
 
 			// std::map::insert is no-op on duplicate keys; without checking we
 			// would leak charString.Code on a malformed font that names the
@@ -1097,17 +1104,21 @@ EStatusCode Type1Input::Type1Seac(const LongList& inOperandList)
 		return eFailure;		
 	}
 
-	LongList::const_reverse_iterator it = inOperandList.rbegin();
+	if(mCurrentDependencies)
+	{
+		LongList::const_reverse_iterator it = inOperandList.rbegin();
 
-	mCurrentDependencies->mCharCodes.insert((Byte)*it);
-	++it;
-	mCurrentDependencies->mCharCodes.insert((Byte)*it);
+		mCurrentDependencies->mCharCodes.insert((Byte)*it);
+		++it;
+		mCurrentDependencies->mCharCodes.insert((Byte)*it);
+	}
 	return eSuccess;
 }
 
 bool Type1Input::IsOtherSubrSupported(long inOtherSubrsIndex)
 {
-	mCurrentDependencies->mOtherSubrs.insert((unsigned short)inOtherSubrsIndex);
+	if(mCurrentDependencies)
+		mCurrentDependencies->mOtherSubrs.insert((unsigned short)inOtherSubrsIndex);
 	return false;
 }
 


### PR DESCRIPTION
Part of the Phase-2 C8 by-file grind (PR 4/7). Three standalone `Type1Input.cpp` findings.

## V-067 — ParseCharstrings ignored Read() return
`ParseCharstrings` did `charString.Code = new Byte[codeLength]` then `mPFBDecoder.Read(charString.Code, codeLength)` without checking the return. A charstring declaring more bytes than the font actually carries left the buffer's tail uninitialized, and that buffer is later handed to the charstring interpreter. Fix rejects a short read before the buffer is inserted/used. (The duplicate-name leak half of V-067 was already fixed in #353.)

## V-068 — dead shadowing local in Reset()
`Reset()` ended with `Type1PrivateDictionary mPrivateDictionary;` — a default-constructed local that shadows the member name but is constructed-then-destroyed with no effect (the member is already reset field-by-field above, since #374). Removed the dead declaration.

## V-069 — unguarded mCurrentDependencies deref (latent)
`Type1Seac` / `IsOtherSubrSupported` dereferenced `mCurrentDependencies` with no null check. Latent — not reachable from the malicious-input flow today; guarded as defense-in-depth.

## Testing rationale (no new regression test)
This is a documented hardening PR, consistent with the project's latent-fix principle (cf. V-047/V-069-CFF in #377, the C4 PRs):

- **V-067** has no pre/post status discriminator. Over-declaring an RD count makes `Read` drain the rest of the stream; the tokenizer then desyncs and `ParseCharstrings` returns `eFailure` *anyway* — just later and for an unrelated reason. Post-fix it fails *fast* at the short read, before any indeterminate buffer reaches the interpreter. Same final `EStatusCode` either way (verified by stash), so a status-based test would pass pre-fix and give false confidence. The safety property (no indeterminate charstring past the read) is structural.
- **V-068** is behaviourally inert (dead-code removal).
- **V-069** is latent.

The existing real-PFB `Type1InputTest` suite (exact-value assertions over `HLB_____.PFB`) guards the happy path against regressions from the `ParseCharstrings` change.

## Verification
- `cmake --build` + full `ctest`: 98/98 green, before and after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)