### PR TITLE
fix: FreeTypeWrapper FreeType-boundary memory hygiene (V-073/V-074/V-075)

### DIFF
--- a/FreeType/CMakeLists.txt
+++ b/FreeType/CMakeLists.txt
@@ -69,7 +69,7 @@ if (WIN32 AND BUILD_SHARED_LIBS)
 endif ()
 
 # set to use FT_CONFIG_OPTION_SYSTEM_ZLIB...or in other words...another zlib
-target_compile_definitions(FreeType PUBLIC FT2_BUILD_LIBRARY=1 FT_CONFIG_OPTION_SYSTEM_ZLIB=1)   
+target_compile_definitions(FreeType PUBLIC FT2_BUILD_LIBRARY=1 FT_CONFIG_OPTION_SYSTEM_ZLIB=1 FT_CONFIG_OPTION_ERROR_STRINGS=1)
 if(USING_UNBUNDLED_ZLIB)
     target_link_libraries(FreeType ZLIB::ZLIB)
 else(USING_UNBUNDLED_ZLIB)

--- a/FreeType/binding.gyp
+++ b/FreeType/binding.gyp
@@ -5,7 +5,8 @@
             'type': 'static_library',
             'defines': [
                 'FT2_BUILD_LIBRARY=1',
-                'FT_CONFIG_OPTION_SYSTEM_ZLIB=1'
+                'FT_CONFIG_OPTION_SYSTEM_ZLIB=1',
+                'FT_CONFIG_OPTION_ERROR_STRINGS=1'
             ],
             'include_dirs': [
              './include',

--- a/PDFWriter/FreeTypeWrapper.cpp
+++ b/PDFWriter/FreeTypeWrapper.cpp
@@ -27,19 +27,6 @@
 using namespace PDFHummus;
 
 
-#undef __FTERRORS_H__                                           
-#define FT_ERRORDEF( e, v, s )  { e, s },                       
-#define FT_ERROR_START_LIST     {                               
-#define FT_ERROR_END_LIST       { 0, 0 } };                     
-                                                             
-static const struct                                                    
-{                                                               
-int          err_code;                                        
-const char*  err_msg;                                         
-} ft_errors[] =                                                 
-                                                             
-#include FT_ERRORS_H                                            
-
 FreeTypeWrapper::FreeTypeWrapper(void)
 {
 	if(FT_Init_FreeType(&mFreeType))
@@ -84,8 +71,10 @@ FT_Face FreeTypeWrapper::NewFace(const std::string& inFilePath,FT_Long inFontInd
 
 		if(ftStatus)
 		{
+			// FT_Error_String returns NULL when FreeType was built without FT_CONFIG_OPTION_ERROR_STRINGS (the bundled build enables it; unbundled may not)
+			const char* errMsg = FT_Error_String(ftStatus);
 			TRACE_LOG2("FreeTypeWrapper::NewFace, unable to load font named %s with index %ld",inFilePath.c_str(),inFontIndex);
-			TRACE_LOG2("FreeTypeWrapper::NewFace, Free Type Error, Code = %d, Message = %s",ft_errors[ftStatus].err_code,ft_errors[ftStatus].err_msg);
+			TRACE_LOG2("FreeTypeWrapper::NewFace, Free Type Error, Code = %d, Message = %s",ftStatus,errMsg ? errMsg : "");
 			face = NULL;
 		}
 
@@ -157,8 +146,9 @@ FT_Face FreeTypeWrapper::NewFace(const std::string& inFilePath,const std::string
 			FT_Error ftStatus = FT_Attach_Stream(face,&attachStreamArguments);
 			if(ftStatus != 0)
 			{
+				const char* errMsg = FT_Error_String(ftStatus);
 				TRACE_LOG1("FreeTypeWrapper::NewFace, unable to load secondary file %s",inSecondaryFilePath.c_str());
-				TRACE_LOG2("FreeTypeWrapper::NewFace, Free Type Error, Code = %d, Message = %s",ft_errors[ftStatus].err_code,ft_errors[ftStatus].err_msg);
+				TRACE_LOG2("FreeTypeWrapper::NewFace, Free Type Error, Code = %d, Message = %s",ftStatus,errMsg ? errMsg : "");
 				DoneFace(face);
 				face = NULL;
 			}

--- a/PDFWriter/FreeTypeWrapper.cpp
+++ b/PDFWriter/FreeTypeWrapper.cpp
@@ -70,7 +70,7 @@ FreeTypeWrapper::~FreeTypeWrapper(void)
 FT_Face FreeTypeWrapper::NewFace(const std::string& inFilePath,FT_Long inFontIndex)
 {
 	FT_Face face;
-	FT_Open_Args openFaceArguments;
+	FT_Open_Args openFaceArguments = {0};
 
 	do
 	{
@@ -140,7 +140,7 @@ void FreeTypeWrapper::RegisterStreamForFace(FT_Face inFace,FT_Stream inStream)
 
 FT_Face FreeTypeWrapper::NewFace(const std::string& inFilePath,const std::string& inSecondaryFilePath,FT_Long inFontIndex)
 {
-	FT_Open_Args attachStreamArguments;
+	FT_Open_Args attachStreamArguments = {0};
 
 	FT_Face face = NewFace(inFilePath,inFontIndex);
 	if(face)
@@ -192,8 +192,8 @@ void FreeTypeWrapper::CleanStreamsForFace(FT_Face inFace)
 		{
 			delete *itStreams;
 		}
+		mOpenStreams.erase(it);
 	}
-	mOpenStreams.erase(it);
 }
 
 
@@ -227,7 +227,10 @@ FT_Stream FreeTypeWrapper::CreateFTStreamForPath(const std::string& inFilePath)
 	InputFile* inputFile = new InputFile;
 
 	if(inputFile->OpenFile(inFilePath) != PDFHummus::eSuccess)
+	{
+		delete inputFile;
 		return NULL;
+	}
 
 	FT_Stream aStream = new FT_StreamRec();
 

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -35,6 +35,7 @@ create_test_sourcelist (Tests
   FreeTypeFaceWrapperTest.cpp
   FreeTypeInitializationTest.cpp
   FreeTypeType1WrapperTest.cpp
+  FreeTypeWrapperTest.cpp
   HighLevelContentContext.cpp
   HighLevelImages.cpp
   ImagesAndFormsForwardReferenceTest.cpp

--- a/PDFWriterTesting/FreeTypeWrapperTest.cpp
+++ b/PDFWriterTesting/FreeTypeWrapperTest.cpp
@@ -1,0 +1,240 @@
+/*
+   Source File : FreeTypeWrapperTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Regression tests for FreeTypeWrapper's FreeType-boundary memory hygiene:
+
+     * V-073: CleanStreamsForFace ran mOpenStreams.erase(it) OUTSIDE the
+       if(it != end()) block, so DoneFace on a face that was never
+       registered (or any second DoneFace) called std::map::erase(end())
+       on an empty/foreign iterator - undefined behavior on the container's
+       internal tree. The unregistered-face case is the clean public-API
+       discriminator: it does not double-free the FT_Face. ASAN flags the
+       pre-fix tree walk; the post-fix path is a no-op.
+
+     * V-074: CreateFTStreamForPath leaked the freshly-new'd InputFile* when
+       InputFile::OpenFile failed (NewFace on a non-existent path). Pure
+       leak with no functional signal; only a leak sanitizer can observe
+       it directly (LSan is unavailable on Darwin - see the per-finding
+       note in the PR). The committed assertion locks in the observable
+       contract: NewFace returns NULL for a bad path and the wrapper stays
+       usable for a subsequent valid load.
+
+     * V-075: NewFace(file, secondaryFile, index) read a possibly-
+       uninitialized FT_Open_Args on an early-fail path; today only safe by
+       FillOpenFaceArgumentsForUTF8String always writing .stream = NULL on
+       failure. Latent (per the latent-fix principle: no synthetic no-op
+       case). The committed assertion locks in the observable contract: a
+       bad secondary path returns NULL without crashing and leaves the
+       wrapper usable.
+*/
+#include "FreeTypeWrapper.h"
+
+#include "testing/TestIO.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace PDFHummus;
+
+// V-073: a face created directly on the wrapper's FT_Library is never
+// registered in mOpenStreams, so DoneFace's CleanStreamsForFace finds
+// end(). Pre-fix it then called mOpenStreams.erase(end()) on an empty map
+// (undefined behavior; ASAN aborts in the red-black tree). Post-fix the
+// erase is inside the if(found) block, so an unregistered face is a clean
+// no-op. FT_Done_Face on this face is well-defined (FT_New_Face created
+// it on the same library), so this isolates the erase-with-end bug without
+// a double-free confound.
+static bool DoneFace_UnregisteredFace_DoesNotCorruptStreamMap(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face foreignFace = NULL;
+	do {
+		// Arrange
+		string arialPath = BuildRelativeInputPath(argv, "fonts/arial.ttf");
+		FT_Error newStatus = FT_New_Face((FT_Library)ft, arialPath.c_str(), 0, &foreignFace);
+		if(newStatus != 0 || foreignFace == NULL) {
+			cout << "FreeTypeWrapperTest [DoneFace::UnregisteredFace_DoesNotCorruptStreamMap]: FT_New_Face failed for arial.ttf" << endl;
+			break;
+		}
+
+		// Act
+		// foreignFace was never registered via FreeTypeWrapper::NewFace
+		FT_Error doneStatus = ft.DoneFace(foreignFace);
+		foreignFace = NULL;
+
+		// Assert
+		if(doneStatus != 0) {
+			cout << "FreeTypeWrapperTest [DoneFace::UnregisteredFace_DoesNotCorruptStreamMap]: DoneFace returned a nonzero FT_Error " << doneStatus << endl;
+			break;
+		}
+		// Map must still be usable after the unregistered DoneFace: a fresh
+		// valid load + DoneFace must succeed (a corrupted tree would crash
+		// or misbehave here).
+		FT_Face validFace = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"), 0);
+		if(validFace == NULL) {
+			cout << "FreeTypeWrapperTest [DoneFace::UnregisteredFace_DoesNotCorruptStreamMap]: NewFace failed after the unregistered DoneFace" << endl;
+			break;
+		}
+		FT_Error secondDone = ft.DoneFace(validFace);
+		if(secondDone != 0) {
+			cout << "FreeTypeWrapperTest [DoneFace::UnregisteredFace_DoesNotCorruptStreamMap]: second DoneFace returned a nonzero FT_Error " << secondDone << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	if(foreignFace != NULL)
+		ft.DoneFace(foreignFace);
+	return ok;
+}
+
+// V-073 happy path: a face loaded through FreeTypeWrapper::NewFace IS
+// registered, so DoneFace must take the found branch, delete the streams
+// and erase the entry. Locks in that moving the erase inside the if did
+// not regress the normal lifecycle (a real glyph still resolves before
+// teardown, and a second NewFace/DoneFace cycle still works).
+static bool NewFaceThenDoneFace_RegisteredFace_RoundTrips(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face face = NULL;
+	do {
+		// Arrange
+		face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"), 0);
+		if(face == NULL) {
+			cout << "FreeTypeWrapperTest [NewFaceThenDoneFace::RegisteredFace_RoundTrips]: NewFace failed for arial.ttf" << endl;
+			break;
+		}
+
+		// Act
+		FT_UInt glyphIndex = FT_Get_Char_Index(face, 'A');
+		FT_Error doneStatus = ft.DoneFace(face);
+		face = NULL;
+
+		// Assert
+		if(glyphIndex == 0) {
+			cout << "FreeTypeWrapperTest [NewFaceThenDoneFace::RegisteredFace_RoundTrips]: no glyph for 'A'" << endl;
+			break;
+		}
+		if(doneStatus != 0) {
+			cout << "FreeTypeWrapperTest [NewFaceThenDoneFace::RegisteredFace_RoundTrips]: DoneFace returned a nonzero FT_Error " << doneStatus << endl;
+			break;
+		}
+		// A second full cycle proves the map entry was erased cleanly.
+		FT_Face face2 = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"), 0);
+		if(face2 == NULL) {
+			cout << "FreeTypeWrapperTest [NewFaceThenDoneFace::RegisteredFace_RoundTrips]: second NewFace failed" << endl;
+			break;
+		}
+		if(ft.DoneFace(face2) != 0) {
+			cout << "FreeTypeWrapperTest [NewFaceThenDoneFace::RegisteredFace_RoundTrips]: second DoneFace returned a nonzero FT_Error" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	if(face != NULL)
+		ft.DoneFace(face);
+	return ok;
+}
+
+// V-074: NewFace on a non-existent path makes InputFile::OpenFile fail
+// inside CreateFTStreamForPath. Pre-fix the new'd InputFile* was dropped
+// on the floor (leak). The leak itself needs a leak sanitizer to observe
+// (unavailable on Darwin); this asserts the observable contract - NewFace
+// returns NULL and the wrapper is still usable for a subsequent valid
+// load (no state corruption from the failed attempt).
+static bool NewFace_NonExistentPath_ReturnsNullAndWrapperStaysUsable(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face validFace = NULL;
+	do {
+		// Arrange / Act
+		FT_Face missing = ft.NewFace("/no/such/font/file.ttf", 0);
+
+		// Assert
+		if(missing != NULL) {
+			cout << "FreeTypeWrapperTest [NewFace::NonExistentPath_ReturnsNullAndWrapperStaysUsable]: expected NULL for a non-existent path" << endl;
+			break;
+		}
+		validFace = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"), 0);
+		if(validFace == NULL) {
+			cout << "FreeTypeWrapperTest [NewFace::NonExistentPath_ReturnsNullAndWrapperStaysUsable]: a valid load failed after a failed one" << endl;
+			break;
+		}
+		if(FT_Get_Char_Index(validFace, 'A') == 0) {
+			cout << "FreeTypeWrapperTest [NewFace::NonExistentPath_ReturnsNullAndWrapperStaysUsable]: no glyph for 'A' on the recovered face" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	if(validFace != NULL)
+		ft.DoneFace(validFace);
+	return ok;
+}
+
+// V-075: NewFace(file, secondaryFile, index) with a valid primary font but
+// a non-existent secondary path. FillOpenFaceArgumentsForUTF8String fails,
+// the inner do-while breaks early, then the function reads
+// attachStreamArguments via CloseOpenFaceArgumentsStream. Pre-fix this was
+// only safe by Fill always zeroing .stream; the fix value-initializes the
+// FT_Open_Args so the early-fail path is well-defined regardless. Asserts
+// the observable contract: NULL, no crash, wrapper still usable.
+static bool NewFaceSecondary_BadSecondaryPath_ReturnsNullAndWrapperStaysUsable(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face recovered = NULL;
+	do {
+		// Arrange / Act
+		FT_Face face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"),
+		                          "/no/such/secondary/file.afm",
+		                          0);
+
+		// Assert
+		if(face != NULL) {
+			cout << "FreeTypeWrapperTest [NewFaceSecondary::BadSecondaryPath_ReturnsNullAndWrapperStaysUsable]: expected NULL when the secondary path is bad" << endl;
+			break;
+		}
+		recovered = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"), 0);
+		if(recovered == NULL) {
+			cout << "FreeTypeWrapperTest [NewFaceSecondary::BadSecondaryPath_ReturnsNullAndWrapperStaysUsable]: a valid load failed after the bad-secondary attempt" << endl;
+			break;
+		}
+		if(FT_Get_Char_Index(recovered, 'A') == 0) {
+			cout << "FreeTypeWrapperTest [NewFaceSecondary::BadSecondaryPath_ReturnsNullAndWrapperStaysUsable]: no glyph for 'A' on the recovered face" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	if(recovered != NULL)
+		ft.DoneFace(recovered);
+	return ok;
+}
+
+int FreeTypeWrapperTest(int argc, char* argv[]) {
+	(void)argc;
+
+	if(!DoneFace_UnregisteredFace_DoesNotCorruptStreamMap(argv)) return 1;
+	if(!NewFaceThenDoneFace_RegisteredFace_RoundTrips(argv)) return 1;
+	if(!NewFace_NonExistentPath_ReturnsNullAndWrapperStaysUsable(argv)) return 1;
+	if(!NewFaceSecondary_BadSecondaryPath_ReturnsNullAndWrapperStaysUsable(argv)) return 1;
+	return 0;
+}


### PR DESCRIPTION
Part of the Phase-2 C8 by-file grind (PR 6/7). Three standalone `FreeTypeWrapper.cpp` findings + a new `FreeTypeWrapperTest.cpp`. A fourth finding (V-091) surfaced during review and was folded in.

## V-073 — erase outside the found-block
`CleanStreamsForFace` called `mOpenStreams.erase(it)` *outside* the `if(it != end())` block. `DoneFace` on a face never registered via `FreeTypeWrapper::NewFace` (or any second `DoneFace`) reached `erase(end())` — undefined behaviour walking the map's red-black tree. Fix moves the `erase` inside the found branch.

## V-074 — InputFile leak on OpenFile failure
`CreateFTStreamForPath` `new`'d an `InputFile`, and on `OpenFile` failure returned `NULL` without deleting it. `NewFace` on a bad path leaks one `InputFile` per attempt; sustained failures exhaust memory. Fix `delete`s before the early `return NULL`.

## V-075 — uninitialized FT_Open_Args (latent)
The `NewFace` overloads read a possibly-uninitialized `FT_Open_Args` on early-fail paths, safe today only because `FillOpenFaceArgumentsForUTF8String` happens to write `.stream` on failure. Value-initialize the struct so the early-fail path is well-defined regardless. Latent — no synthetic no-op case (latent-fix principle).

## V-091 — OOB read in ft_errors[] lookup (folded during review)
The TRACE_LOG path at `NewFace` built a static `ft_errors[]` table via FreeType's legacy "include-and-expand" macro idiom (anonymous-struct declaration + `#include FT_ERRORS_H` to populate entries), then indexed by raw `FT_Error` value: `ft_errors[ftStatus].err_msg`. Sequential base errors (`0x00..~0x9X`) fit; **module-prefixed errors** (CFF/Type 1/TrueType modules at `0x100+`) walked past the array — OOB read into the format string, reachable via `FT_Open_Face`/`FT_Attach_Stream` on malformed fonts.

Replaced with `FT_Error_String` (FreeType 2.10+), which is bounds-safe and strips module prefixes internally. `FT_CONFIG_OPTION_ERROR_STRINGS` enabled for the bundled FreeType build (CMake + gyp). For unbundled FreeType builds that may not enable the option, `FT_Error_String` can return NULL; guarded at both call sites (`errMsg ? errMsg : ""`). The legacy 13-line macro block is deleted as part of the change.

No dedicated regression test — deterministically triggering a module-prefixed FT error from a unit test is impractical (same shape as the latent-fix decisions on V-075 / V-081 / V-084). The full font-loading suite exercises the happy path.

## Tests (`FreeTypeWrapperTest.cpp`)
- **V-073 discriminator**: `DoneFace_UnregisteredFace_DoesNotCorruptStreamMap` — a face created directly on the wrapper's `FT_Library` (never registered) is passed to `DoneFace`. The `FT_Done_Face` itself is well-defined, isolating the erase-with-`end()` bug without a double-free confound.
- **V-073 happy path**: `NewFaceThenDoneFace_RegisteredFace_RoundTrips` — registered face round-trips (locks in that moving the erase didn't regress the normal lifecycle).
- **V-074 / V-075**: observable-contract assertions (NULL on bad path, wrapper still usable). The leak (V-074) needs a leak sanitizer to observe directly — LSan is unavailable on Darwin — and V-075 is latent; both documented.

## Verification
- `cmake --build` + full `ctest`: 99/99 green (with V-091 fix applied; full FreeType rebuild after enabling the option).
- **ASAN stash-verify (V-073)** per the project's documented OOB/UAF protocol: with the fix, ASAN-clean. Stashing the production file, ASAN aborts pre-fix with `stack-buffer-overflow` in `std::map::erase` ← `FreeTypeWrapper::CleanStreamsForFace` at the `erase(it)` line, driven from the unregistered-`DoneFace` test. Deterministic pre/post discriminator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)