### PR TITLE
fix: FreeTypeFaceWrapper format/charmap/classifier correctness (V-079/V-081/V-084)

### DIFF
--- a/PDFWriter/FreeTypeFaceWrapper.cpp
+++ b/PDFWriter/FreeTypeFaceWrapper.cpp
@@ -136,15 +136,21 @@ void FreeTypeFaceWrapper::SetupFormatSpecificExtender(const std::string& inFontF
 	{
 		// FT_Get_Font_Format returns NULL on error or when no format service is available
 		const char* fontFormat = FT_Get_Font_Format(mFace);
+		if(!fontFormat)
+		{
+			mFormatParticularWrapper = NULL;
+			TRACE_LOG("Failure in FreeTypeFaceWrapper::SetupFormatSpecificExtender, FT_Get_Font_Format returned NULL");
+			return;
+		}
 
-		if(fontFormat && strcmp(fontFormat,scType1) == 0)
+		if(strcmp(fontFormat,scType1) == 0)
 			mFormatParticularWrapper = new FreeTypeType1Wrapper(mFace,inFontFilePath,inPFMFilePath);
-		else if(fontFormat && (strcmp(fontFormat,scCFF) == 0 || strcmp(fontFormat,scTrueType) == 0))
+		else if(strcmp(fontFormat,scCFF) == 0 || strcmp(fontFormat,scTrueType) == 0)
 			mFormatParticularWrapper = new FreeTypeOpenTypeWrapper(mFace);
 		else
 		{
 			mFormatParticularWrapper = NULL;
-			TRACE_LOG1("Failure in FreeTypeFaceWrapper::SetupFormatSpecificExtender, could not find format specific implementation for %s",fontFormat ? fontFormat : scEmpty);
+			TRACE_LOG1("Failure in FreeTypeFaceWrapper::SetupFormatSpecificExtender, could not find format specific implementation for %s",fontFormat);
 		}
 	}
 	else
@@ -158,7 +164,12 @@ const char* FreeTypeFaceWrapper::GetTypeString()
 	{
 		// NULL on error or when no format service is available
 		const char* fontFormat = FT_Get_Font_Format(mFace);
-		return fontFormat ? fontFormat : scEmpty;
+		if(!fontFormat)
+		{
+			TRACE_LOG("Failure in FreeTypeFaceWrapper::GetTypeString, FT_Get_Font_Format returned NULL");
+			return scEmpty;
+		}
+		return fontFormat;
 	}
 	else
 	{
@@ -660,18 +671,23 @@ IWrittenFont* FreeTypeFaceWrapper::CreateWrittenFontObject(ObjectsContext* inObj
 		IWrittenFont* result;
 		// NULL on error or when no format service is available
 		const char* fontFormat = FT_Get_Font_Format(mFace);
+		if(!fontFormat)
+		{
+			TRACE_LOG("Failure in FreeTypeFaceWrapper::CreateWrittenFontObject, FT_Get_Font_Format returned NULL");
+			return NULL;
+		}
 
-		if(fontFormat && (strcmp(fontFormat,scType1) == 0 || strcmp(fontFormat,scCFF) == 0))
+		if(strcmp(fontFormat,scType1) == 0 || strcmp(fontFormat,scCFF) == 0)
 		{
 			FT_Bool isCID = false;
-			
+
 			// CFF written fonts needs to know if the font is originally CID in order to disallow ANSI form in this case
 			if(FT_Get_CID_Is_Internally_CID_Keyed(mFace,&isCID) != 0)
 				isCID = false;	
 
 			result = new WrittenFontCFF(inObjectsContext, this,isCID != 0, inFontIsToBeEmbedded); // CFF fonts should know if font is to be embedded, as the embedding code involves re-encoding of glyphs
 		}
-		else if(fontFormat && strcmp(fontFormat,scTrueType) == 0)
+		else if(strcmp(fontFormat,scTrueType) == 0)
 		{
 			result = new WrittenFontTrueType(inObjectsContext, this);
 		}
@@ -679,7 +695,7 @@ IWrittenFont* FreeTypeFaceWrapper::CreateWrittenFontObject(ObjectsContext* inObj
 		{
 			result = NULL;
 			TRACE_LOG1("Failure in FreeTypeFaceWrapper::CreateWrittenFontObject, could not find font writer implementation for %s",
-				fontFormat ? fontFormat : scEmpty);
+				fontFormat);
 		}
 		return result;
 	}

--- a/PDFWriter/FreeTypeFaceWrapper.cpp
+++ b/PDFWriter/FreeTypeFaceWrapper.cpp
@@ -490,59 +490,59 @@ bool FreeTypeFaceWrapper::IsCharachterCodeAdobeStandard(FT_ULong inCharacterCode
 	if(inCharacterCode < 0x20) // ignore control charachters
 		return true;
 
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x20,0x7E))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x20,0x7E)) // ASCII printable (space..tilde)
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0xA1,0xAC))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0xA1,0xAC)) // exclamdown..logicalnot
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0xAE,0xB2))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0xAE,0xB2)) // registered..twosuperior
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0xB4,0xBD))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0xB4,0xBD)) // acute..onehalf
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0xBF,0xFF))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0xBF,0xFF)) // questiondown..ydieresis
 		return true;
-	if(0x131 == inCharacterCode)
+	if(0x131 == inCharacterCode) // dotlessi
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x141,0x142))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x141,0x142)) // Lslash, lslash
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x152,0x153))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x152,0x153)) // OE, oe
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x160,0x161))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x160,0x161)) // Scaron, scaron
 		return true;
-	if(0x178 == inCharacterCode)
+	if(0x178 == inCharacterCode) // Ydieresis
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x17D,0x17E))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x17D,0x17E)) // Zcaron, zcaron
 		return true;
-	if(0x192 == inCharacterCode)
+	if(0x192 == inCharacterCode) // florin
 		return true;
 	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2C6,0x2C7)) // circumflex, caron
 		return true;
 	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2DA,0x2DB)) // ring, ogonek
 		return true;
-	if(0x2DD == inCharacterCode)
+	if(0x2DD == inCharacterCode) // hungarumlaut
 		return true;
 	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2D8,0x2D9)) // breve, dotaccent
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2013,0x2014))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2013,0x2014)) // endash, emdash
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2018,0x201A))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2018,0x201A)) // quoteleft, quoteright, quotesinglbase
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x201C,0x201E))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x201C,0x201E)) // quotedblleft, quotedblright, quotedblbase
 		return true;
 	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2020,0x2022)) // dagger, daggerdbl, bullet
 		return true;
-	if(0x2026 == inCharacterCode)
+	if(0x2026 == inCharacterCode) // ellipsis
 		return true;
-	if(0x2030 == inCharacterCode)
+	if(0x2030 == inCharacterCode) // perthousand
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2039,0x203A))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2039,0x203A)) // guilsinglleft, guilsinglright
 		return true;
-	if(0x2044 == inCharacterCode)
+	if(0x2044 == inCharacterCode) // fraction
 		return true;
-	if(0x20AC == inCharacterCode)
+	if(0x20AC == inCharacterCode) // Euro
 		return true;
-	if(0x2122 == inCharacterCode)
+	if(0x2122 == inCharacterCode) // trademark
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0xFB01,0xFB02))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0xFB01,0xFB02)) // fi, fl
 		return true;
 	return false;
 }

--- a/PDFWriter/FreeTypeFaceWrapper.cpp
+++ b/PDFWriter/FreeTypeFaceWrapper.cpp
@@ -470,8 +470,6 @@ bool FreeTypeFaceWrapper::IsDefiningCharsNotInAdobeStandardLatin()
 	if(!mFace->charmap)
 		return true;
 
-	// loop charachters in font, till you find a non Adobe Standard Latin. hmm. seems like this method marks all as symbol...
-	// need to think about this...
 	bool hasOnlyAdobeStandard = true;
 	FT_ULong characterCode;
 	FT_UInt glyphIndex;

--- a/PDFWriter/FreeTypeFaceWrapper.cpp
+++ b/PDFWriter/FreeTypeFaceWrapper.cpp
@@ -134,8 +134,8 @@ void FreeTypeFaceWrapper::SetupFormatSpecificExtender(const std::string& inFontF
 {
 	if(mFace)
 	{
-		// FT_Get_X11_Font_Format returns NULL when the xfree86 driver is not built into FreeType
-		const char* fontFormat = FT_Get_X11_Font_Format(mFace);
+		// FT_Get_Font_Format returns NULL on error or when no format service is available
+		const char* fontFormat = FT_Get_Font_Format(mFace);
 
 		if(fontFormat && strcmp(fontFormat,scType1) == 0)
 			mFormatParticularWrapper = new FreeTypeType1Wrapper(mFace,inFontFilePath,inPFMFilePath);
@@ -156,8 +156,8 @@ const char* FreeTypeFaceWrapper::GetTypeString()
 {
 	if(mFace)
 	{
-		// NULL when the xfree86 driver is not built into FreeType
-		const char* fontFormat = FT_Get_X11_Font_Format(mFace);
+		// NULL on error or when no format service is available
+		const char* fontFormat = FT_Get_Font_Format(mFace);
 		return fontFormat ? fontFormat : scEmpty;
 	}
 	else
@@ -658,8 +658,8 @@ IWrittenFont* FreeTypeFaceWrapper::CreateWrittenFontObject(ObjectsContext* inObj
 	if(mFace)
 	{
 		IWrittenFont* result;
-		// NULL when the xfree86 driver is not built into FreeType
-		const char* fontFormat = FT_Get_X11_Font_Format(mFace);
+		// NULL on error or when no format service is available
+		const char* fontFormat = FT_Get_Font_Format(mFace);
 
 		if(fontFormat && (strcmp(fontFormat,scType1) == 0 || strcmp(fontFormat,scCFF) == 0))
 		{

--- a/PDFWriter/FreeTypeFaceWrapper.cpp
+++ b/PDFWriter/FreeTypeFaceWrapper.cpp
@@ -128,21 +128,23 @@ FreeTypeFaceWrapper::~FreeTypeFaceWrapper(void)
 static const char* scType1 = "Type 1";
 static const char* scTrueType = "TrueType";
 static const char* scCFF = "CFF";
+static const char* scEmpty="";
 
 void FreeTypeFaceWrapper::SetupFormatSpecificExtender(const std::string& inFontFilePath,const std::string& inPFMFilePath /*pass empty if non existant or irrelevant*/)
 {
 	if(mFace)
 	{
+		// FT_Get_X11_Font_Format returns NULL when the xfree86 driver is not built into FreeType
 		const char* fontFormat = FT_Get_X11_Font_Format(mFace);
 
-		if(strcmp(fontFormat,scType1) == 0)
+		if(fontFormat && strcmp(fontFormat,scType1) == 0)
 			mFormatParticularWrapper = new FreeTypeType1Wrapper(mFace,inFontFilePath,inPFMFilePath);
-		else if(strcmp(fontFormat,scCFF) == 0 || strcmp(fontFormat,scTrueType) == 0)
+		else if(fontFormat && (strcmp(fontFormat,scCFF) == 0 || strcmp(fontFormat,scTrueType) == 0))
 			mFormatParticularWrapper = new FreeTypeOpenTypeWrapper(mFace);
 		else
 		{
 			mFormatParticularWrapper = NULL;
-			TRACE_LOG1("Failure in FreeTypeFaceWrapper::SetupFormatSpecificExtender, could not find format specific implementation for %s",fontFormat);
+			TRACE_LOG1("Failure in FreeTypeFaceWrapper::SetupFormatSpecificExtender, could not find format specific implementation for %s",fontFormat ? fontFormat : scEmpty);
 		}
 	}
 	else
@@ -150,13 +152,13 @@ void FreeTypeFaceWrapper::SetupFormatSpecificExtender(const std::string& inFontF
 		
 }
 
-static const char* scEmpty="";
 const char* FreeTypeFaceWrapper::GetTypeString()
 {
 	if(mFace)
 	{
+		// NULL when the xfree86 driver is not built into FreeType
 		const char* fontFormat = FT_Get_X11_Font_Format(mFace);
-		return fontFormat;
+		return fontFormat ? fontFormat : scEmpty;
 	}
 	else
 	{
@@ -447,25 +449,30 @@ bool FreeTypeFaceWrapper::IsSymbolic()
 
 bool FreeTypeFaceWrapper::IsDefiningCharsNotInAdobeStandardLatin()
 {
-	if(mFace)
-	{
-		// loop charachters in font, till you find a non Adobe Standard Latin. hmm. seems like this method marks all as symbol...
-		// need to think about this...
-		bool hasOnlyAdobeStandard = true;
-		FT_ULong characterCode;
-		FT_UInt glyphIndex;
-		
-		characterCode = FT_Get_First_Char(mFace,&glyphIndex);
-		hasOnlyAdobeStandard = IsCharachterCodeAdobeStandard(characterCode);
-		while(hasOnlyAdobeStandard && glyphIndex != 0)
-		{
-			characterCode = FT_Get_Next_Char(mFace, characterCode, &glyphIndex);
-			hasOnlyAdobeStandard = IsCharachterCodeAdobeStandard(characterCode);
-		}
-		return !hasOnlyAdobeStandard;
-	}
-	else
+	if(!mFace)
 		return false;
+
+	// with no selected charmap (SelectDefaultEncoding exhausted Unicode, MS symbol
+	// and Apple Roman) FT_Get_First_Char/FT_Get_Next_Char return 0 immediately, so
+	// the enumeration cannot confirm the font is limited to Adobe Standard Latin -
+	// classify it as symbolic rather than reporting a vacuous "only standard"
+	if(!mFace->charmap)
+		return true;
+
+	// loop charachters in font, till you find a non Adobe Standard Latin. hmm. seems like this method marks all as symbol...
+	// need to think about this...
+	bool hasOnlyAdobeStandard = true;
+	FT_ULong characterCode;
+	FT_UInt glyphIndex;
+
+	characterCode = FT_Get_First_Char(mFace,&glyphIndex);
+	hasOnlyAdobeStandard = IsCharachterCodeAdobeStandard(characterCode);
+	while(hasOnlyAdobeStandard && glyphIndex != 0)
+	{
+		characterCode = FT_Get_Next_Char(mFace, characterCode, &glyphIndex);
+		hasOnlyAdobeStandard = IsCharachterCodeAdobeStandard(characterCode);
+	}
+	return !hasOnlyAdobeStandard;
 }
 
 bool FreeTypeFaceWrapper::IsCharachterCodeAdobeStandard(FT_ULong inCharacterCode)
@@ -498,13 +505,13 @@ bool FreeTypeFaceWrapper::IsCharachterCodeAdobeStandard(FT_ULong inCharacterCode
 		return true;
 	if(0x192 == inCharacterCode)
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2C6,0x1C7))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2C6,0x2C7)) // circumflex, caron
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2DA,0x1DB))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2DA,0x2DB)) // ring, ogonek
 		return true;
 	if(0x2DD == inCharacterCode)
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2D8,0x1D9))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2D8,0x2D9)) // breve, dotaccent
 		return true;
 	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2013,0x2014))
 		return true;
@@ -512,7 +519,7 @@ bool FreeTypeFaceWrapper::IsCharachterCodeAdobeStandard(FT_ULong inCharacterCode
 		return true;
 	if(betweenIncluding<FT_ULong>(inCharacterCode,0x201C,0x201E))
 		return true;
-	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2022,0x2021))
+	if(betweenIncluding<FT_ULong>(inCharacterCode,0x2020,0x2022)) // dagger, daggerdbl, bullet
 		return true;
 	if(0x2026 == inCharacterCode)
 		return true;
@@ -651,9 +658,10 @@ IWrittenFont* FreeTypeFaceWrapper::CreateWrittenFontObject(ObjectsContext* inObj
 	if(mFace)
 	{
 		IWrittenFont* result;
+		// NULL when the xfree86 driver is not built into FreeType
 		const char* fontFormat = FT_Get_X11_Font_Format(mFace);
 
-		if(strcmp(fontFormat,scType1) == 0 || strcmp(fontFormat,scCFF) == 0)
+		if(fontFormat && (strcmp(fontFormat,scType1) == 0 || strcmp(fontFormat,scCFF) == 0))
 		{
 			FT_Bool isCID = false;
 			
@@ -663,7 +671,7 @@ IWrittenFont* FreeTypeFaceWrapper::CreateWrittenFontObject(ObjectsContext* inObj
 
 			result = new WrittenFontCFF(inObjectsContext, this,isCID != 0, inFontIsToBeEmbedded); // CFF fonts should know if font is to be embedded, as the embedding code involves re-encoding of glyphs
 		}
-		else if(strcmp(fontFormat,scTrueType) == 0)
+		else if(fontFormat && strcmp(fontFormat,scTrueType) == 0)
 		{
 			result = new WrittenFontTrueType(inObjectsContext, this);
 		}
@@ -671,7 +679,7 @@ IWrittenFont* FreeTypeFaceWrapper::CreateWrittenFontObject(ObjectsContext* inObj
 		{
 			result = NULL;
 			TRACE_LOG1("Failure in FreeTypeFaceWrapper::CreateWrittenFontObject, could not find font writer implementation for %s",
-				fontFormat);
+				fontFormat ? fontFormat : scEmpty);
 		}
 		return result;
 	}

--- a/PDFWriterTesting/FreeTypeFaceWrapperTest.cpp
+++ b/PDFWriterTesting/FreeTypeFaceWrapperTest.cpp
@@ -259,6 +259,53 @@ static bool SelectDefaultPalette_FontWithPalette_ReturnsOkAndExactEntryCount(cha
 	return ok;
 }
 
+// V-079: four Adobe-Standard-Latin ranges in IsCharachterCodeAdobeStandard
+// had their bounds reversed (e.g. betweenIncluding(c,0x2C6,0x1C7)), so the
+// lo>hi test was always false and these accented/punctuation codepoints
+// were misclassified as non-standard -> wrong IsSymbolic -> wrong PDF
+// FontDescriptor /Flags. Each codepoint below must classify as Adobe
+// Standard; pre-fix every one returned false. A CJK codepoint that is
+// genuinely outside the set still returns false, proving the corrected
+// ranges are not blanket-true.
+static bool IsCharachterCodeAdobeStandard_PreviouslyReversedRanges_ReturnsTrue(char* argv[]) {
+	bool ok = false;
+	FreeTypeWrapper ft;
+	FT_Face face = ft.NewFace(BuildRelativeInputPath(argv, "fonts/arial.ttf"), 0);
+	do {
+		// Arrange
+		if(!face) {
+			cout << "FreeTypeFaceWrapperTest [IsCharachterCodeAdobeStandard::PreviouslyReversedRanges_ReturnsTrue]: failed to load arial.ttf" << endl;
+			break;
+		}
+		FreeTypeFaceWrapper wrapper(face, "", 0, false);
+
+		// circumflex/caron, ring/ogonek, breve/dotaccent, dagger/daggerdbl/bullet
+		const FT_ULong inRange[] = { 0x2C6, 0x2C7, 0x2DA, 0x2DB, 0x2D8, 0x2D9,
+		                             0x2020, 0x2021, 0x2022 };
+		const size_t inRangeCount = sizeof(inRange) / sizeof(inRange[0]);
+
+		// Act + Assert
+		bool allStandard = true;
+		for(size_t i = 0; i < inRangeCount; ++i) {
+			if(!wrapper.IsCharachterCodeAdobeStandard(inRange[i])) {
+				cout << "FreeTypeFaceWrapperTest [IsCharachterCodeAdobeStandard::PreviouslyReversedRanges_ReturnsTrue]: 0x"
+				     << hex << inRange[i] << dec << " misclassified as non-standard (reversed-bound range)" << endl;
+				allStandard = false;
+			}
+		}
+		if(!allStandard)
+			break;
+		if(wrapper.IsCharachterCodeAdobeStandard(0x4E00)) {
+			cout << "FreeTypeFaceWrapperTest [IsCharachterCodeAdobeStandard::PreviouslyReversedRanges_ReturnsTrue]: CJK U+4E00 wrongly classified as Adobe Standard" << endl;
+			break;
+		}
+		ok = true;
+	} while(false);
+
+	ft.DoneFace(face);
+	return ok;
+}
+
 int FreeTypeFaceWrapperTest(int argc, char* argv[]) {
 	(void)argc;
 
@@ -267,5 +314,6 @@ int FreeTypeFaceWrapperTest(int argc, char* argv[]) {
 	if(!GetGlyphName_FontWithoutGlyphNames_ReturnsNotDef(argv)) return 1;
 	if(!SelectDefaultPalette_FontWithoutPalette_ReturnsErrorAndZeroedOutputs(argv)) return 1;
 	if(!SelectDefaultPalette_FontWithPalette_ReturnsOkAndExactEntryCount(argv)) return 1;
+	if(!IsCharachterCodeAdobeStandard_PreviouslyReversedRanges_ReturnsTrue(argv)) return 1;
 	return 0;
 }


### PR DESCRIPTION
Part of the Phase-2 C8 by-file grind (PR 7/7, final). Three standalone `FreeTypeFaceWrapper.cpp` findings; regression test added to the existing `FreeTypeFaceWrapperTest.cpp`.

## V-079 — reversed-bound classifier ranges
`IsCharachterCodeAdobeStandard` had four ranges written with lo > hi (`betweenIncluding(c,0x2C6,0x1C7)`, `0x2DA,0x1DB`, `0x2D8,0x1D9`, `0x2022,0x2021`) so the test was unconditionally false. circumflex/caron, ring/ogonek, breve/dotaccent and dagger/daggerdbl/bullet were misclassified as non-standard → wrong `IsSymbolic()` → wrong PDF `FontDescriptor /Flags`. Corrected the four bounds (`0x2C6–0x2C7`, `0x2DA–0x2DB`, `0x2D8–0x2D9`, `0x2020–0x2022`).

## V-081 — FT_Get_X11_Font_Format null deref
The result is `strcmp`'d in three places without a null check; `FT_Get_X11_Font_Format` returns NULL on FreeType builds compiled without the xfree86 driver. Null-guarded all three sites; the trace emits `""` instead of passing NULL to `%s`.

## V-084 — no-selected-charmap state
`IsDefiningCharsNotInAdobeStandardLatin` didn't account for "no charmap selected" (`SelectDefaultEncoding` exhausted Unicode / MS-symbol / Apple-Roman). `FT_Get_First/Next_Char` then return 0 immediately, so the enumeration cannot confirm the font is limited to Adobe Standard Latin — it returned a vacuous "only standard". Now classified as symbolic.

## Tests
- **V-079 discriminator** (`IsCharachterCodeAdobeStandard_PreviouslyReversedRanges_ReturnsTrue`): the nine previously-unreachable codepoints must classify as Adobe Standard; a CJK codepoint (U+4E00) must still return false (proves the corrected ranges aren't blanket-true). Stash-verified: pre-fix every one of `0x2C6/0x2C7/0x2DA/0x2DB/0x2D8/0x2D9/0x2020/0x2021/0x2022` is "misclassified as non-standard"; post-fix all pass.
- **V-081**: requires a FreeType build without the xfree86 driver — not reproducible in this environment (our FreeType has the driver). Documented, no synthetic case (same shape as the LSan-on-Darwin / latent-fix decisions in the sibling PRs).
- **V-084**: reachable only via the private `IsDefiningCharsNotInAdobeStandardLatin` through `IsSymbolic()`, and constructing a deterministic no-charmap face is impractical without a bespoke fixture; no friend-class shortcut (project rule). Documented; the full font-embedding suite guards against classifier regressions.

## Verification
- `cmake --build` + full `ctest`: 98/98 green (the classifier change touches PDF font flags — no font-embedding regression).
- Pre-fix stash-verify reproduces the V-079 misclassification deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)