### PR TITLE
fix: bound TIFF size calcs + check TIFFGetField returns (V-102..V-105)

### DIFF
--- a/PDFWriter/TIFFImageHandler.cpp
+++ b/PDFWriter/TIFFImageHandler.cpp
@@ -2844,7 +2844,13 @@ void TIFFImageHandler::CalculateTiffSizeNoTiles()
 	else
 	{
 		tmsize_t scanline = TIFFScanlineSize(mT2p->input);
-		uint64_t totalSize = (scanline > 0) ? static_cast<uint64_t>(scanline) * mT2p->tiff_length : 0;
+		uint64_t totalSize = 0;
+		if(scanline > 0 && mT2p->tiff_length > 0 &&
+			static_cast<uint64_t>(scanline) <=
+				static_cast<uint64_t>(TIFF_TMSIZE_T_MAX) / mT2p->tiff_length)
+		{
+			totalSize = static_cast<uint64_t>(scanline) * mT2p->tiff_length;
+		}
 		if(mT2p->tiff_planar==PLANARCONFIG_SEPARATE && mT2p->tiff_samplesperpixel != 0)
 		{
 			if(totalSize > static_cast<uint64_t>(TIFF_TMSIZE_T_MAX) / mT2p->tiff_samplesperpixel)
@@ -2852,8 +2858,6 @@ void TIFFImageHandler::CalculateTiffSizeNoTiles()
 			else
 				totalSize *= mT2p->tiff_samplesperpixel;
 		}
-		if(totalSize > static_cast<uint64_t>(TIFF_TMSIZE_T_MAX))
-			totalSize = 0;
 		mT2p->tiff_datasize = static_cast<tsize_t>(totalSize);
 	}
 }

--- a/PDFWriter/TIFFImageHandler.cpp
+++ b/PDFWriter/TIFFImageHandler.cpp
@@ -704,8 +704,9 @@ EStatusCode TIFFImageHandler::ReadTopLevelTiffInformation()
 			if( (TIFFGetField(mT2p->input, TIFFTAG_PLANARCONFIG, &xuint16_t) != 0)
 				&& (xuint16_t == PLANARCONFIG_SEPARATE ) )
 			{
-					TIFFGetField(mT2p->input, TIFFTAG_SAMPLESPERPIXEL, &xuint16_t);
-					mT2p->tiff_tiles[i].tiles_tilecount/= xuint16_t;
+					TIFFGetFieldDefaulted(mT2p->input, TIFFTAG_SAMPLESPERPIXEL, &xuint16_t);
+					if(xuint16_t != 0)
+						mT2p->tiff_tiles[i].tiles_tilecount/= xuint16_t;
 			}
 			if( mT2p->tiff_tiles[i].tiles_tilecount > 0)
 			{
@@ -2317,15 +2318,24 @@ void TIFFImageHandler::CalculateTiffTileSize(int inTileIndex)
 			// 	TIFFTAG_TILEBYTECOUNTS changed in tiff 4.0.0;
 
 			tsize_t_compat* tbc = NULL;
-			TIFFGetField(mT2p->input, TIFFTAG_TILEBYTECOUNTS, &tbc);
-			mT2p->tiff_datasize=static_cast<tsize_t>(tbc[inTileIndex]);
+			if(TIFFGetField(mT2p->input, TIFFTAG_TILEBYTECOUNTS, &tbc) != 0 && tbc != NULL)
+				mT2p->tiff_datasize=static_cast<tsize_t>(tbc[inTileIndex]);
+			else
+				mT2p->tiff_datasize=0;
 		}
 	}
 	else
 	{
-		mT2p->tiff_datasize=TIFFTileSize(mT2p->input);
-		if(mT2p->tiff_planar==PLANARCONFIG_SEPARATE)
-			mT2p->tiff_datasize*= mT2p->tiff_samplesperpixel;
+		tmsize_t tileSize = TIFFTileSize(mT2p->input);
+		uint64_t totalSize = (tileSize > 0) ? static_cast<uint64_t>(tileSize) : 0;
+		if(mT2p->tiff_planar==PLANARCONFIG_SEPARATE && mT2p->tiff_samplesperpixel != 0)
+		{
+			if(totalSize > static_cast<uint64_t>(TIFF_TMSIZE_T_MAX) / mT2p->tiff_samplesperpixel)
+				totalSize = 0;
+			else
+				totalSize *= mT2p->tiff_samplesperpixel;
+		}
+		mT2p->tiff_datasize = static_cast<tsize_t>(totalSize);
 	}
 }
 
@@ -2417,6 +2427,13 @@ EStatusCode TIFFImageHandler::WriteImageTileData(PDFStream* inImageStream,int in
 
 	do
 	{
+		if(mT2p->tiff_datasize <= 0)
+		{
+			TRACE_LOG1("TIFFImageHandler::WriteImageTileData, invalid tiff_datasize for %s",
+						mT2p->inputFilePath.c_str());
+			status = PDFHummus::eFailure;
+			break;
+		}
 		// if recompression is not required, passthrough the image information and finish
 		if((mT2p->pdf_transcode == T2P_TRANSCODE_RAW) && (edge == 0) &&
 			(mT2p->pdf_compression == T2P_COMPRESS_G4 ||
@@ -2819,14 +2836,25 @@ void TIFFImageHandler::CalculateTiffSizeNoTiles()
 	{
 		// TIFFTAG_STRIPBYTECOUNTS size changed in tiff 4.0.0
 		tsize_t_compat * sbc = NULL;
-		TIFFGetField(mT2p->input, TIFFTAG_STRIPBYTECOUNTS, &sbc);
-		mT2p->tiff_datasize = static_cast<tsize_t>(sbc[0]);
+		if(TIFFGetField(mT2p->input, TIFFTAG_STRIPBYTECOUNTS, &sbc) != 0 && sbc != NULL)
+			mT2p->tiff_datasize = static_cast<tsize_t>(sbc[0]);
+		else
+			mT2p->tiff_datasize = 0;
 	}
 	else
 	{
-		mT2p->tiff_datasize=TIFFScanlineSize(mT2p->input) * mT2p->tiff_length;
-		if(mT2p->tiff_planar==PLANARCONFIG_SEPARATE)
-			mT2p->tiff_datasize*= mT2p->tiff_samplesperpixel;
+		tmsize_t scanline = TIFFScanlineSize(mT2p->input);
+		uint64_t totalSize = (scanline > 0) ? static_cast<uint64_t>(scanline) * mT2p->tiff_length : 0;
+		if(mT2p->tiff_planar==PLANARCONFIG_SEPARATE && mT2p->tiff_samplesperpixel != 0)
+		{
+			if(totalSize > static_cast<uint64_t>(TIFF_TMSIZE_T_MAX) / mT2p->tiff_samplesperpixel)
+				totalSize = 0;
+			else
+				totalSize *= mT2p->tiff_samplesperpixel;
+		}
+		if(totalSize > static_cast<uint64_t>(TIFF_TMSIZE_T_MAX))
+			totalSize = 0;
+		mT2p->tiff_datasize = static_cast<tsize_t>(totalSize);
 	}
 }
 
@@ -2851,6 +2879,13 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 
 	do
 	{
+		if(mT2p->tiff_datasize <= 0)
+		{
+			TRACE_LOG1("TIFFImageHandler::WriteImageData, invalid tiff_datasize for %s",
+						mT2p->inputFilePath.c_str());
+			status = PDFHummus::eFailure;
+			break;
+		}
 		if(mT2p->pdf_transcode == T2P_TRANSCODE_RAW)
 		{
 			if(mT2p->pdf_compression == T2P_COMPRESS_G4 ||
@@ -3031,6 +3066,19 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 
 			if(mT2p->pdf_sample & T2P_SAMPLE_REALIZE_PALETTE)
 			{
+				if(mT2p->tiff_samplesperpixel != 0 &&
+					static_cast<uint64_t>(mT2p->tiff_datasize) >
+						static_cast<uint64_t>(TIFF_TMSIZE_T_MAX) / mT2p->tiff_samplesperpixel)
+				{
+					TRACE_LOG3(
+						"Refusing oversized palette-realize allocation %lldx%u for %s",
+						static_cast<long long>(mT2p->tiff_datasize),
+						mT2p->tiff_samplesperpixel,
+						mT2p->inputFilePath.c_str());
+					status = PDFHummus::eFailure;
+					_TIFFfree(buffer);
+					break;
+				}
 				samplebuffer=(unsigned char*)_TIFFrealloc( 
 					(tdata_t) buffer, 
 					mT2p->tiff_datasize * mT2p->tiff_samplesperpixel);


### PR DESCRIPTION
## Summary

Four MED-sev defensive fixes in `TIFFImageHandler`, all in the `tiff2pdf` port. Stacked with **PR #389** (V-100/V-101); both touch `TIFFImageHandler.cpp` but in different blocks — minor rebase expected after either merges.

**V-102 — `CalculateTiffTileSize` NULL deref.** `TIFFGetField(input, TIFFTAG_TILEBYTECOUNTS, &tbc)` return was not checked; when the tag is absent `tbc` stays `NULL` and `tbc[inTileIndex]` derefs NULL. Added return + NULL check; on failure `tiff_datasize` is set to `0` and the caller-side entry guard rejects.

**V-103 — `CalculateTiffSizeNoTiles` NULL deref.** Same shape for `STRIPBYTECOUNTS` → `sbc[0]`. Same fix.

**V-104 — `ReadTopLevelTiffInformation` zero-divide.** `TIFFGetField(input, SAMPLESPERPIXEL, &xuint16_t)` followed by `tiles_tilecount /= xuint16_t`. Switched to `TIFFGetFieldDefaulted` (matches the codebase's other SAMPLESPERPIXEL read at line 812 in `ReadTIFFPageInformation`), so libtiff applies the spec default of 1 if the tag is absent. Added an explicit zero-guard around the divide as defense-in-depth.

**V-105 — width×length overflow cluster.**
- `CalculateTiffSizeNoTiles:2826` (`TIFFScanlineSize × tiff_length`) and `CalculateTiffTileSize:2327` (`TIFFTileSize`) widened to `uint64_t` with `TIFF_TMSIZE_T_MAX` bound; overflow sets `tiff_datasize=0`.
- `PLANARCONFIG_SEPARATE`'s `tiff_datasize *= samplesperpixel` got the same widened/bounded treatment in both calculators.
- `WriteImageData` palette-realize site (`tiff_datasize × samplesperpixel` passed to `_TIFFrealloc`) got a pre-check guard that fails cleanly on overflow.
- Remaining `tiff_width × tiff_length` sites (sample-transform args at `WriteImageData:3057/3064/3102/3110`, `WriteImageTileData:2562/2570/2585`, `SampleRealizePalette:3136`) are safe-by-construction: overflow truncates the iteration count and the buffer was sized by the now-bounded upstream alloc, so the loops under-count rather than going OOB.

**Caller-side entry guards.** `WriteImageData` and `WriteImageTileData` now check `tiff_datasize <= 0` at the start of their `do{}while(false)` and break with `eFailure`. This surfaces the `0` sentinel from V-102/V-103/V-105 as a clean rejection rather than relying on `_TIFFmalloc(0)` (which returns a valid 0-byte pointer on most allocators — `TIFFReadEncodedStrip` would then OOB-write into it).

## Relationship to PR #389 (V-100/V-101)

PR #389's V-101 guard at `WriteImageData:3071` (RGBA realloc) was defense-in-depth because the realistic attack path was shadowed by the unbounded `_TIFFmalloc(tiff_datasize)` upstream. This PR bounds that upstream alloc (V-105 at `CalculateTiffSizeNoTiles:2826`). Together they form complete coverage; either PR alone leaves the other's guarded site reachable in theory.

## Why no new regression tests

On 64-bit (the main test platform), the observable rejection path is identical with and without these fixes — `_TIFFmalloc` returns NULL on multi-GB requests, hitting the existing NULL-check path. The fixes matter:
- On **32-bit** where `tsize_t = int32_t` overflows realistically.
- As **defense-in-depth** against future relaxations of the upstream allocations.
- For **NULL-deref paths** (V-102/V-103) where libtiff is asked for tags it can't return (severely malformed TIFFs that libtiff would default or reject before reaching these calculators in practice).

Existing `TIFFImageTest` (palette + YCBCR + planar + tiled paths) confirms no happy-path regression.

## Test plan

- [x] `cmake --build .` clean (only pre-existing sprintf-deprecation warnings)
- [x] `ctest -C Release` — all 101 tests pass
- [x] `ctest -R "TIFF|Tiff"` — TIFFImageTest + TiffSpecialsTest pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)