### PR TITLE
fix: clear SOFMarkerNotFound only after successful read (V-099)

### DIFF
--- a/PDFWriter/JPEGImageParser.cpp
+++ b/PDFWriter/JPEGImageParser.cpp
@@ -425,6 +425,7 @@ EStatusCode JPEGImageParser::ReadExifData(JPEGImageInformation& outImageInformat
 			(memcmp(mReadBuffer, scAPP1ID_1, 6) != 0 && memcmp(mReadBuffer, scAPP1ID_2, 6) != 0))
 		{
 			// might be wrong ID (XMP / unsupported)
+			TRACE_LOG("JPEGImageParser::ReadExifData, APP1 identifier did not match \"Exif\\0\\0\" or \"Exif\\0\\xff\"");
 			status = PDFHummus::eFailure;
 			break;
 		}
@@ -442,6 +443,7 @@ EStatusCode JPEGImageParser::ReadExifData(JPEGImageInformation& outImageInformat
 			isBigEndian = false;
 		else
 		{
+			TRACE_LOG1("JPEGImageParser::ReadExifData, TIFF endianness marker 0x%04x is neither MM nor II", encodingType);
 			status = PDFHummus::eFailure;
 			break;
 		}

--- a/PDFWriter/JPEGImageParser.cpp
+++ b/PDFWriter/JPEGImageParser.cpp
@@ -21,6 +21,7 @@
 #include "JPEGImageParser.h"
 #include "JPEGImageInformation.h"
 #include "IByteReaderWithPosition.h"
+#include "Trace.h"
 
 #include <memory.h>
 
@@ -192,17 +193,22 @@ EStatusCode JPEGImageParser::ReadJpegTag(unsigned int& outTagID)
 
 EStatusCode JPEGImageParser::ReadSOF0Data(JPEGImageInformation& outImageInformation)
 {
-	unsigned int toSkip;
+	unsigned int markerLen;
 	EStatusCode status;
 
 	status = ReadStreamToBuffer(8);
 	if(PDFHummus::eSuccess == status)
 	{
-		toSkip = GetIntValue(mReadBuffer) - 8;
+		markerLen = GetIntValue(mReadBuffer);
+		if (markerLen < 8)
+		{
+			TRACE_LOG1("JPEGImageParser::ReadSOF0Data, SOF marker length %u below the 8-byte fixed header", markerLen);
+			return PDFHummus::eFailure;
+		}
 		outImageInformation.SamplesHeight = GetIntValue(mReadBuffer + 3);
 		outImageInformation.SamplesWidth = GetIntValue(mReadBuffer + 5);
 		outImageInformation.ColorComponentsCount = (unsigned int)mReadBuffer[7];
-		SkipStream(toSkip);
+		SkipStream(markerLen - 8);
 	}
 	return status;
 }
@@ -235,18 +241,23 @@ void JPEGImageParser::SkipStream(unsigned long inSkip)
 
 EStatusCode JPEGImageParser::ReadJFIFData(JPEGImageInformation& outImageInformation)
 {
-	unsigned int toSkip;
+	unsigned int markerLen;
 	EStatusCode status;
 
 	status = ReadStreamToBuffer(14);
 	if(PDFHummus::eSuccess == status)
 	{
+		markerLen = GetIntValue(mReadBuffer);
+		if (markerLen < 14)
+		{
+			TRACE_LOG1("JPEGImageParser::ReadJFIFData, JFIF marker length %u below the 14-byte fixed header", markerLen);
+			return PDFHummus::eFailure;
+		}
 		outImageInformation.JFIFInformationExists = true;
-		toSkip = GetIntValue(mReadBuffer) - 14;
 		outImageInformation.JFIFUnit = (unsigned int)mReadBuffer[9];
 		outImageInformation.JFIFXDensity = GetIntValue(mReadBuffer + 10);
 		outImageInformation.JFIFYDensity = GetIntValue(mReadBuffer + 12);
-		SkipStream(toSkip);
+		SkipStream(markerLen - 14);
 	}
 	return status;
 }
@@ -271,6 +282,20 @@ TwoLevelStatus JPEGImageParser::ReadLongValue(
 	EStatusCode status = ReadLongValue(outLongValue, inUseLittleEndian);
 	if (status == PDFHummus::eSuccess)
 		refReadLimit -= 4;
+	return TwoLevelStatus(status, PDFHummus::eSuccess);
+}
+
+TwoLevelStatus JPEGImageParser::ReadIntValue(
+	unsigned long& refReadLimit,
+	unsigned int& outIntValue,
+	bool inUseLittleEndian)
+{
+	if (refReadLimit < 2)
+		return TwoLevelStatus(PDFHummus::eSuccess, PDFHummus::eFailure);
+
+	EStatusCode status = ReadIntValue(outIntValue, inUseLittleEndian);
+	if (status == PDFHummus::eSuccess)
+		refReadLimit -= 2;
 	return TwoLevelStatus(status, PDFHummus::eSuccess);
 }
 
@@ -301,6 +326,12 @@ EStatusCode JPEGImageParser::ReadPhotoshopData(JPEGImageInformation& outImageInf
 		twoLevelStatus.primary = ReadIntValue(intSkip);
 		if (twoLevelStatus.primary != PDFHummus::eSuccess)
 			break;
+		if (intSkip < 2)
+		{
+			TRACE_LOG1("JPEGImageParser::ReadPhotoshopData, Photoshop marker length %u below the 2-byte length field", intSkip);
+			twoLevelStatus.primary = PDFHummus::eFailure;
+			break;
+		}
 		toSkip = intSkip - 2;
 		twoLevelStatus.primary = SkipTillChar(scEOS, toSkip);
 		if (twoLevelStatus.primary != PDFHummus::eSuccess)
@@ -356,132 +387,206 @@ EStatusCode JPEGImageParser::ReadPhotoshopData(JPEGImageInformation& outImageInf
 
 EStatusCode JPEGImageParser::ReadExifData(JPEGImageInformation& outImageInformation)
 {
-	EStatusCode status;
-	unsigned long ifdOffset;
-	unsigned int ifdDirectorySize, tagID, toSkip;
-	bool isBigEndian;
+	EStatusCode status = PDFHummus::eSuccess;
+	TwoLevelStatus tls(PDFHummus::eSuccess, PDFHummus::eSuccess);
+	unsigned long toSkip = 0;
+	unsigned int markerLen;
+	unsigned long ifdOffset = 0;
+	unsigned int ifdDirectorySize;
+	unsigned int tagID;
+	unsigned int encodingType;
+	bool isBigEndian = false;
 	unsigned long xResolutionOffset = 0;
 	unsigned long yResolutionOffset = 0;
-	unsigned int resolutionUnitValue = 0; 
+	unsigned int resolutionUnitValue = 0;
 
-	do 
+	do
 	{
-		//read Exif Tag size
-		status = ReadIntValue(toSkip);
+		// read Exif Tag size
+		status = ReadIntValue(markerLen);
 		if (status != PDFHummus::eSuccess)
 			break;
-		
-		toSkip -= 2;
+		if (markerLen < 2)
+		{
+			TRACE_LOG1("JPEGImageParser::ReadExifData, APP1 marker length %u below the 2-byte length field", markerLen);
+			status = PDFHummus::eFailure;
+			break;
+		}
+		toSkip = (unsigned long)(markerLen - 2);
 
-		//read Exif ID
-		status = ReadExifID();
-		toSkip -= 6;
-		if (status != PDFHummus::eSuccess)
-        {
-            // might be wrong ID
-            SkipStream(toSkip);
+		// read Exif ID (6 bytes "Exif\0\0" or "Exif\0\xff")
+		tls = ReadStreamToBuffer(6, toSkip);
+		if (tls.primary != PDFHummus::eSuccess)
+		{
+			status = tls.primary;
+			break;
+		}
+		if (tls.secondary != PDFHummus::eSuccess ||
+			(memcmp(mReadBuffer, scAPP1ID_1, 6) != 0 && memcmp(mReadBuffer, scAPP1ID_2, 6) != 0))
+		{
+			// might be wrong ID (XMP / unsupported)
+			status = PDFHummus::eFailure;
 			break;
 		}
 
-		//read encoding
-		status = IsBigEndianExif(isBigEndian);
+		// read encoding (2 bytes)
+		tls = ReadIntValue(toSkip, encodingType);
+		if (tls.eitherBad())
+		{
+			status = PDFHummus::eFailure;
+			break;
+		}
+		if (encodingType == scAPP1BigEndian)
+			isBigEndian = true;
+		else if (encodingType == scAPP1LittleEndian)
+			isBigEndian = false;
+		else
+		{
+			status = PDFHummus::eFailure;
+			break;
+		}
+
+		// skip 0x002a magic
+		status = SkipStream(2, toSkip);
 		if (status != PDFHummus::eSuccess)
 			break;
 
-		toSkip -= 2;
+		// read IFD0 offset
+		tls = ReadLongValue(toSkip, ifdOffset, !isBigEndian);
+		if (tls.eitherBad())
+		{
+			status = PDFHummus::eFailure;
+			break;
+		}
 
-		//skip 0x002a
-		SkipStream(2);		
-		toSkip -= 2;
+		// IFD0 offset is relative to the TIFF header start; TIFF header is 8 bytes, so any
+		// in-spec offset is >= 8.
+		if (ifdOffset < 8)
+		{
+			TRACE_LOG1("JPEGImageParser::ReadExifData, IFD0 offset %lu below the 8-byte TIFF header minimum", ifdOffset);
+			status = PDFHummus::eFailure;
+			break;
+		}
 
-		//read IFD0 offset
-		status = ReadLongValue(ifdOffset, !isBigEndian);	
+		// skip to the IFD beginning
+		status = SkipStream(ifdOffset - 8, toSkip);
 		if (status != PDFHummus::eSuccess)
 			break;
 
-		toSkip -= 4;
-
-		//skip to the IFD beginning
-		SkipStream(ifdOffset - 8);
-		toSkip -= (ifdOffset - 8);
-
-		//read IFD size
-		status = ReadIntValue(ifdDirectorySize, !isBigEndian);
-		if (status != PDFHummus::eSuccess)
+		// read IFD size
+		tls = ReadIntValue(toSkip, ifdDirectorySize, !isBigEndian);
+		if (tls.eitherBad())
+		{
+			status = PDFHummus::eFailure;
 			break;
-
-		toSkip -= 2;
+		}
 
 		for (unsigned int i = 0; i < ifdDirectorySize; i++)
-		{			
+		{
 			if (0 != xResolutionOffset && 0 != yResolutionOffset && 0 != resolutionUnitValue)
 			{
-				SkipStream(12 * (ifdDirectorySize - i));
-				toSkip -= (12 * (ifdDirectorySize - i));
+				status = SkipStream(12UL * (ifdDirectorySize - i), toSkip);
 				break;
 			}
 
-			status = ReadIntValue(tagID, !isBigEndian);
-			if (status != PDFHummus::eSuccess)
+			tls = ReadIntValue(toSkip, tagID, !isBigEndian);
+			if (tls.eitherBad())
+			{
+				status = PDFHummus::eFailure;
 				break;
-
-			toSkip -= 2;
+			}
 
 			switch (tagID)
 			{
 				case scAPP1xResolutionTagID:
-					SkipStream(6);					
-					status = ReadLongValue(xResolutionOffset, !isBigEndian);
+					status = SkipStream(6, toSkip);
+					if (status != PDFHummus::eSuccess) break;
+					tls = ReadLongValue(toSkip, xResolutionOffset, !isBigEndian);
+					if (tls.eitherBad()) status = PDFHummus::eFailure;
 					break;
 				case scAPP1yResolutionTagID:
-					SkipStream(6);		
-					status = ReadLongValue(yResolutionOffset, !isBigEndian);
+					status = SkipStream(6, toSkip);
+					if (status != PDFHummus::eSuccess) break;
+					tls = ReadLongValue(toSkip, yResolutionOffset, !isBigEndian);
+					if (tls.eitherBad()) status = PDFHummus::eFailure;
 					break;
 				case scAPP1ResolutionUnitTagID:
-					SkipStream(6);		
-					status = ReadIntValue(resolutionUnitValue, !isBigEndian);
-					SkipStream(2);
+					status = SkipStream(6, toSkip);
+					if (status != PDFHummus::eSuccess) break;
+					tls = ReadIntValue(toSkip, resolutionUnitValue, !isBigEndian);
+					if (tls.eitherBad()) { status = PDFHummus::eFailure; break; }
+					status = SkipStream(2, toSkip);
 					break;
 				default:
-					SkipStream(10);
+					status = SkipStream(10, toSkip);
 					break;
 			}
 
-			toSkip -= 10;
 			if (status != PDFHummus::eSuccess)
 				break;
 		}
-		
-		outImageInformation.ExifInformationExists = true;
-		if (resolutionUnitValue != 0) 
-			outImageInformation.ExifUnit = resolutionUnitValue;		
-		else
-			outImageInformation.ExifUnit = 2;
-
-
-		unsigned long currentOffset = 0;																					
-		if(ifdOffset > 8) 																							
-		{																													
-			// that would be the case where the IFD data appears before thee ifd header. avoid issues with negative skip values by placing
-			// the position before the table
-			mImageStream->SetPosition(mImageStream->GetCurrentPosition() - (ifdOffset + ifdDirectorySize * 12 + 2));		
-			toSkip+=(ifdOffset + ifdDirectorySize * 12 + 2);																
-		}																													
-		else																												
-		{																													
-			currentOffset = ifdOffset + ifdDirectorySize * 12 + 2;
-		}																													
-		unsigned long tempOffset = currentOffset;
-		status = GetResolutionFromExif(outImageInformation, xResolutionOffset, yResolutionOffset, tempOffset, !isBigEndian);
 		if (status != PDFHummus::eSuccess)
 			break;
 
-		toSkip -= (tempOffset - currentOffset);
+		outImageInformation.ExifInformationExists = true;
+		if (resolutionUnitValue != 0)
+			outImageInformation.ExifUnit = resolutionUnitValue;
+		else
+			outImageInformation.ExifUnit = 2;
 
-		if (PDFHummus::eSuccess == status)
-			SkipStream(toSkip);
+		unsigned long currentOffset = 0;
+		unsigned long rewindAmount = ifdOffset + (unsigned long)ifdDirectorySize * 12 + 2;
+		if (ifdOffset > 8)
+		{
+			// the IFD data may appear before the IFD header; rewind to the TIFF header start so
+			// in-Exif offsets can be reached by forward seek
+			LongFilePositionType currentPos = mImageStream->GetCurrentPosition();
+			if (currentPos < 0 || (unsigned long long)currentPos < (unsigned long long)rewindAmount)
+			{
+				TRACE_LOG2("JPEGImageParser::ReadExifData, TIFF-header rewind %lu exceeds current stream position %lld", rewindAmount, (long long)currentPos);
+				status = PDFHummus::eFailure;
+				break;
+			}
+			mImageStream->SetPosition(currentPos - (LongFilePositionType)rewindAmount);
+			toSkip += rewindAmount;
+		}
+		else
+		{
+			currentOffset = rewindAmount;
+		}
+		unsigned long tempOffset = currentOffset;
+		// Measure actual stream consumption rather than relying on
+		// tempOffset: GetResolutionFromExif's inoutOffset only advances on
+		// success, so a partial read leaves it stale.
+		LongFilePositionType posBefore = mImageStream->GetCurrentPosition();
+		EStatusCode getResStatus = GetResolutionFromExif(outImageInformation, xResolutionOffset, yResolutionOffset, tempOffset, !isBigEndian);
+		LongFilePositionType posAfter = mImageStream->GetCurrentPosition();
+		unsigned long consumed = (posAfter > posBefore) ? (unsigned long)(posAfter - posBefore) : 0;
+		if (consumed > toSkip)
+		{
+			TRACE_LOG2("JPEGImageParser::ReadExifData, resolution read consumed %lu bytes, exceeds remaining marker budget %lu", consumed, toSkip);
+			status = PDFHummus::eFailure;
+			toSkip = 0;
+			break;
+		}
+		toSkip -= consumed;
+		if (getResStatus != PDFHummus::eSuccess)
+		{
+			status = getResStatus;
+			break;
+		}
+
+		SkipStream(toSkip);
+		toSkip = 0;
 	}
-	while(false);	
+	while(false);
+
+	// Drain any remaining marker bytes so Parse can locate the next marker
+	// after a partial Exif rejection. Parse treats Exif failure as "not Exif,
+	// try the next APP1" and re-enters the loop.
+	if (toSkip > 0)
+		SkipStream(toSkip);
+
 	return status;
 }
 
@@ -520,11 +625,17 @@ EStatusCode JPEGImageParser::GetResolutionFromExif(
 		if (0 == firstOffset)
 			break;
 
+		if (firstOffset < inoutOffset)
+		{
+			TRACE_LOG2("JPEGImageParser::GetResolutionFromExif, first resolution offset %lu precedes parser position %lu", firstOffset, inoutOffset);
+			status = PDFHummus::eFailure;
+			break;
+		}
 		SkipStream(firstOffset - inoutOffset);
-		inoutOffset += (firstOffset - inoutOffset);
+		inoutOffset = firstOffset;
 
 		status = ReadRationalValue(
-			xResolutionIsFirst? outImageInformation.ExifXDensity : outImageInformation.ExifYDensity, 
+			xResolutionIsFirst? outImageInformation.ExifXDensity : outImageInformation.ExifYDensity,
 			inUseLittleEndian);
 
 		if (status != PDFHummus::eSuccess)
@@ -535,11 +646,17 @@ EStatusCode JPEGImageParser::GetResolutionFromExif(
 		if (0 == secondOffset)
 			break;
 
-		SkipStream(secondOffset - firstOffset - 8);
-		inoutOffset += (secondOffset - firstOffset - 8);
+		if (secondOffset < inoutOffset)
+		{
+			TRACE_LOG2("JPEGImageParser::GetResolutionFromExif, second resolution offset %lu precedes parser position %lu", secondOffset, inoutOffset);
+			status = PDFHummus::eFailure;
+			break;
+		}
+		SkipStream(secondOffset - inoutOffset);
+		inoutOffset = secondOffset;
 
 		status = ReadRationalValue(
-			xResolutionIsFirst? outImageInformation.ExifYDensity : outImageInformation.ExifXDensity, 
+			xResolutionIsFirst? outImageInformation.ExifYDensity : outImageInformation.ExifXDensity,
 			inUseLittleEndian);
 		if (status != PDFHummus::eSuccess)
 			break;
@@ -564,38 +681,14 @@ EStatusCode JPEGImageParser::ReadRationalValue(
 	if (status != PDFHummus::eSuccess)
 		return status;
 
-	outDoubleValue = ((double) numerator) / ((double) denominator); 
+	if (denominator == 0)
+	{
+		TRACE_LOG("JPEGImageParser::ReadRationalValue, rational denominator is zero");
+		return PDFHummus::eFailure;
+	}
+
+	outDoubleValue = ((double) numerator) / ((double) denominator);
 	return status;
-}
-
-EStatusCode JPEGImageParser::ReadExifID()
-{
-	EStatusCode status = ReadStreamToBuffer(6);
-	if (status != PDFHummus::eSuccess)
-		return status;
-
-	if (memcmp(mReadBuffer, scAPP1ID_1, 6) != 0 && memcmp(mReadBuffer, scAPP1ID_2,6) != 0)
-		return PDFHummus::eFailure;
-
-	return PDFHummus::eSuccess;
-}
-
-EStatusCode JPEGImageParser::IsBigEndianExif(bool& outIsBigEndian)
-{	
-	unsigned int encodingType;
-	EStatusCode status = ReadIntValue(encodingType);
-		
-	if (status != PDFHummus::eSuccess)
-		return status;
-	
-	if (encodingType == scAPP1BigEndian)
-		outIsBigEndian = true;
-	else if (encodingType == scAPP1LittleEndian)
-		outIsBigEndian = false;
-	else
-		return PDFHummus::eFailure;
-
-	return PDFHummus::eSuccess;
 }
 
 EStatusCode JPEGImageParser::ReadIntValue(
@@ -678,6 +771,13 @@ EStatusCode JPEGImageParser::SkipTag()
 	status = ReadIntValue(toSkip);
 	// skipping -2 because int was already read
 	if(PDFHummus::eSuccess == status)
+	{
+		if (toSkip < 2)
+		{
+			TRACE_LOG1("JPEGImageParser::SkipTag, marker length %u below the 2-byte length field", toSkip);
+			return PDFHummus::eFailure;
+		}
 		SkipStream(toSkip-2);
+	}
 	return status;
 }

--- a/PDFWriter/JPEGImageParser.cpp
+++ b/PDFWriter/JPEGImageParser.cpp
@@ -96,8 +96,9 @@ EStatusCode JPEGImageParser::Parse(IByteReaderWithPosition* inImageStream,JPEGIm
 				case scSOF7TagID : case scSOF9TagID : case scSOF10TagID:
 				case scSOF11TagID : case scSOF13TagID : case scSOF14TagID:
 				case scSOF15TagID :
-					SOFMarkerNotFound = false;
 					status = ReadSOF0Data(outImageInformation);
+					if (status == PDFHummus::eSuccess)
+						SOFMarkerNotFound = false;
 					break;
 				case scAPP0TagID:
 					if(JFIFMarkerNotFound)

--- a/PDFWriter/JPEGImageParser.h
+++ b/PDFWriter/JPEGImageParser.h
@@ -77,10 +77,12 @@ private:
 									   bool inUseLittleEndian);
 	PDFHummus::EStatusCode ReadRationalValue(double& outDoubleValue,
 								  bool inUseLittleEndian);
-	PDFHummus::EStatusCode ReadExifID();
-	PDFHummus::EStatusCode IsBigEndianExif(bool& outIsBigEndian);
 	PDFHummus::EStatusCode ReadIntValue(	unsigned int& outIntValue,
 								bool inUseLittleEndian = false);
+	TwoLevelStatus ReadIntValue(
+		unsigned long& refReadLimit,
+		unsigned int& outIntValue,
+		bool inUseLittleEndian = false);
 	PDFHummus::EStatusCode SkipTillChar(IOBasicTypes::Byte inSkipUntilValue,unsigned long& refSkipLimit);
 	PDFHummus::EStatusCode ReadLongValue(unsigned long& outLongValue,
 		bool inUseLittleEndian);

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -43,6 +43,7 @@ create_test_sourcelist (Tests
   InputFlateDecodeTester.cpp
   InputImagesAsStreamsTest.cpp
   InputPFBDecodeStreamTest.cpp
+  JPEGImageParserTest.cpp
   JpegLibTest.cpp
   JPGImageTest.cpp
   LinksTest.cpp

--- a/PDFWriterTesting/JPEGImageParserTest.cpp
+++ b/PDFWriterTesting/JPEGImageParserTest.cpp
@@ -1,0 +1,518 @@
+/*
+   Source File : JPEGImageParserTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+*/
+#include "JPEGImageParser.h"
+#include "JPEGImageInformation.h"
+#include "InputByteArrayStream.h"
+#include "EStatusCode.h"
+#include "IOBasicTypes.h"
+
+#include <iostream>
+#include <vector>
+
+using namespace std;
+using namespace PDFHummus;
+using IOBasicTypes::Byte;
+
+// ---- byte emitters ------------------------------------------------------
+
+static void EmitU8(vector<Byte>& out, unsigned int v)
+{
+	out.push_back((Byte)(v & 0xff));
+}
+static void EmitU16BE(vector<Byte>& out, unsigned int v)
+{
+	EmitU8(out, (v >> 8) & 0xff);
+	EmitU8(out, v & 0xff);
+}
+static void EmitU32BE(vector<Byte>& out, unsigned long v)
+{
+	EmitU16BE(out, (unsigned int)((v >> 16) & 0xffffUL));
+	EmitU16BE(out, (unsigned int)(v & 0xffffUL));
+}
+static void EmitU16LE(vector<Byte>& out, unsigned int v)
+{
+	EmitU8(out, v & 0xff);
+	EmitU8(out, (v >> 8) & 0xff);
+}
+static void EmitU32LE(vector<Byte>& out, unsigned long v)
+{
+	EmitU16LE(out, (unsigned int)(v & 0xffffUL));
+	EmitU16LE(out, (unsigned int)((v >> 16) & 0xffffUL));
+}
+
+// SOI marker
+static void EmitSOI(vector<Byte>& out)
+{
+	EmitU8(out, 0xff);
+	EmitU8(out, 0xd8);
+}
+
+// Minimal SOF0: declared marker length, then height/width/components.
+// markerLen counts the length field (2 bytes) plus payload. Real SOF0 needs
+// >= 11 bytes (precision + h + w + nf + per-component triples); tests can pass
+// shorter values to exercise the length-underflow guard.
+static void EmitSOF0(vector<Byte>& out,
+                     unsigned int markerLen,
+                     unsigned int height,
+                     unsigned int width,
+                     unsigned int components)
+{
+	EmitU8(out, 0xff);
+	EmitU8(out, 0xc0);
+	EmitU16BE(out, markerLen);
+	EmitU8(out, 8);              // precision
+	EmitU16BE(out, height);
+	EmitU16BE(out, width);
+	EmitU8(out, components);
+	// per-component triples (3 bytes each) so a real markerLen >= 11 is consistent
+	for(unsigned int i = 0; i < components; ++i) {
+		EmitU8(out, (unsigned int)(i + 1));
+		EmitU8(out, 0x11);
+		EmitU8(out, 0);
+	}
+}
+
+// APP0 (JFIF) marker. Real markerLen is >= 16 in practice (incl 5-byte "JFIF\0"
+// identifier and version), but the parser only requires >= 14 because it reads
+// exactly 14 bytes of header. Tests may pass shorter values to exercise the
+// guard.
+static void EmitJFIF(vector<Byte>& out,
+                     unsigned int markerLen,
+                     unsigned int xDensity,
+                     unsigned int yDensity)
+{
+	EmitU8(out, 0xff);
+	EmitU8(out, 0xe0);
+	EmitU16BE(out, markerLen);
+	// "JFIF\0" identifier
+	EmitU8(out, 'J'); EmitU8(out, 'F'); EmitU8(out, 'I'); EmitU8(out, 'F'); EmitU8(out, 0);
+	EmitU8(out, 1);              // version major
+	EmitU8(out, 2);              // version minor
+	EmitU8(out, 1);              // units (1 = dots-per-inch)
+	EmitU16BE(out, xDensity);
+	EmitU16BE(out, yDensity);
+	// thumbnail width/height (assumed 0)
+	if(markerLen >= 16) {
+		EmitU8(out, 0);
+		EmitU8(out, 0);
+	}
+	// extra padding to reach markerLen
+	unsigned int written = 14;
+	if(markerLen >= 16) written = 16;
+	while(written < markerLen) {
+		EmitU8(out, 0);
+		++written;
+	}
+}
+
+// Single-byte APP14 (unknown to the parser) used to exercise SkipTag's
+// length-underflow guard. markerLen of 1 is below the 2-byte length field
+// itself; with the guard in place SkipTag must reject it.
+static void EmitUnknownApp(vector<Byte>& out, unsigned int markerLen)
+{
+	EmitU8(out, 0xff);
+	EmitU8(out, 0xee);           // APP14
+	EmitU16BE(out, markerLen);
+	// no payload — short-length is the whole point
+}
+
+// APP13 (Photoshop) with a declared marker length. Bytes after the length
+// field aren't validated when markerLen < 2 because the guard fires before any
+// payload read.
+static void EmitPhotoshopShort(vector<Byte>& out, unsigned int markerLen)
+{
+	EmitU8(out, 0xff);
+	EmitU8(out, 0xed);
+	EmitU16BE(out, markerLen);
+}
+
+// ---- Exif builders ------------------------------------------------------
+
+// Builds an APP1/Exif segment containing a 3-entry IFD: xResolution,
+// yResolution, ResolutionUnit. The rational values for x/y resolution are
+// placed immediately after the IFD entries. inXResOffset / inYResOffset
+// override the offset value written into the IFD entry without changing the
+// position of the actual rational data (used to provoke offset-arithmetic
+// faults).
+//
+// inIfdOffset is the value written for the IFD0 offset; in well-formed input
+// it equals 8 (IFD immediately follows the 8-byte TIFF header). Smaller
+// values exercise the IFD-offset bound check.
+//
+// inRationalDenominator is the denominator written into each rational; 0
+// exercises the divide-by-zero guard.
+static void EmitExifSegment(vector<Byte>& out,
+                            unsigned long inIfdOffset,
+                            unsigned long inXResOffset,
+                            unsigned long inYResOffset,
+                            unsigned int  inResolutionUnit,
+                            unsigned long inRationalNumerator,
+                            unsigned long inRationalDenominator)
+{
+	// Big-endian Exif.
+	const unsigned int xResTag        = 0x011a;
+	const unsigned int yResTag        = 0x011b;
+	const unsigned int resUnitTag     = 0x0128;
+	const unsigned int tiffType_RATIONAL = 5;
+	const unsigned int tiffType_SHORT    = 3;
+
+	// Compute marker payload separately so we can write the size up front.
+	vector<Byte> payload;
+
+	// "Exif\0\0"
+	EmitU8(payload, 'E'); EmitU8(payload, 'x'); EmitU8(payload, 'i'); EmitU8(payload, 'f');
+	EmitU8(payload, 0);   EmitU8(payload, 0);
+
+	// TIFF header — big endian.
+	EmitU8(payload, 'M'); EmitU8(payload, 'M');
+	EmitU16BE(payload, 0x002a);
+	EmitU32BE(payload, inIfdOffset);
+
+	// If the declared IFD offset > 8, pad the gap so the IFD lands where we
+	// claimed.
+	unsigned long padTo = inIfdOffset;
+	if(padTo < 8) padTo = 8;            // bound-check tests still need a sane layout
+	for(unsigned long i = 8; i < padTo; ++i) EmitU8(payload, 0);
+
+	// IFD0: 3 entries.
+	EmitU16BE(payload, 3);
+
+	// Each entry: tag(2) type(2) count(4) value-or-offset(4) = 12 bytes.
+	EmitU16BE(payload, xResTag);
+	EmitU16BE(payload, tiffType_RATIONAL);
+	EmitU32BE(payload, 1);
+	EmitU32BE(payload, inXResOffset);
+
+	EmitU16BE(payload, yResTag);
+	EmitU16BE(payload, tiffType_RATIONAL);
+	EmitU32BE(payload, 1);
+	EmitU32BE(payload, inYResOffset);
+
+	EmitU16BE(payload, resUnitTag);
+	EmitU16BE(payload, tiffType_SHORT);
+	EmitU32BE(payload, 1);
+	// SHORT value packed into the high half of the 4-byte field for big endian.
+	EmitU16BE(payload, inResolutionUnit);
+	EmitU16BE(payload, 0);
+
+	// Two rationals placed sequentially. Their absolute offsets from the TIFF
+	// header start are (padTo + 2 + 3*12) and (padTo + 2 + 3*12 + 8).
+	EmitU32BE(payload, inRationalNumerator);
+	EmitU32BE(payload, inRationalDenominator);
+	EmitU32BE(payload, inRationalNumerator);
+	EmitU32BE(payload, inRationalDenominator);
+
+	// Length field counts itself (2 bytes) + payload.
+	unsigned int markerLen = (unsigned int)(2 + payload.size());
+
+	EmitU8(out, 0xff);
+	EmitU8(out, 0xe1);
+	EmitU16BE(out, markerLen);
+	out.insert(out.end(), payload.begin(), payload.end());
+}
+
+// ---- test runner --------------------------------------------------------
+
+static EStatusCode RunParse(const vector<Byte>& inBytes, JPEGImageInformation& outInfo)
+{
+	// Arrange
+	InputByteArrayStream stream((Byte*)&inBytes[0], (long long)inBytes.size());
+
+	// Act
+	JPEGImageParser parser;
+	return parser.Parse(&stream, outInfo);
+}
+
+// ---- happy-path baseline ------------------------------------------------
+
+static bool Parse_MinimalSOF0_Succeeds()
+{
+	// Arrange
+	vector<Byte> bytes;
+	EmitSOI(bytes);
+	EmitSOF0(bytes, 11, 100, 200, 1);
+
+	// Act
+	JPEGImageInformation info;
+	EStatusCode status = RunParse(bytes, info);
+
+	// Assert
+	if(status != eSuccess) {
+		cout << "JPEGImageParserTest [Parse_MinimalSOF0_Succeeds]: status " << status
+		     << ", expected " << eSuccess << endl;
+		return false;
+	}
+	if(info.SamplesHeight != 100 || info.SamplesWidth != 200) {
+		cout << "JPEGImageParserTest [Parse_MinimalSOF0_Succeeds]: dims "
+		     << info.SamplesWidth << "x" << info.SamplesHeight
+		     << ", expected 200x100" << endl;
+		return false;
+	}
+	if(info.ColorComponentsCount != 1) {
+		cout << "JPEGImageParserTest [Parse_MinimalSOF0_Succeeds]: components "
+		     << info.ColorComponentsCount << ", expected 1" << endl;
+		return false;
+	}
+	return true;
+}
+
+static bool Parse_JfifThenSOF0_RecordsDensity()
+{
+	// Arrange
+	vector<Byte> bytes;
+	EmitSOI(bytes);
+	EmitJFIF(bytes, 16, 72, 96);
+	EmitSOF0(bytes, 11, 50, 80, 3);
+
+	// Act
+	JPEGImageInformation info;
+	EStatusCode status = RunParse(bytes, info);
+
+	// Assert
+	if(status != eSuccess) {
+		cout << "JPEGImageParserTest [Parse_JfifThenSOF0_RecordsDensity]: status " << status << endl;
+		return false;
+	}
+	if(!info.JFIFInformationExists) {
+		cout << "JPEGImageParserTest [Parse_JfifThenSOF0_RecordsDensity]: "
+		        "JFIFInformationExists not set" << endl;
+		return false;
+	}
+	if(info.JFIFXDensity != 72 || info.JFIFYDensity != 96) {
+		cout << "JPEGImageParserTest [Parse_JfifThenSOF0_RecordsDensity]: density "
+		     << info.JFIFXDensity << "x" << info.JFIFYDensity
+		     << ", expected 72x96" << endl;
+		return false;
+	}
+	return true;
+}
+
+// ---- length-underflow cluster ------------------------------------------
+
+// Each short-marker case declares a marker length below the parser's
+// fixed-size header read. Pre-fix code would write attacker-controlled values
+// into JPEGImageInformation BEFORE noticing the length was wrong (the
+// underflow then drove a wild SkipStream call). With the guards in place
+// each per-marker reader rejects the short read before any output field is
+// written, so the discriminating assertion is "the info struct is at its
+// default-constructed state".
+//
+// Parse's outer status is not a discriminator here: the per-marker case-arm
+// flips its "marker not found" flag BEFORE calling the per-marker reader, so
+// Parse may still report success after a per-marker failure.
+
+static bool IsJpegInfoAtDefaults(const JPEGImageInformation& info)
+{
+	return info.SamplesWidth == 0
+	    && info.SamplesHeight == 0
+	    && info.ColorComponentsCount == 0
+	    && !info.JFIFInformationExists
+	    && info.JFIFXDensity == 0 && info.JFIFYDensity == 0
+	    && !info.ExifInformationExists
+	    && info.ExifXDensity == 0 && info.ExifYDensity == 0
+	    && !info.PhotoshopInformationExists
+	    && info.PhotoshopXDensity == 0 && info.PhotoshopYDensity == 0;
+}
+
+struct ShortMarkerCase {
+	const char* label;
+	void (*buildAfterSOI)(vector<Byte>&);
+};
+
+// SOF0 with declared length 7 — below the 8-byte fixed header read. Pre-fix
+// code would still copy SamplesHeight=100 and SamplesWidth=200 from the read
+// buffer.
+static void BuildShortSOF0(vector<Byte>& out)
+{
+	EmitSOF0(out, /*markerLen*/ 7, /*h*/ 100, /*w*/ 200, /*comp*/ 1);
+}
+// JFIF with declared length 13 — below the 14-byte fixed header read. Pre-fix
+// code would set JFIFInformationExists=true and write the densities.
+static void BuildShortJFIF(vector<Byte>& out)
+{
+	EmitJFIF(out, /*markerLen*/ 13, /*xDen*/ 72, /*yDen*/ 96);
+}
+// Photoshop / SkipTag short markers don't surface in observable info fields
+// even pre-fix; the guard's value is reaching this assertion at all (rather
+// than driving a wild skip).
+static void BuildShortPhotoshop(vector<Byte>& out) { EmitPhotoshopShort(out, /*markerLen*/ 1); }
+static void BuildShortUnknownApp(vector<Byte>& out){ EmitUnknownApp     (out, /*markerLen*/ 1); }
+
+static const ShortMarkerCase scShortMarkerCases[] = {
+	{"ShortSOF0_DoesNotRecordDimensions",     BuildShortSOF0},
+	{"ShortJFIF_DoesNotRecordDensity",        BuildShortJFIF},
+	{"ShortPhotoshop_LeavesInfoAtDefaults",   BuildShortPhotoshop},
+	{"ShortSkipTag_LeavesInfoAtDefaults",     BuildShortUnknownApp},
+};
+
+static bool RunShortMarkerCases()
+{
+	const size_t count = sizeof(scShortMarkerCases) / sizeof(scShortMarkerCases[0]);
+	for(size_t i = 0; i < count; ++i) {
+		const ShortMarkerCase& c = scShortMarkerCases[i];
+
+		// Arrange
+		vector<Byte> bytes;
+		EmitSOI(bytes);
+		c.buildAfterSOI(bytes);
+
+		// Act
+		JPEGImageInformation info;
+		(void)RunParse(bytes, info);
+
+		// Assert
+		if(!IsJpegInfoAtDefaults(info)) {
+			cout << "JPEGImageParserTest [ShortMarker::" << c.label
+			     << "]: info struct was mutated despite short marker length "
+			        "(dims=" << info.SamplesWidth << "x" << info.SamplesHeight
+			     << " jfif=" << info.JFIFInformationExists
+			     << " exif=" << info.ExifInformationExists
+			     << " psd="  << info.PhotoshopInformationExists << ")" << endl;
+			return false;
+		}
+	}
+	return true;
+}
+
+// ---- Exif-path cases ---------------------------------------------------
+
+// Exif failure is treated by Parse as "not Exif" and the marker is ignored
+// (ExifMarkerNotFound is reset to true). Every case below pairs an Exif
+// segment with a valid SOF0 so Parse's outer status stays eSuccess and the
+// SOF0 dimensions become a sanity check that the post-Exif drain didn't
+// over-skip the stream.
+struct ExifCase {
+	const char* label;
+	// input — fed into EmitExifSegment
+	unsigned long ifdOffset;
+	unsigned long xResOff;
+	unsigned long yResOff;
+	unsigned long rationalNumerator;
+	unsigned long rationalDenominator;
+	// expected outcome
+	bool          expectExifInfoSet;     // ExifInformationExists after parse
+	double        expectedXDensity;
+	double        expectedYDensity;
+};
+
+// Offset to the first rational when ifdOffset=8 (no TIFF-header padding) and
+// the IFD has 3 entries placed immediately after the IFD entry count: 8 (TIFF
+// header) + 2 (entry count) + 3*12 (entries) = 46.
+static const unsigned long scRational0Off = 46;
+static const unsigned long scRational1Off = 54; // 46 + 8
+
+static const ExifCase scExifCases[] = {
+	// Well-formed baseline: pins the happy path mapping (300/2 = 150).
+	{"WellFormed_RecordsDensity",
+	 /*ifdOffset*/ 8, /*xRes*/ scRational0Off, /*yRes*/ scRational1Off,
+	 /*num*/ 300, /*den*/ 2,
+	 /*exifSet*/ true, /*x*/ 150.0, /*y*/ 150.0},
+
+	// IFD0 offset below the 8-byte TIFF header minimum — rejected at V-093
+	// guard, BEFORE ExifInformationExists is set.
+	{"IfdOffsetBelowEight_IgnoredAsXMP",
+	 /*ifdOffset*/ 4, /*xRes*/ scRational0Off, /*yRes*/ scRational1Off,
+	 /*num*/ 72, /*den*/ 1,
+	 /*exifSet*/ false, /*x*/ 0.0, /*y*/ 0.0},
+
+	// xResolution IFD-entry offset (10) precedes parser position after IFD
+	// loop (46) — rejected at GetResolutionFromExif's ordering guard, AFTER
+	// ExifInformationExists is set.
+	{"ResolutionOffsetBeforeIfd_IgnoredAsXMP",
+	 /*ifdOffset*/ 8, /*xRes*/ 10, /*yRes*/ scRational1Off,
+	 /*num*/ 72, /*den*/ 1,
+	 /*exifSet*/ true, /*x*/ 0.0, /*y*/ 0.0},
+
+	// Valid offsets, denominator=0 — rejected at ReadRationalValue, AFTER
+	// ExifInformationExists is set.
+	{"RationalDenominatorZero_IgnoredAsXMP",
+	 /*ifdOffset*/ 8, /*xRes*/ scRational0Off, /*yRes*/ scRational1Off,
+	 /*num*/ 72, /*den*/ 0,
+	 /*exifSet*/ true, /*x*/ 0.0, /*y*/ 0.0},
+};
+
+static bool RunExifCases()
+{
+	const size_t count = sizeof(scExifCases) / sizeof(scExifCases[0]);
+	for(size_t i = 0; i < count; ++i) {
+		const ExifCase& c = scExifCases[i];
+
+		// Arrange
+		vector<Byte> bytes;
+		EmitSOI(bytes);
+		EmitExifSegment(bytes, c.ifdOffset, c.xResOff, c.yResOff,
+		                /*resUnit*/ 2, c.rationalNumerator, c.rationalDenominator);
+		EmitSOF0(bytes, 11, /*h*/ 100, /*w*/ 200, /*comp*/ 1);
+
+		// Act
+		JPEGImageInformation info;
+		EStatusCode status = RunParse(bytes, info);
+
+		// Assert — overall parse, SOF0 reached, Exif fields match expectation.
+		if(status != eSuccess) {
+			cout << "JPEGImageParserTest [Exif::" << c.label
+			     << "]: status " << status << ", expected eSuccess" << endl;
+			return false;
+		}
+		if(info.SamplesWidth != 200 || info.SamplesHeight != 100) {
+			cout << "JPEGImageParserTest [Exif::" << c.label
+			     << "]: SOF0 dims " << info.SamplesWidth << "x" << info.SamplesHeight
+			     << ", expected 200x100 (drain must end at marker boundary)" << endl;
+			return false;
+		}
+		if(info.ExifInformationExists != c.expectExifInfoSet) {
+			cout << "JPEGImageParserTest [Exif::" << c.label
+			     << "]: ExifInformationExists=" << info.ExifInformationExists
+			     << ", expected " << c.expectExifInfoSet << endl;
+			return false;
+		}
+		if(info.ExifXDensity != c.expectedXDensity || info.ExifYDensity != c.expectedYDensity) {
+			cout << "JPEGImageParserTest [Exif::" << c.label
+			     << "]: density " << info.ExifXDensity << "x" << info.ExifYDensity
+			     << ", expected " << c.expectedXDensity << "x" << c.expectedYDensity << endl;
+			return false;
+		}
+	}
+	return true;
+}
+
+// Silence unused-warning for the little-endian emitters; they exist so future
+// Exif fixtures can flip endianness without touching the builder.
+static void EnsureEmittersReferenced()
+{
+	vector<Byte> tmp;
+	EmitU16LE(tmp, 0);
+	EmitU32LE(tmp, 0);
+	(void)tmp;
+}
+
+int JPEGImageParserTest(int argc, char* argv[])
+{
+	(void)argc;
+	(void)argv;
+	EnsureEmittersReferenced();
+
+	if(!Parse_MinimalSOF0_Succeeds())        return 1;
+	if(!Parse_JfifThenSOF0_RecordsDensity()) return 1;
+	if(!RunShortMarkerCases())               return 1;
+	if(!RunExifCases())                      return 1;
+	return 0;
+}

--- a/PDFWriterTesting/JPEGImageParserTest.cpp
+++ b/PDFWriterTesting/JPEGImageParserTest.cpp
@@ -234,7 +234,7 @@ static void EmitExifSegment(vector<Byte>& out,
 static EStatusCode RunParse(const vector<Byte>& inBytes, JPEGImageInformation& outInfo)
 {
 	// Arrange
-	InputByteArrayStream stream((Byte*)&inBytes[0], (long long)inBytes.size());
+	InputByteArrayStream stream(const_cast<Byte*>(inBytes.data()), (long long)inBytes.size());
 
 	// Act
 	JPEGImageParser parser;

--- a/PDFWriterTesting/JPEGImageParserTest.cpp
+++ b/PDFWriterTesting/JPEGImageParserTest.cpp
@@ -312,12 +312,10 @@ static bool Parse_JfifThenSOF0_RecordsDensity()
 // into JPEGImageInformation BEFORE noticing the length was wrong (the
 // underflow then drove a wild SkipStream call). With the guards in place
 // each per-marker reader rejects the short read before any output field is
-// written, so the discriminating assertion is "the info struct is at its
-// default-constructed state".
-//
-// Parse's outer status is not a discriminator here: the per-marker case-arm
-// flips its "marker not found" flag BEFORE calling the per-marker reader, so
-// Parse may still report success after a per-marker failure.
+// written, and Parse propagates the failure: SOFMarkerNotFound is now only
+// cleared on a successful ReadSOF0Data, so a malformed SOF0 keeps the flag
+// raised and Parse returns eFailure. The other short-marker cases never
+// reach a valid SOF, so they also fail.
 
 static bool IsJpegInfoAtDefaults(const JPEGImageInformation& info)
 {
@@ -376,9 +374,15 @@ static bool RunShortMarkerCases()
 
 		// Act
 		JPEGImageInformation info;
-		(void)RunParse(bytes, info);
+		EStatusCode status = RunParse(bytes, info);
 
-		// Assert
+		// Assert — Parse must report failure (no valid SOF reached) and the
+		// info struct must stay at defaults.
+		if(status == eSuccess) {
+			cout << "JPEGImageParserTest [ShortMarker::" << c.label
+			     << "]: Parse returned eSuccess; expected eFailure" << endl;
+			return false;
+		}
 		if(!IsJpegInfoAtDefaults(info)) {
 			cout << "JPEGImageParserTest [ShortMarker::" << c.label
 			     << "]: info struct was mutated despite short marker length "


### PR DESCRIPTION
## Summary
`Parse` flipped `SOFMarkerNotFound = false` *before* calling `ReadSOF0Data`, so a per-marker reader failure left the flag cleared and the trailing `if (SOFMarkerNotFound) eFailure else eSuccess` forced Parse to report success on malformed SOF markers. Downstream, `JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation` writes `/Width` and `/Height` into the dictionary **before** the `ColorComponentsCount` switch, so a malformed SOF would emit `/Width 0 /Height 0` into the PDF stream before bailing out — producing a half-written, malformed image XObject.

Match the Photoshop pattern (already correct): run the per-marker reader first, clear the flag only on `eSuccess`.

## Causality
Pre-existing in `JPEGImageParser.cpp`. Surfaced by Copilot during review of #386 as a critical finding; #386 didn't introduce it (the same Parse=eSuccess outcome happens pre-#386 via the wild-skip path), and the fix is malformedness-rejection scope rather than memory safety, so we kept it out of #386 and opened this stacked follow-up.

## Stacking
Based on `fix/jpeg-parser-bounded-arithmetic` (#386) because the test update touches `JPEGImageParserTest.cpp`, which is introduced by that PR. Merge after #386.

## Test plan
- [x] `JPEGImageParserTest::RunShortMarkerCases` now asserts `Parse` returns `eFailure` (previously discarded the status). `ShortSOF0` is the discriminator — `ShortJFIF` / `ShortPhotoshop` / `ShortSkipTag` already exhibited `eFailure` since they never reach a SOF.
- [x] Full suite 101/101 passing locally.
- [x] Well-formed Exif followed by SOF0 (`Exif::WellFormed_RecordsDensity`) still returns `eSuccess` — confirms the SOF-found path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)