### PR TITLE
fix: bound TIFF YCBCR realloc, add break on palette OOM (V-100/V-101)

### DIFF
--- a/PDFWriter/TIFFImageHandler.cpp
+++ b/PDFWriter/TIFFImageHandler.cpp
@@ -94,6 +94,7 @@
 
 #include <stdlib.h> 
 #include <search.h>
+#include <stdint.h>
 
 using namespace PDFHummus;
 
@@ -3041,6 +3042,7 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 						mT2p->inputFilePath.c_str());
 					status = PDFHummus::eFailure;
 				  _TIFFfree(buffer);
+					break;
 				} 
 				else 
 				{
@@ -3066,6 +3068,18 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 
 			if(mT2p->pdf_sample & T2P_SAMPLE_YCBCR_TO_RGB)
 			{
+				if(mT2p->tiff_width != 0 &&
+					mT2p->tiff_length > UINT32_MAX / 4 / mT2p->tiff_width)
+				{
+					TRACE_LOG3(
+						"Refusing oversized RGBA allocation %ux%ux4 for %s",
+						mT2p->tiff_width,
+						mT2p->tiff_length,
+						mT2p->inputFilePath.c_str());
+					status = PDFHummus::eFailure;
+					_TIFFfree(buffer);
+					break;
+				}
 				samplebuffer=(unsigned char*)_TIFFrealloc(
 					(tdata_t)buffer, 
 					mT2p->tiff_width*mT2p->tiff_length*4);


### PR DESCRIPTION
## Summary

Two HIGH-sev memory-safety fixes in `TIFFImageHandler::WriteImageData`, both in the t2p_readwrite_pdf_image port from libtiff's `tiff2pdf` tool.

**V-100 — palette-realize UAF.** In the `T2P_SAMPLE_REALIZE_PALETTE` block, when `_TIFFrealloc` returns NULL the code freed `buffer` but the surrounding `if/else` then fell through unconditionally to `SampleRealizePalette(buffer)` — UAF on the just-freed pointer (and the subsequent RGBA / YCBCR / LAB sample-transform blocks would compound it). Fix: `break;` after the `_TIFFfree(buffer)`, matching the existing pattern in the `T2P_SAMPLE_YCBCR_TO_RGB` block immediately below.

**V-101 — RGBA realloc overflow (defense-in-depth).** In the `T2P_SAMPLE_YCBCR_TO_RGB` block, `_TIFFrealloc(buffer, tiff_width * tiff_length * 4)` performs the multiplication in `uint32_t`. For sufficiently large declared dimensions the product truncates; on overflow the realloc shrinks the buffer and the subsequent `TIFFReadRGBAImageOriented` writes the full image into the truncated allocation → heap overflow. Fix: overflow guard before the realloc using the existing `SIZE_MAX/N/W` pattern (UINT32_MAX here since the operands are `uint32_t`).

In practice the V-101 attack is shadowed by the prior `_TIFFmalloc(tiff_datasize)` at line 2995, which over-allocates on the same root cause (declared dimensions × samplesperpixel × bps/8). That upstream overflow is **V-105**, queued for PR B. The V-101 guard remains as defense-in-depth so future relaxations of the upstream alloc don't reopen the path.

## Why no new regression test

- **V-100** only fires on `_TIFFrealloc` OOM. No injection harness in the project today.
- **V-101** requires the prior `_TIFFmalloc(tiff_datasize)` to succeed at multi-GB while `width*length*4` still overflows `uint32_t`. With YCBCR's required `samplesperpixel >= 2`, both can't hold together within reasonable memory. End-to-end regression will ship with **V-105 in PR B**, where the upstream alloc is bounded and this path becomes reachable.

Existing `TIFFImageTest` (palette + YCBCR happy paths via `flower-palette-*.tif` and `ycbcr-cat.tif`) confirms neither fix regressed normal flow.

## Test plan

- [x] `cmake --build .` clean (only pre-existing sprintf-deprecation warnings)
- [x] `ctest -C Release` — all 101 tests pass
- [x] `ctest -R "TIFF|Tiff"` — TIFFImageTest + TiffSpecialsTest pass (palette + YCBCR + planar + tiled paths exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)