### PR TITLE
fix: SafeParse helpers replace BoxingBase string-ctor parses (V-064)

### DIFF
--- a/PDFWriter/BoxingBase.h
+++ b/PDFWriter/BoxingBase.h
@@ -131,6 +131,11 @@ public:
 	BoxingBaseWithRW(const U& inValue);
 	BoxingBaseWithRW(const BoxingBase<U>& inOther);
 	BoxingBaseWithRW(const BoxingBaseWithRW<U,Reader,Writer>& inOther);
+	// DEPRECATED for parsing untrusted input: these constructors cannot
+	// signal parse failure. On a failed extraction, boxedValue is left
+	// uninitialized (pre-C++11) or set to 0 (C++11+) — indistinguishable
+	// from a real "0". Use PDFHummus::TryParse / TryParseOrDefault from
+	// SafeParse.h instead when parsing attacker-controlled strings.
 	BoxingBaseWithRW(const std::wstring& inReadFrom);
 	BoxingBaseWithRW(const std::string& inReadFrom);
 

--- a/PDFWriter/CMakeLists.txt
+++ b/PDFWriter/CMakeLists.txt
@@ -358,6 +358,7 @@ RefCountObject.h
 RefCountPtr.h
 ResourcesDictionary.h
 SafeBufferMacrosDefs.h
+SafeParse.h
 SimpleGlyphsDrawingContext.h
 SimpleStringTokenizer.h
 Singleton.h
@@ -585,6 +586,7 @@ EPDFVersion.h
 EStatusCode.h
 MyStringBuf.h
 SafeBufferMacrosDefs.h
+SafeParse.h
 )
 
 source_group(Infrastructure\\Encoding FILES

--- a/PDFWriter/PDFDate.cpp
+++ b/PDFWriter/PDFDate.cpp
@@ -21,7 +21,7 @@
 #include "PDFDate.h"
 #include "SafeBufferMacrosDefs.h"
 #include "Trace.h"
-#include "BoxingBase.h"
+#include "SafeParse.h"
 #if defined (__MWERKS__)
 	// MAC OSX methods for providing UTC difference
 	#include <CoreFoundation/CFDate.h>
@@ -257,8 +257,8 @@ void PDFDate::ParseString(std::string inValue)
         Year = -1;
         return;
     }
-    
-    Year = Int(inValue.substr(2,4));
+
+    PDFHummus::TryParseOrDefault(inValue.substr(2,4), Year, -1);
     Month = -1;
     Day = -1;
     Hour = -1;
@@ -267,35 +267,35 @@ void PDFDate::ParseString(std::string inValue)
     UTC = eUndefined;
     HourFromUTC = -1;
     MinuteFromUTC = -1;
-    
+
     if(inValue.length() < 7)
         return;
-    
-    Month = Int(inValue.substr(6,2));
+
+    PDFHummus::TryParseOrDefault(inValue.substr(6,2), Month, -1);
 
     if(inValue.length() < 9)
         return;
-    
-    Day = Int(inValue.substr(8,2));
-    
+
+    PDFHummus::TryParseOrDefault(inValue.substr(8,2), Day, -1);
+
     if(inValue.length() < 11)
         return;
-    
-    Hour = Int(inValue.substr(10,2));
-    
+
+    PDFHummus::TryParseOrDefault(inValue.substr(10,2), Hour, -1);
+
     if(inValue.length() < 13)
         return;
-    
-    Minute = Int(inValue.substr(12,2));
-    
+
+    PDFHummus::TryParseOrDefault(inValue.substr(12,2), Minute, -1);
+
     if(inValue.length() < 15)
         return;
-    
-    Second = Int(inValue.substr(14,2));
+
+    PDFHummus::TryParseOrDefault(inValue.substr(14,2), Second, -1);
 
     if(inValue.length() < 17)
         return;
-    
+
     if(inValue[16] == 'Z')
     {
         UTC = eSame;
@@ -303,16 +303,16 @@ void PDFDate::ParseString(std::string inValue)
     else if(inValue[16] == '-' || inValue[16] == '+')
     {
         UTC = (inValue[16] == '-') ? eEarlier:eLater;
-        
+
         if(inValue.length() < 18)
             return;
-        
-        HourFromUTC = Int(inValue.substr(17,2));
-        
+
+        PDFHummus::TryParseOrDefault(inValue.substr(17,2), HourFromUTC, -1);
+
         if(inValue.length() < 21) // skipping '
             return;
-        
-        MinuteFromUTC = Int(inValue.substr(20,2));
+
+        PDFHummus::TryParseOrDefault(inValue.substr(20,2), MinuteFromUTC, -1);
     }
-    
+
 }

--- a/PDFWriter/PDFObjectParser.cpp
+++ b/PDFWriter/PDFObjectParser.cpp
@@ -33,7 +33,7 @@
 #include "PDFSymbol.h"
 #include "PDFStreamInput.h"
 #include "Trace.h"
-#include "BoxingBase.h"
+#include "SafeParse.h"
 #include "PDFStream.h"
 #include "IByteReader.h"
 #include "RefCountPtr.h"
@@ -563,7 +563,12 @@ PDFObject* PDFObjectParser::ParseNumber(const std::string& inToken)
 {
 	// once we know this is a number, then parsing is easy. just determine if it's a real or integer, so as to separate classes for better accuracy
 	if(inToken.find(scDot) != inToken.npos) {
-		return new PDFReal(Double(inToken));
+		double realValue;
+		if(!PDFHummus::TryParse(inToken, realValue)) {
+			TRACE_LOG1("PDFObjectParser::ParseNumber, real-number token '%s' is not parseable", inToken.c_str());
+			return NULL;
+		}
+		return new PDFReal(realValue);
 	} else {
 		errno = 0;
 		// use strtoll to parse long long with overflow validation

--- a/PDFWriter/PDFParser.cpp
+++ b/PDFWriter/PDFParser.cpp
@@ -25,9 +25,8 @@
 #include "PDFInteger.h"
 #include "PDFObject.h"
 #include "PDFSymbol.h"
-#include "BoxingBase.h"
 #include "PDFDictionary.h"
-#include "BoxingBase.h"
+#include "SafeParse.h"
 #include "PDFIndirectObjectReference.h"
 #include "PDFName.h"
 #include "PDFArray.h"
@@ -176,7 +175,12 @@ EStatusCode PDFParser::ParseHeaderLine()
 	{
 		if(tokenizerResult.second.compare(0,scPDFMagic.size(),scPDFMagic) == 0)
 		{
-			mPDFLevel = Double(tokenizerResult.second.substr(scPDFMagic.size()));
+			std::string versionToken = tokenizerResult.second.substr(scPDFMagic.size());
+			if(!PDFHummus::TryParse(versionToken, mPDFLevel))
+			{
+				TRACE_LOG1("PDFParser::ParseHeaderLine, PDF version token '%s' is not a valid number.", versionToken.c_str());
+				return PDFHummus::eFailure;
+			}
 			mStream.SetOffset(mStream.GetCurrentPosition() - tokenizerResult.second.size() - 1);
 			return PDFHummus::eSuccess;
 		}
@@ -552,9 +556,6 @@ EStatusCode PDFParser::InitializeXref()
 	return PDFHummus::eSuccess;
 }
 
-typedef BoxingBaseWithRW<ObjectIDType> ObjectIDTypeBox;
-typedef BoxingBaseWithRW<unsigned long> ULong;
-typedef BoxingBaseWithRW<LongFilePositionType> LongFilePositionTypeBox;
 static const ObjectIDType scMaxObjectIDType = (ObjectIDType)(-1);
 
 static bool ParseObjectIDTypeToken(const std::string& inToken, ObjectIDType& outValue)
@@ -702,8 +703,20 @@ EStatusCode PDFParser::ParseXrefFromXrefTable(XrefEntryInputVector& inXrefTable,
 					if (status != eSuccess)
 						break;
 
-					inXrefTable[currentObject].mObjectPosition = LongFilePositionTypeBox(std::string((const char*)entry, 10));
-					inXrefTable[currentObject].mRivision = ULong(std::string((const char*)(entry + 11), 5));
+					std::string positionToken((const char*)entry, 10);
+					std::string revisionToken((const char*)(entry + 11), 5);
+					if(!PDFHummus::TryParse(positionToken, inXrefTable[currentObject].mObjectPosition))
+					{
+						TRACE_LOG1("PDFParser::BuildXrefTableFromTable, xref entry offset '%s' is not numeric.", positionToken.c_str());
+						status = PDFHummus::eFailure;
+						break;
+					}
+					if(!PDFHummus::TryParse(revisionToken, inXrefTable[currentObject].mRivision))
+					{
+						TRACE_LOG1("PDFParser::BuildXrefTableFromTable, xref entry revision '%s' is not numeric.", revisionToken.c_str());
+						status = PDFHummus::eFailure;
+						break;
+					}
 					inXrefTable[currentObject].mType = entry[17] == 'n' ? eXrefEntryExisting:eXrefEntryDelete;
 				}
 				++currentObject;

--- a/PDFWriter/PDFParser.cpp
+++ b/PDFWriter/PDFParser.cpp
@@ -707,13 +707,13 @@ EStatusCode PDFParser::ParseXrefFromXrefTable(XrefEntryInputVector& inXrefTable,
 					std::string revisionToken((const char*)(entry + 11), 5);
 					if(!PDFHummus::TryParse(positionToken, inXrefTable[currentObject].mObjectPosition))
 					{
-						TRACE_LOG1("PDFParser::BuildXrefTableFromTable, xref entry offset '%s' is not numeric.", positionToken.c_str());
+						TRACE_LOG1("PDFParser::ParseXrefFromXrefTable, xref entry offset '%s' is not numeric.", positionToken.c_str());
 						status = PDFHummus::eFailure;
 						break;
 					}
 					if(!PDFHummus::TryParse(revisionToken, inXrefTable[currentObject].mRivision))
 					{
-						TRACE_LOG1("PDFParser::BuildXrefTableFromTable, xref entry revision '%s' is not numeric.", revisionToken.c_str());
+						TRACE_LOG1("PDFParser::ParseXrefFromXrefTable, xref entry revision '%s' is not numeric.", revisionToken.c_str());
 						status = PDFHummus::eFailure;
 						break;
 					}

--- a/PDFWriter/SafeParse.h
+++ b/PDFWriter/SafeParse.h
@@ -1,0 +1,112 @@
+/*
+   Source File : SafeParse.h
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+*/
+#pragma once
+
+/*
+	SafeParse provides parse helpers that distinguish parse failure from a
+	successful parse of a value. The historical convenience path through
+	BoxingBaseWithRW(const std::string&) silently produces an indeterminate
+	(pre-C++11) or deterministic-zero (C++11+) value when extraction fails,
+	indistinguishable from a real parse of 0. Prefer these helpers for any
+	parse of attacker-controlled input.
+
+	TryParse: returns whether the parse succeeded; outValue is untouched on failure.
+	TryParseOrDefault: fire-and-forget; writes inDefault when parse fails.
+
+	Lenient on trailing input (e.g. TryParse("12abc", x) succeeds with x=12) —
+	caller-side range/semantic checks are responsible for rejecting wrong
+	numbers; this helper only distinguishes "parsed nothing" from "parsed something".
+*/
+
+#include "Trace.h"
+
+#include <sstream>
+#include <string>
+
+namespace PDFHummus
+{
+
+template <typename T>
+bool TryParse(const std::string& inReadFrom, T& outValue)
+{
+	// Note: we deliberately do NOT check stream.eof() after extraction —
+	// trailing non-numeric input is accepted (e.g. "12abc" parses to 12).
+	// Callers handle wrong/malicious numbers via range checks; this helper
+	// only distinguishes "parsed nothing" from "parsed something".
+	std::stringstream stream(inReadFrom);
+	T tmp;
+	stream >> tmp;
+	if(stream.fail())
+	{
+		TRACE_LOG1("SafeParse::TryParse failed for input '%s'", inReadFrom.c_str());
+		return false;
+	}
+	outValue = tmp;
+	return true;
+}
+
+template <typename T>
+bool TryParse(const std::wstring& inReadFrom, T& outValue)
+{
+	// See lenient-on-trailing-input note on the std::string overload.
+	std::wstringstream stream(inReadFrom);
+	T tmp;
+	stream >> tmp;
+	if(stream.fail())
+	{
+		TRACE_LOG("SafeParse::TryParse<wstring> failed");
+		return false;
+	}
+	outValue = tmp;
+	return true;
+}
+
+inline bool TryParse(const std::string& inReadFrom, bool& outValue)
+{
+	if(inReadFrom == "true")  { outValue = true;  return true; }
+	if(inReadFrom == "false") { outValue = false; return true; }
+	TRACE_LOG1("SafeParse::TryParse<bool> failed for input '%s' (expected \"true\" or \"false\")", inReadFrom.c_str());
+	return false;
+}
+
+inline bool TryParse(const std::wstring& inReadFrom, bool& outValue)
+{
+	if(inReadFrom == L"true")  { outValue = true;  return true; }
+	if(inReadFrom == L"false") { outValue = false; return true; }
+	TRACE_LOG("SafeParse::TryParse<bool,wstring> failed (expected \"true\" or \"false\")");
+	return false;
+}
+
+template <typename T>
+void TryParseOrDefault(const std::string& inReadFrom, T& outValue, const T& inDefault)
+{
+	if(!TryParse(inReadFrom, outValue))
+		outValue = inDefault;
+}
+
+template <typename T>
+void TryParseOrDefault(const std::wstring& inReadFrom, T& outValue, const T& inDefault)
+{
+	if(!TryParse(inReadFrom, outValue))
+		outValue = inDefault;
+}
+
+}  // namespace PDFHummus

--- a/PDFWriter/SafeParse.h
+++ b/PDFWriter/SafeParse.h
@@ -44,21 +44,27 @@
 namespace PDFHummus
 {
 
+// TryParse does NOT log on failure: it returns a bool, so callers carry the
+// context (which field / which token) in their own TRACE_LOG. Adding a log
+// here would only restate the offending value with no context the caller
+// doesn't already have.
+//
+// TryParseOrDefault is fire-and-forget (void return), so callers can't easily
+// log on the failure path. The helper logs there as the sole signal.
+//
+// Note: we deliberately do NOT check stream.eof() after extraction. Trailing
+// non-numeric input is accepted (e.g. "12abc" parses to 12). Callers handle
+// wrong / malicious numbers via range checks; this helper only distinguishes
+// "parsed nothing" from "parsed something".
+
 template <typename T>
 bool TryParse(const std::string& inReadFrom, T& outValue)
 {
-	// Note: we deliberately do NOT check stream.eof() after extraction —
-	// trailing non-numeric input is accepted (e.g. "12abc" parses to 12).
-	// Callers handle wrong/malicious numbers via range checks; this helper
-	// only distinguishes "parsed nothing" from "parsed something".
 	std::stringstream stream(inReadFrom);
 	T tmp;
 	stream >> tmp;
 	if(stream.fail())
-	{
-		TRACE_LOG1("SafeParse::TryParse failed for input '%s'", inReadFrom.c_str());
 		return false;
-	}
 	outValue = tmp;
 	return true;
 }
@@ -66,15 +72,11 @@ bool TryParse(const std::string& inReadFrom, T& outValue)
 template <typename T>
 bool TryParse(const std::wstring& inReadFrom, T& outValue)
 {
-	// See lenient-on-trailing-input note on the std::string overload.
 	std::wstringstream stream(inReadFrom);
 	T tmp;
 	stream >> tmp;
 	if(stream.fail())
-	{
-		TRACE_LOG("SafeParse::TryParse<wstring> failed");
 		return false;
-	}
 	outValue = tmp;
 	return true;
 }
@@ -83,7 +85,6 @@ inline bool TryParse(const std::string& inReadFrom, bool& outValue)
 {
 	if(inReadFrom == "true")  { outValue = true;  return true; }
 	if(inReadFrom == "false") { outValue = false; return true; }
-	TRACE_LOG1("SafeParse::TryParse<bool> failed for input '%s' (expected \"true\" or \"false\")", inReadFrom.c_str());
 	return false;
 }
 
@@ -91,7 +92,6 @@ inline bool TryParse(const std::wstring& inReadFrom, bool& outValue)
 {
 	if(inReadFrom == L"true")  { outValue = true;  return true; }
 	if(inReadFrom == L"false") { outValue = false; return true; }
-	TRACE_LOG("SafeParse::TryParse<bool,wstring> failed (expected \"true\" or \"false\")");
 	return false;
 }
 
@@ -99,14 +99,20 @@ template <typename T>
 void TryParseOrDefault(const std::string& inReadFrom, T& outValue, const T& inDefault)
 {
 	if(!TryParse(inReadFrom, outValue))
+	{
+		TRACE_LOG1("SafeParse::TryParseOrDefault failed for input '%s', falling back to default", inReadFrom.c_str());
 		outValue = inDefault;
+	}
 }
 
 template <typename T>
 void TryParseOrDefault(const std::wstring& inReadFrom, T& outValue, const T& inDefault)
 {
 	if(!TryParse(inReadFrom, outValue))
+	{
+		TRACE_LOG("SafeParse::TryParseOrDefault<wstring> failed, falling back to default");
 		outValue = inDefault;
+	}
 }
 
 }  // namespace PDFHummus

--- a/PDFWriter/Type1Input.cpp
+++ b/PDFWriter/Type1Input.cpp
@@ -20,8 +20,7 @@
 */
 #include "Type1Input.h"
 #include "IByteReaderWithPosition.h"
-#include "BoxingBase.h"
-#include "PSBool.h"
+#include "SafeParse.h"
 #include "StandardEncoding.h"
 #include "Trace.h"
 #include "CharStringType1Interpreter.h"
@@ -50,7 +49,8 @@ using namespace PDFHummus;
 // they drive allocations or array indexing.
 static bool TryParseBoundedLong(const std::string& inToken,long inMinInclusive,long inMaxInclusive,long& outValue)
 {
-	outValue = Long(inToken);
+	if(!TryParse(inToken, outValue))
+		return false;
 	return outValue >= inMinInclusive && outValue <= inMaxInclusive;
 }
 
@@ -242,14 +242,24 @@ EStatusCode Type1Input::ReadFontDictionary()
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mFontDictionary.PaintType = Int(value);
+			if(!TryParse(value, mFontDictionary.PaintType))
+			{
+				TRACE_LOG1("Type1Input::ReadFontDictionary, /PaintType has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/FontType") == 0)
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mFontDictionary.FontType = Int(value);
+			if(!TryParse(value, mFontDictionary.FontType))
+			{
+				TRACE_LOG1("Type1Input::ReadFontDictionary, /FontType has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/FontMatrix") == 0)
@@ -268,7 +278,12 @@ EStatusCode Type1Input::ReadFontDictionary()
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mFontDictionary.UniqueID = Int(value);
+			if(!TryParse(value, mFontDictionary.UniqueID))
+			{
+				TRACE_LOG1("Type1Input::ReadFontDictionary, /UniqueID has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 
@@ -276,7 +291,12 @@ EStatusCode Type1Input::ReadFontDictionary()
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mFontDictionary.StrokeWidth = Double(value);
+			if(!TryParse(value, mFontDictionary.StrokeWidth))
+			{
+				TRACE_LOG1("Type1Input::ReadFontDictionary, /StrokeWidth has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 
@@ -292,7 +312,12 @@ EStatusCode Type1Input::ReadFontDictionary()
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mFontInfoDictionary.fsType = (unsigned short)Int(value);
+			if(!TryParse(value, mFontInfoDictionary.fsType))
+			{
+				TRACE_LOG1("Type1Input::ReadFontDictionary, /FSType has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			mFontInfoDictionary.FSTypeValid = true;
 		}
 	}
@@ -371,28 +396,48 @@ EStatusCode Type1Input::ReadFontInfoDictionary()
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mFontInfoDictionary.ItalicAngle = Double(value);
+			if(!TryParse(value, mFontInfoDictionary.ItalicAngle))
+			{
+				TRACE_LOG1("Type1Input::ReadFontInfoDictionary, /ItalicAngle has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/isFixedPitch") == 0)
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mFontInfoDictionary.isFixedPitch = PSBool(value);
+			if(!TryParse(value, mFontInfoDictionary.isFixedPitch))
+			{
+				TRACE_LOG1("Type1Input::ReadFontInfoDictionary, /isFixedPitch has bad boolean value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/UnderlinePosition") == 0)
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mFontInfoDictionary.UnderlinePosition = Double(value);
+			if(!TryParse(value, mFontInfoDictionary.UnderlinePosition))
+			{
+				TRACE_LOG1("Type1Input::ReadFontInfoDictionary, /UnderlinePosition has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/UnderlineThickness") == 0)
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mFontInfoDictionary.UnderlineThickness = Double(value);
+			if(!TryParse(value, mFontInfoDictionary.UnderlineThickness))
+			{
+				TRACE_LOG1("Type1Input::ReadFontInfoDictionary, /UnderlineThickness has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 
@@ -400,11 +445,16 @@ EStatusCode Type1Input::ReadFontInfoDictionary()
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mFontInfoDictionary.fsType = (unsigned short)Int(value);
+			if(!TryParse(value, mFontInfoDictionary.fsType))
+			{
+				TRACE_LOG1("Type1Input::ReadFontInfoDictionary, /FSType has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			mFontInfoDictionary.FSTypeValid = true;
 		}
 	}
-	return status;	
+	return status;
 }
 
 EStatusCode Type1Input::ParseDoubleArray(double* inArray,int inArraySize)
@@ -419,8 +469,17 @@ EStatusCode Type1Input::ParseDoubleArray(double* inArray,int inArraySize)
 	for(int i=0; i < inArraySize && eSuccess == status;++i)
 	{
 		token = mPFBDecoder.GetNextToken();
-		status = token.first ? eSuccess:eFailure;
-		inArray[i] = Double(token.second);
+		if(!token.first)
+		{
+			status = eFailure;
+			break;
+		}
+		if(!TryParse(token.second, inArray[i]))
+		{
+			TRACE_LOG1("Type1Input::ParseDoubleArray, bad numeric value '%s'", token.second.c_str());
+			status = eFailure;
+			break;
+		}
 	}
 
 	// skip the last ] or }
@@ -477,7 +536,12 @@ EStatusCode Type1Input::ParseEncoding()
 		token = mPFBDecoder.GetNextToken();
 		if(!token.first)
 			break;
-		encodingIndex = Int(token.second);
+		if(!TryParse(token.second, encodingIndex))
+		{
+			TRACE_LOG1("Type1Input::ParseEncoding, encoding index has bad numeric value '%s'", token.second.c_str());
+			status = eFailure;
+			break;
+		}
 		if(encodingIndex < 0 || encodingIndex > 255)
 		{
 			status = eFailure;
@@ -566,7 +630,12 @@ EStatusCode Type1Input::ReadPrivateDictionary()
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mPrivateDictionary.UniqueID = Int(value);
+			if(!TryParse(value, mPrivateDictionary.UniqueID))
+			{
+				TRACE_LOG1("Type1Input::ReadPrivateDictionary, /UniqueID has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 
@@ -594,21 +663,36 @@ EStatusCode Type1Input::ReadPrivateDictionary()
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mPrivateDictionary.BlueScale = Double(value);
+			if(!TryParse(value, mPrivateDictionary.BlueScale))
+			{
+				TRACE_LOG1("Type1Input::ReadPrivateDictionary, /BlueScale has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/BlueShift") == 0)
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mPrivateDictionary.BlueShift = Int(value);
+			if(!TryParse(value, mPrivateDictionary.BlueShift))
+			{
+				TRACE_LOG1("Type1Input::ReadPrivateDictionary, /BlueShift has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/BlueFuzz") == 0)
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mPrivateDictionary.BlueFuzz = Int(value);
+			if(!TryParse(value, mPrivateDictionary.BlueFuzz))
+			{
+				TRACE_LOG1("Type1Input::ReadPrivateDictionary, /BlueFuzz has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/StdHW") == 0)
@@ -617,7 +701,12 @@ EStatusCode Type1Input::ReadPrivateDictionary()
 				break;
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mPrivateDictionary.StdHW = Double(value);
+			if(!TryParse(value, mPrivateDictionary.StdHW))
+			{
+				TRACE_LOG1("Type1Input::ReadPrivateDictionary, /StdHW has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			if(!ReadNextTokenValue(value,status)) // skip ]
 				break;
 			continue;
@@ -628,7 +717,12 @@ EStatusCode Type1Input::ReadPrivateDictionary()
 				break;
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mPrivateDictionary.StdVW = Double(value);
+			if(!TryParse(value, mPrivateDictionary.StdVW))
+			{
+				TRACE_LOG1("Type1Input::ReadPrivateDictionary, /StdVW has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			if(!ReadNextTokenValue(value,status)) // skip ]
 				break;
 			continue;
@@ -647,28 +741,48 @@ EStatusCode Type1Input::ReadPrivateDictionary()
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mPrivateDictionary.ForceBold = PSBool(value);
+			if(!TryParse(value, mPrivateDictionary.ForceBold))
+			{
+				TRACE_LOG1("Type1Input::ReadPrivateDictionary, /ForceBold has bad boolean value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/LanguageGroup") == 0)
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mPrivateDictionary.LanguageGroup = Int(value);
+			if(!TryParse(value, mPrivateDictionary.LanguageGroup))
+			{
+				TRACE_LOG1("Type1Input::ReadPrivateDictionary, /LanguageGroup has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/lenIV") == 0)
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mPrivateDictionary.lenIV = Int(value);
+			if(!TryParse(value, mPrivateDictionary.lenIV))
+			{
+				TRACE_LOG1("Type1Input::ReadPrivateDictionary, /lenIV has bad numeric value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/RndStemUp") == 0)
 		{
 			if(!ReadNextTokenValue(value,status))
 				break;
-			mPrivateDictionary.RndStemUp = PSBool(value);
+			if(!TryParse(value, mPrivateDictionary.RndStemUp))
+			{
+				TRACE_LOG1("Type1Input::ReadPrivateDictionary, /RndStemUp has bad boolean value '%s'", value.c_str());
+				status = eFailure;
+				break;
+			}
 			continue;
 		}
 		if(token.second.compare("/Subrs") == 0)
@@ -702,7 +816,13 @@ EStatusCode Type1Input::ParseIntVector(std::vector<int>& inVector)
 		if(token.second.compare("]") == 0 || token.second.compare("}") == 0)
 			break;
 
-		inVector.push_back(Int(token.second));
+		int parsed;
+		if(!TryParse(token.second, parsed))
+		{
+			TRACE_LOG1("Type1Input::ParseIntVector, bad numeric value '%s'", token.second.c_str());
+			return eFailure;
+		}
+		inVector.push_back(parsed);
 	}
 	return token.first ? eSuccess:eFailure;
 }
@@ -721,7 +841,13 @@ EStatusCode Type1Input::ParseDoubleVector(std::vector<double>& inVector)
 		if(token.second.compare("]") == 0 || token.second.compare("}") == 0)
 			break;
 
-		inVector.push_back(Double(token.second));
+		double parsed;
+		if(!TryParse(token.second, parsed))
+		{
+			TRACE_LOG1("Type1Input::ParseDoubleVector, bad numeric value '%s'", token.second.c_str());
+			return eFailure;
+		}
+		inVector.push_back(parsed);
 	}
 	return token.first ? eSuccess:eFailure;
 }

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -74,6 +74,7 @@ create_test_sourcelist (Tests
   RecryptPDF.cpp
   RefCountTest.cpp
   RotatedPagesPDF.cpp
+  SafeParseTest.cpp
   ShutDownRestartTest.cpp
   SimpleContentPageTest.cpp
   SimpleTextUsage.cpp

--- a/PDFWriterTesting/SafeParseTest.cpp
+++ b/PDFWriterTesting/SafeParseTest.cpp
@@ -1,0 +1,169 @@
+/*
+   Source File : SafeParseTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+*/
+#include "SafeParse.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace PDFHummus;
+
+// ---- TryParse<T> ---------------------------------------------------------
+
+template <typename T>
+struct ParseCase {
+	const char* label;         // <Condition>_<Result>
+	const char* input;
+	bool        expectedOk;
+	T           expectedValue; // only consulted when expectedOk == true
+};
+
+template <typename T>
+static bool RunParseCases(const char* inTypeLabel,
+                          const ParseCase<T>* inCases,
+                          size_t inCount) {
+	for(size_t i = 0; i < inCount; ++i) {
+		const ParseCase<T>& testCase = inCases[i];
+
+		// Arrange
+		T outValue = T();
+
+		// Act
+		bool ok = TryParse(string(testCase.input), outValue);
+
+		// Assert
+		if(ok != testCase.expectedOk) {
+			cout << "SafeParseTest [" << inTypeLabel << "::" << testCase.label
+			     << "]: return " << ok << ", expected " << testCase.expectedOk << endl;
+			return false;
+		}
+		if(ok && outValue != testCase.expectedValue) {
+			cout << "SafeParseTest [" << inTypeLabel << "::" << testCase.label
+			     << "]: outValue " << outValue
+			     << ", expected " << testCase.expectedValue << endl;
+			return false;
+		}
+	}
+	return true;
+}
+
+static const ParseCase<int> scIntCases[] = {
+	{"PositiveInteger_Succeeds",            "42",    true,  42},
+	{"NegativeInteger_Succeeds",            "-17",   true,  -17},
+	{"TrailingNonNumeric_SucceedsLenient",  "12abc", true,  12},
+	{"NonNumeric_Fails",                    "ABC",   false, 0},
+	{"EmptyString_Fails",                   "",      false, 0},
+};
+
+// One row, just to prove TryParse instantiates for double and extracts as a
+// real (3.14, not 3-with-dot-as-trailing-garbage). The shared template body
+// is otherwise covered by the int table.
+static const ParseCase<double> scDoubleCases[] = {
+	{"DecimalNumber_ParsesAsReal", "3.14", true, 3.14},
+};
+
+// Bool overload is strict — only "true" / "false" accepted.
+static const ParseCase<bool> scBoolCases[] = {
+	{"LiteralTrue_Succeeds",      "true",    true,  true},
+	{"LiteralFalse_Succeeds",     "false",   true,  false},
+	{"NotABool_FailsStrict",      "garbage", false, false},
+	{"EmptyString_FailsStrict",   "",        false, false},
+	{"NumericOne_FailsStrict",    "1",       false, false},
+	{"MixedCaseTrue_FailsStrict", "True",    false, false},
+};
+
+// ---- TryParseOrDefault<T> ------------------------------------------------
+
+template <typename T>
+struct ParseOrDefaultCase {
+	const char* label;
+	const char* input;
+	T           defaultValue;
+	T           expectedFinal;
+};
+
+template <typename T>
+static bool RunParseOrDefaultCases(const char* inTypeLabel,
+                                   const ParseOrDefaultCase<T>* inCases,
+                                   size_t inCount) {
+	for(size_t i = 0; i < inCount; ++i) {
+		const ParseOrDefaultCase<T>& testCase = inCases[i];
+
+		// Arrange
+		T outValue = T();
+
+		// Act
+		TryParseOrDefault(string(testCase.input), outValue, testCase.defaultValue);
+
+		// Assert
+		if(outValue != testCase.expectedFinal) {
+			cout << "SafeParseTest [" << inTypeLabel << "::" << testCase.label
+			     << "]: outValue " << outValue
+			     << ", expected " << testCase.expectedFinal << endl;
+			return false;
+		}
+	}
+	return true;
+}
+
+static const ParseOrDefaultCase<int> scOrDefaultIntCases[] = {
+	{"ParseSucceeds_WritesParsedValue", "5",   99, 5},
+	{"ParseFails_WritesDefault",        "ABC", 99, 99},
+	{"EmptyString_WritesDefault",       "",    -1, -1},
+};
+
+// ---- wstring overload sanity --------------------------------------------
+
+static bool WStringOverload_ParsesValidInput() {
+	// Arrange / Act / Assert
+	int parsed = 0;
+	if(!TryParse(wstring(L"77"), parsed) || parsed != 77) {
+		cout << "SafeParseTest [WString::ParsesValidInput]: "
+		        "TryParse(L\"77\") yielded " << parsed << ", expected 77" << endl;
+		return false;
+	}
+	return true;
+}
+
+static bool WStringOverload_RejectsNonNumeric() {
+	// Arrange / Act / Assert
+	int outValue = 0;
+	if(TryParse(wstring(L"ABC"), outValue)) {
+		cout << "SafeParseTest [WString::RejectsNonNumeric]: "
+		        "TryParse(L\"ABC\") returned true, expected false" << endl;
+		return false;
+	}
+	return true;
+}
+
+#define COUNT_OF(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+int SafeParseTest(int argc, char* argv[]) {
+	(void) argc;
+	(void) argv;
+	if(!RunParseCases<int>   ("Int",    scIntCases,    COUNT_OF(scIntCases)))    return 1;
+	if(!RunParseCases<double>("Double", scDoubleCases, COUNT_OF(scDoubleCases))) return 1;
+	if(!RunParseCases<bool>  ("Bool",   scBoolCases,   COUNT_OF(scBoolCases)))   return 1;
+	if(!RunParseOrDefaultCases<int>("OrDefaultInt", scOrDefaultIntCases, COUNT_OF(scOrDefaultIntCases))) return 1;
+	if(!WStringOverload_ParsesValidInput())   return 1;
+	if(!WStringOverload_RejectsNonNumeric())  return 1;
+	return 0;
+}

--- a/PDFWriterTesting/Type1InputTest.cpp
+++ b/PDFWriterTesting/Type1InputTest.cpp
@@ -332,6 +332,46 @@ static bool RunBadNumericValueCases() {
 	return true;
 }
 
+// V-064 (boolean siblings): /isFixedPitch in FontInfo and /ForceBold /
+// /RndStemUp in Private dict went through PSBool's lenient ctor, which mapped
+// anything that wasn't literally "true" to false silently. The strict
+// SafeParse bool overload now rejects non-"true"/"false" tokens; the
+// migrated call sites surface that as eFailure.
+struct BadBooleanValueCase {
+	const char* label;
+	const char* ascii;
+	const char* dictKey;
+};
+
+static const BadBooleanValueCase scBadBooleanValueCases[] = {
+	{"FontInfoIsFixedPitch_Fails",       "12 dict begin\n/FontInfo 4 dict dup begin\n/isFixedPitch garbage\n", "/isFixedPitch"},
+	{"PrivateDictionaryForceBold_Fails", "/Private 5 dict dup begin\n/ForceBold maybe\n",                      "/ForceBold"},
+	{"PrivateDictionaryRndStemUp_Fails", "/Private 5 dict dup begin\n/RndStemUp truth\n",                      "/RndStemUp"},
+};
+
+static bool RunBadBooleanValueCases() {
+	const size_t count = sizeof(scBadBooleanValueCases) / sizeof(scBadBooleanValueCases[0]);
+	for(size_t i = 0; i < count; ++i) {
+		const BadBooleanValueCase& testCase = scBadBooleanValueCases[i];
+
+		// Arrange
+		string pfb = Type1SyntheticBuilder::RawPFBFromAsciiSegment(testCase.ascii);
+
+		// Act
+		Type1Input type1;
+		EStatusCode status = Type1SyntheticBuilder::ParseAsType1(pfb, type1);
+
+		// Assert
+		if(status == eSuccess) {
+			cout << "Type1InputTest [BadBooleanValue::" << testCase.label
+			     << "]: non-boolean " << testCase.dictKey
+			     << " value was silently accepted (V-064 regression)" << endl;
+			return false;
+		}
+	}
+	return true;
+}
+
 // P3: Reset() did not default Type1FontDictionary::PaintType / FontType /
 // FontBBox. A valid font that omits those keys left them indeterminate.
 // Reset() now seeds them (PaintType 0, FontType 1, FontBBox all 0); a parse
@@ -496,6 +536,7 @@ int Type1InputTest(int argc, char* argv[]) {
 	if(!RunAddDependentGlyphsCases()) return 1;
 	if(!RunMissingValueTokenCases()) return 1;
 	if(!RunBadNumericValueCases()) return 1;
+	if(!RunBadBooleanValueCases()) return 1;
 	if(!RunSegmentSplitCases()) return 1;
 	if(!GetNextToken_RegularTokenEndedByEndOfData_TokenReturned()) return 1;
 	if(!Reset_OmittedFontDictMetrics_DefaultsApplied()) return 1;

--- a/PDFWriterTesting/Type1InputTest.cpp
+++ b/PDFWriterTesting/Type1InputTest.cpp
@@ -292,6 +292,46 @@ static bool RunMissingValueTokenCases() {
 	return true;
 }
 
+// V-064: dictionary value tokens were converted with BoxingBase's string ctor,
+// which silently yielded 0 on a non-numeric token. A malformed font with a
+// value like /PaintType ABC was silently accepted with PaintType = 0. The
+// SafeParse::TryParse migration now reports eFailure when the value token
+// won't parse as a number.
+struct BadNumericValueCase {
+	const char* label;       // <Condition>_<Result>
+	const char* ascii;       // raw ASCII segment with a non-numeric value
+	const char* dictKey;     // for the failure message
+};
+
+static const BadNumericValueCase scBadNumericValueCases[] = {
+	{"FontDictionaryPaintType_Fails", "12 dict begin\n/PaintType ABC\n",        "/PaintType"},
+	{"FontDictionaryFontType_Fails",  "12 dict begin\n/FontType ABC\n",         "/FontType"},
+	{"PrivateDictionaryLenIV_Fails",  "/Private 5 dict dup begin\n/lenIV xyz\n", "/lenIV"},
+};
+
+static bool RunBadNumericValueCases() {
+	const size_t count = sizeof(scBadNumericValueCases) / sizeof(scBadNumericValueCases[0]);
+	for(size_t i = 0; i < count; ++i) {
+		const BadNumericValueCase& testCase = scBadNumericValueCases[i];
+
+		// Arrange
+		string pfb = Type1SyntheticBuilder::RawPFBFromAsciiSegment(testCase.ascii);
+
+		// Act
+		Type1Input type1;
+		EStatusCode status = Type1SyntheticBuilder::ParseAsType1(pfb, type1);
+
+		// Assert
+		if(status == eSuccess) {
+			cout << "Type1InputTest [BadNumericValue::" << testCase.label
+			     << "]: non-numeric " << testCase.dictKey
+			     << " value was silently accepted (V-064 regression)" << endl;
+			return false;
+		}
+	}
+	return true;
+}
+
 // P3: Reset() did not default Type1FontDictionary::PaintType / FontType /
 // FontBBox. A valid font that omits those keys left them indeterminate.
 // Reset() now seeds them (PaintType 0, FontType 1, FontBBox all 0); a parse
@@ -455,6 +495,7 @@ int Type1InputTest(int argc, char* argv[]) {
 	if(!ReadType1File_RealPFB_ParsesFontInfoStrings(argv)) return 1;
 	if(!RunAddDependentGlyphsCases()) return 1;
 	if(!RunMissingValueTokenCases()) return 1;
+	if(!RunBadNumericValueCases()) return 1;
 	if(!RunSegmentSplitCases()) return 1;
 	if(!GetNextToken_RegularTokenEndedByEndOfData_TokenReturned()) return 1;
 	if(!Reset_OmittedFontDictMetrics_DefaultsApplied()) return 1;


### PR DESCRIPTION
## Summary

`BoxingBase`'s string ctor cannot signal parse failure — on a failed stream extraction it leaves `boxedValue` uninit (pre-C++11) or set to `0` (C++11+), indistinguishable from a real parse of `0`. Every call site parsing attacker-controlled font / PDF input through `Int(s)` / `Double(s)` / `PSBool(s)` silently accepted malformed values.

- Introduces `PDFHummus::TryParse` / `TryParseOrDefault` in a new `SafeParse.h` — bool + out-param, untouched on failure; strict `"true"`/`"false"` overload for booleans; lenient on trailing input (`"12abc"` → `12`, callers' range / semantic checks still own wrong-number rejection).
- Migrates every reachable string-ctor parse site:
  - `Type1Input.cpp` — ~25 dict + array parsers + `TryParseBoundedLong`
  - `PDFDate.cpp` — 7 sentinel-on-failure sites via `TryParseOrDefault(..., -1)`
  - `PDFParser.cpp` — `%PDF` header version + xref entry offset/revision
  - `PDFObjectParser::ParseNumber` — real-number branch now matches the existing `strtoll`/`ERANGE` failure path (returns `NULL` with `TRACE_LOG`)
- Deprecation comment on `BoxingBaseWithRW(const std::string&)` / `(const std::wstring&)` pointing future callers at `SafeParse.h`.
- **V-063 reclassified:** `BoxingBase`'s empty default ctor mirrors primitive `T`'s uninit-by-default semantics — design-by-intent, not a bug. No production call site reads a default-constructed `BoxingBase` without assignment. The reachable failure mode was the string ctor, closed by this migration.

## Test plan

- [x] `cmake --build . --config Release` clean
- [x] `ctest -C Release` — 100/100 pass
- [x] New `SafeParseTest.cpp` — per-type tables + template runners cover: int parse success / failure / empty / trailing-garbage-lenient; double instantiation sanity (3.14 parses as real); strict bool — `"true"`/`"false"` succeed, `"True"`/`"1"`/`"garbage"`/`""` reject; `TryParseOrDefault` writes parsed on success, default on failure; wstring overload parses and rejects.
- [x] `Type1InputTest::RunBadNumericValueCases` — `/PaintType ABC`, `/FontType ABC`, `/lenIV xyz` now return `eFailure` instead of silently substituting `0` (V-064 regression).
- [x] No behavior change on the happy-path real PFB (`Type1InputTest::ReadType1File_RealPFB_ParsesFontInfoStrings` still green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)