### PR TITLE
fix: clear SOFMarkerNotFound only after successful read (V-099)

### DIFF
--- a/PDFWriter/JPEGImageParser.cpp
+++ b/PDFWriter/JPEGImageParser.cpp
@@ -96,8 +96,9 @@ EStatusCode JPEGImageParser::Parse(IByteReaderWithPosition* inImageStream,JPEGIm
 				case scSOF7TagID : case scSOF9TagID : case scSOF10TagID:
 				case scSOF11TagID : case scSOF13TagID : case scSOF14TagID:
 				case scSOF15TagID :
-					SOFMarkerNotFound = false;
 					status = ReadSOF0Data(outImageInformation);
+					if (status == PDFHummus::eSuccess)
+						SOFMarkerNotFound = false;
 					break;
 				case scAPP0TagID:
 					if(JFIFMarkerNotFound)

--- a/PDFWriterTesting/JPEGImageParserTest.cpp
+++ b/PDFWriterTesting/JPEGImageParserTest.cpp
@@ -312,12 +312,10 @@ static bool Parse_JfifThenSOF0_RecordsDensity()
 // into JPEGImageInformation BEFORE noticing the length was wrong (the
 // underflow then drove a wild SkipStream call). With the guards in place
 // each per-marker reader rejects the short read before any output field is
-// written, so the discriminating assertion is "the info struct is at its
-// default-constructed state".
-//
-// Parse's outer status is not a discriminator here: the per-marker case-arm
-// flips its "marker not found" flag BEFORE calling the per-marker reader, so
-// Parse may still report success after a per-marker failure.
+// written, and Parse propagates the failure: SOFMarkerNotFound is now only
+// cleared on a successful ReadSOF0Data, so a malformed SOF0 keeps the flag
+// raised and Parse returns eFailure. The other short-marker cases never
+// reach a valid SOF, so they also fail.
 
 static bool IsJpegInfoAtDefaults(const JPEGImageInformation& info)
 {
@@ -376,9 +374,15 @@ static bool RunShortMarkerCases()
 
 		// Act
 		JPEGImageInformation info;
-		(void)RunParse(bytes, info);
+		EStatusCode status = RunParse(bytes, info);
 
-		// Assert
+		// Assert — Parse must report failure (no valid SOF reached) and the
+		// info struct must stay at defaults.
+		if(status == eSuccess) {
+			cout << "JPEGImageParserTest [ShortMarker::" << c.label
+			     << "]: Parse returned eSuccess; expected eFailure" << endl;
+			return false;
+		}
 		if(!IsJpegInfoAtDefaults(info)) {
 			cout << "JPEGImageParserTest [ShortMarker::" << c.label
 			     << "]: info struct was mutated despite short marker length "


### PR DESCRIPTION
## Summary
`Parse` flipped `SOFMarkerNotFound = false` *before* calling `ReadSOF0Data`, so a per-marker reader failure left the flag cleared and the trailing `if (SOFMarkerNotFound) eFailure else eSuccess` forced Parse to report success on malformed SOF markers. Downstream, `JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation` writes `/Width` and `/Height` into the dictionary **before** the `ColorComponentsCount` switch, so a malformed SOF would emit `/Width 0 /Height 0` into the PDF stream before bailing out — producing a half-written, malformed image XObject.

Match the Photoshop pattern (already correct in the same function): run the per-marker reader first, clear the flag only on `eSuccess`.

## Context
Surfaced by Copilot during review of #386. Pre-existing in `JPEGImageParser.cpp` — #386 didn't introduce it. Memory-safety hardening landed in #386; this completes the picture by propagating the SOF failure cleanly.

Replaces #387 (closed; conflicted with the squash merge of #386).

## Test plan
- [x] `JPEGImageParserTest::RunShortMarkerCases` now asserts `Parse` returns `eFailure` (previously discarded the status). `ShortSOF0` is the discriminator — `ShortJFIF` / `ShortPhotoshop` / `ShortSkipTag` already exhibited `eFailure` since they never reach a SOF.
- [x] Well-formed Exif followed by SOF0 (`Exif::WellFormed_RecordsDensity`) still returns `eSuccess` — confirms the SOF-found path is unaffected.
- [x] Full suite 101/101 passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)