### PR TITLE
fix: assemble PFB segment length in 64-bit, no signed-shift UB (V-061)

### DIFF
--- a/PDFWriter/InputPFBDecodeStream.cpp
+++ b/PDFWriter/InputPFBDecodeStream.cpp
@@ -610,7 +610,8 @@ LongBufferSizeType InputPFBDecodeStream::Read(Byte* inBuffer,LongBufferSizeType 
 				PDFHummus::eSuccess == mInternalState)
 		{
 			mInternalState = mDecodeMethod(this,inBuffer[bufferIndex]);
-			++bufferIndex;
+			if(PDFHummus::eSuccess == mInternalState)
+				++bufferIndex;
 		}
 
 		// segment ended, initialize next segment

--- a/PDFWriter/InputPFBDecodeStream.cpp
+++ b/PDFWriter/InputPFBDecodeStream.cpp
@@ -190,7 +190,11 @@ EStatusCode InputPFBDecodeStream::StoreSegmentLength()
 	if(mStreamToDecode->Read(&byte4,1) != 1)
 		return PDFHummus::eFailure;
 
-	mSegmentSize = byte1 | (byte2<<8) | (byte3<<16) | (byte4<<24);
+	mSegmentSize =
+		(LongFilePositionType)byte1 |
+		((LongFilePositionType)byte2 << 8) |
+		((LongFilePositionType)byte3 << 16) |
+		((LongFilePositionType)byte4 << 24);
 	return PDFHummus::eSuccess;
 }
 

--- a/PDFWriterTesting/InputPFBDecodeStreamTest.cpp
+++ b/PDFWriterTesting/InputPFBDecodeStreamTest.cpp
@@ -31,13 +31,22 @@
    object's uninitialized members are often incidentally zero on a given
    build, masking the bug). Post-fix the constructor zeroes every member, so
    Read() on the un-Assigned stream returns 0 and writes nothing.
+
+   Also covers the PFB segment-length assembly: a declared length whose high
+   byte is >= 0x80 must yield the correct large unsigned value. The old
+   `byte4 << 24` performed the shift in `int`, which is signed-overflow UB
+   when byte4 >= 0x80 and (on two's-complement) produced a negative
+   mSegmentSize -- the loop bound -- so the segment was silently treated as
+   zero-length and skipped.
 */
 #include "InputPFBDecodeStream.h"
+#include "InputByteArrayStream.h"
 #include "EStatusCode.h"
 
 #include <iostream>
 #include <new>
 #include <cstring>
+#include <string>
 
 using namespace std;
 using namespace PDFHummus;
@@ -84,8 +93,80 @@ static bool Read_FreshlyConstructedWithoutAssign_ReturnsZeroAndDisclosesNothing(
 	return ok;
 }
 
+// One row exercises StoreSegmentLength (observed through Read): a type-1
+// ASCII PFB segment whose declared length high byte is mHighByte, carrying a
+// short "abc" payload. The declared length is always far larger than the
+// payload, so Read drains the 3 payload bytes and then makes one more
+// (failing) read attempt that still bumps the returned count -- giving a
+// uniform expected return of 4 with the first 3 bytes "abc". Pre-fix, a
+// mHighByte >= 0x80 made mSegmentSize negative (signed-shift UB), the inner
+// read loop never ran, and Read returned 0.
+struct StoreSegmentLengthCase {
+	const char* mLabel;
+	Byte mHighByte;
+};
+
+static const StoreSegmentLengthCase scStoreSegmentLengthCases[] = {
+	{ "HighByteZero_ReadsPayload",        0x00 },
+	{ "HighByteSignBit_ReadsPayload",     0x80 },
+	{ "HighByteAllOnes_ReadsPayload",     0xFF },
+};
+
+static bool RunStoreSegmentLengthCases() {
+	const char payload[3] = { 'a', 'b', 'c' };
+	const size_t caseCount = sizeof(scStoreSegmentLengthCases) / sizeof(scStoreSegmentLengthCases[0]);
+	bool ok = true;
+
+	for(size_t i = 0; i < caseCount; ++i) {
+		const StoreSegmentLengthCase& testCase = scStoreSegmentLengthCases[i];
+
+		// Arrange: type-1 ASCII segment header (0x80 0x01) + 4-byte LE
+		// declared length 0xFF 0x00 0x00 <highByte> (always >> 3) + 3 payload
+		// bytes, then the source stream simply ends.
+		std::string pfb;
+		pfb.push_back((char)0x80);
+		pfb.push_back((char)0x01);
+		pfb.push_back((char)0xFF);
+		pfb.push_back((char)0x00);
+		pfb.push_back((char)0x00);
+		pfb.push_back((char)testCase.mHighByte);
+		pfb.append(payload, sizeof(payload));
+
+		InputByteArrayStream* source = new InputByteArrayStream((Byte*)&pfb[0], (LongFilePositionType)pfb.size());
+		InputPFBDecodeStream stream;
+		EStatusCode assigned = stream.Assign(source);
+
+		const Byte sentinel = 0xAB;
+		Byte out[8];
+		memset(out, sentinel, sizeof(out));
+
+		// Act
+		LongBufferSizeType got = stream.Read(out, sizeof(out));
+
+		// Assert: segment length decoded as a large positive value, so the
+		// whole payload is delivered.
+		if(assigned != eSuccess) {
+			cout << "InputPFBDecodeStreamTest[" << testCase.mLabel
+			     << "]: Assign returned non-eSuccess" << endl;
+			ok = false;
+		}
+		if(got != 4) {
+			cout << "InputPFBDecodeStreamTest[" << testCase.mLabel
+			     << "]: Read returned " << got << ", expected 4 (segment skipped: signed-shift UB?)" << endl;
+			ok = false;
+		}
+		if(!(out[0] == 'a' && out[1] == 'b' && out[2] == 'c')) {
+			cout << "InputPFBDecodeStreamTest[" << testCase.mLabel
+			     << "]: payload bytes not 'abc'" << endl;
+			ok = false;
+		}
+	}
+	return ok;
+}
+
 int InputPFBDecodeStreamTest(int argc, char* argv[]) {
 	(void)argc;
 	if(!Read_FreshlyConstructedWithoutAssign_ReturnsZeroAndDisclosesNothing(argv)) return 1;
+	if(!RunStoreSegmentLengthCases()) return 1;
 	return 0;
 }

--- a/PDFWriterTesting/InputPFBDecodeStreamTest.cpp
+++ b/PDFWriterTesting/InputPFBDecodeStreamTest.cpp
@@ -96,9 +96,7 @@ static bool Read_FreshlyConstructedWithoutAssign_ReturnsZeroAndDisclosesNothing(
 // One row exercises StoreSegmentLength (observed through Read): a type-1
 // ASCII PFB segment whose declared length high byte is mHighByte, carrying a
 // short "abc" payload. The declared length is always far larger than the
-// payload, so Read drains the 3 payload bytes and then makes one more
-// (failing) read attempt that still bumps the returned count -- giving a
-// uniform expected return of 4 with the first 3 bytes "abc". Pre-fix, a
+// payload, so Read drains the 3 payload bytes and returns 3. Pre-fix, a
 // mHighByte >= 0x80 made mSegmentSize negative (signed-shift UB), the inner
 // read loop never ran, and Read returned 0.
 struct StoreSegmentLengthCase {
@@ -150,9 +148,9 @@ static bool RunStoreSegmentLengthCases() {
 			     << "]: Assign returned non-eSuccess" << endl;
 			ok = false;
 		}
-		if(got != 4) {
+		if(got != 3) {
 			cout << "InputPFBDecodeStreamTest[" << testCase.mLabel
-			     << "]: Read returned " << got << ", expected 4 (segment skipped: signed-shift UB?)" << endl;
+			     << "]: Read returned " << got << ", expected 3 (segment skipped: signed-shift UB?)" << endl;
 			ok = false;
 		}
 		if(!(out[0] == 'a' && out[1] == 'b' && out[2] == 'c')) {


### PR DESCRIPTION
Part of the Phase-2 C8 by-file grind (PR 5/7). One standalone `InputPFBDecodeStream.cpp` finding (V-061). A second finding (V-092) surfaced during review and was folded in.

## V-061 (signed-shift UB half)
`StoreSegmentLength` assembled the 4-byte little-endian PFB segment length as `byte1 | (byte2<<8) | (byte3<<16) | (byte4<<24)`. Each `Byte` promotes to `int`; when `byte4 >= 0x80`, `byte4<<24` overflows signed `int` — undefined behaviour. On a two's-complement target it yields a negative `mSegmentSize`, which is the inner read-loop bound, so the entire segment is silently treated as zero-length and skipped (the rest of the font is lost).

Fix casts each byte to `LongFilePositionType` (the signed 64-bit type `mSegmentSize` already is) before shifting, so the whole assembly is done in 64-bit with no overflow.

**Scope:** V-061 was split in triage — only the signed-shift UB half is in scope here. The "no upper bound on `mSegmentSize`" half joins the deferred DoS-cap class.

## V-092 — Read over-counts failed decode (folded during review)
`InputPFBDecodeStream::Read`'s inner loop incremented `bufferIndex` unconditionally, including on the iteration where `mDecodeMethod` returned `eFailure`. When a PFB segment header claimed more bytes than the underlying source actually had, `Read` drained the available bytes and then over-counted by one for the final failing decode attempt — violating the `IByteReader::Read` contract ("number of bytes actually read") and leaving one indeterminate byte's worth of count exposed to callers.

Same shape as **V-055** (`InputType1Decoder::Read`, PR #362); sibling missed during the C8 audit. Fix gates `++bufferIndex` on `mInternalState == eSuccess`, matching the V-055 pattern.

## Regression test
Table-driven `RunStoreSegmentLengthCases` over high-byte values `0x00`, `0x80`, `0xFF`: a type-1 ASCII PFB segment with a large declared length and an `"abc"` payload; `Read` must deliver the payload.

The single row now discriminates **both** bugs cleanly:
- Pre-V-061 fix, any V-092: returns 0 (segment skipped) — test fails.
- Post-V-061 fix, pre-V-092 fix: returns 4 (overcount) — test fails.
- Post-V-061 + post-V-092 fixes: returns 3 — test passes.

Stash-verified pre-fix:
- `HighByteZero` (0x00): returns 4 with both fixes absent (overcount; the V-061 path doesn't trigger), so it doesn't fail in the "expected 3" sense until V-092 is also addressed.
- `HighByteSignBit` (0x80) / `HighByteAllOnes` (0xFF): **fail pre-V-061 fix** — "Read returned 0, expected 3 (segment skipped: signed-shift UB?)" — segment skipped because `mSegmentSize` went negative.

All three pass post-fix.

## Verification
- `cmake --build` + full `ctest`: 98/98 green.
- Pre-fix stash-verify reproduces the V-061 skip on the high-bit rows and the V-092 overcount on the zero row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)