### PR TITLE
fix: memmove + stripsize underflow + palette bounds in TIFF (V-106..V-108)

### DIFF
--- a/PDFWriter/TIFFImageHandler.cpp
+++ b/PDFWriter/TIFFImageHandler.cpp
@@ -2673,7 +2673,7 @@ tsize_t TIFFImageHandler::SampleRGBAAToRGB(tdata_t inData, uint32_t inSampleCoun
 	uint32_t i;
 	
 	for(i = 0; i < inSampleCount; i++)
-		memcpy((uint8_t*)inData + i * 3, (uint8_t*)inData + i * 4, 3);
+		memmove((uint8_t*)inData + i * 3, (uint8_t*)inData + i * 4, 3);
 
 	return(i * 3);	
 }
@@ -2948,7 +2948,10 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 					break;
 				}
 				bufferoffset+=read;
-				stripsize = (stripsize > mT2p->tiff_datasize - bufferoffset) ? (mT2p->tiff_datasize - bufferoffset) : stripsize;
+				if(bufferoffset < mT2p->tiff_datasize)
+					stripsize = (stripsize > mT2p->tiff_datasize - bufferoffset) ? (mT2p->tiff_datasize - bufferoffset) : stripsize;
+				else
+					stripsize = 0;
 			}
 			if(status != PDFHummus::eSuccess)
 				break;
@@ -3063,7 +3066,10 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 					break;
 				}
 				bufferoffset+=read;
-				stripsize = (stripsize > mT2p->tiff_datasize - bufferoffset) ? (mT2p->tiff_datasize - bufferoffset) : stripsize;
+				if(bufferoffset < mT2p->tiff_datasize)
+					stripsize = (stripsize > mT2p->tiff_datasize - bufferoffset) ? (mT2p->tiff_datasize - bufferoffset) : stripsize;
+				else
+					stripsize = 0;
 			}
 			if(status != PDFHummus::eSuccess)
 				break;
@@ -3197,14 +3203,31 @@ void TIFFImageHandler::SampleRealizePalette(unsigned char* inBuffer)
 	uint16_t component_count=0;
 	uint32_t palette_offset=0;
 	uint32_t sample_offset=0;
+	uint32_t palette_entries=0;
+	uint32_t max_samples=0;
+	uint32_t idx=0;
 	uint32_t i=0;
 	uint32_t j=0;
 	sample_count=mT2p->tiff_width*mT2p->tiff_length;
 	component_count=mT2p->tiff_samplesperpixel;
-	
+
+	// Cap to keep expand-in-place writes within tiff_datasize, and clamp
+	// the index against the colormap (which holds 2^bps entries — fewer
+	// than 256 when bps<8 and the input byte aliases a wider value).
+	if(component_count != 0)
+	{
+		max_samples = (uint32_t)(mT2p->tiff_datasize / component_count);
+		if(sample_count > max_samples)
+			sample_count = max_samples;
+		palette_entries = (uint32_t)(mT2p->pdf_palettesize / component_count);
+	}
+
 	for(i=sample_count;i>0;i--)
 	{
-		palette_offset=inBuffer[i-1] * component_count;
+		idx = inBuffer[i-1];
+		if(idx >= palette_entries)
+			idx = 0;
+		palette_offset = idx * component_count;
 		sample_offset= (i-1) * component_count;
 		for(j=0;j<component_count;j++)
 			inBuffer[sample_offset+j]=mT2p->pdf_palette[palette_offset+j];

--- a/PDFWriter/TIFFImageHandler.cpp
+++ b/PDFWriter/TIFFImageHandler.cpp
@@ -2948,10 +2948,10 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 					break;
 				}
 				bufferoffset+=read;
-				if(bufferoffset < mT2p->tiff_datasize)
-					stripsize = (stripsize > mT2p->tiff_datasize - bufferoffset) ? (mT2p->tiff_datasize - bufferoffset) : stripsize;
-				else
-					stripsize = 0;
+				if(bufferoffset >= mT2p->tiff_datasize)
+					break;
+				if(stripsize > mT2p->tiff_datasize - bufferoffset)
+					stripsize = mT2p->tiff_datasize - bufferoffset;
 			}
 			if(status != PDFHummus::eSuccess)
 				break;
@@ -3066,10 +3066,10 @@ EStatusCode TIFFImageHandler::WriteImageData(PDFStream* inImageStream)
 					break;
 				}
 				bufferoffset+=read;
-				if(bufferoffset < mT2p->tiff_datasize)
-					stripsize = (stripsize > mT2p->tiff_datasize - bufferoffset) ? (mT2p->tiff_datasize - bufferoffset) : stripsize;
-				else
-					stripsize = 0;
+				if(bufferoffset >= mT2p->tiff_datasize)
+					break;
+				if(stripsize > mT2p->tiff_datasize - bufferoffset)
+					stripsize = mT2p->tiff_datasize - bufferoffset;
 			}
 			if(status != PDFHummus::eSuccess)
 				break;
@@ -3211,16 +3211,18 @@ void TIFFImageHandler::SampleRealizePalette(unsigned char* inBuffer)
 	sample_count=mT2p->tiff_width*mT2p->tiff_length;
 	component_count=mT2p->tiff_samplesperpixel;
 
+	// Nothing safe to do without a sized output unit or a populated colormap.
+	if(component_count == 0 || mT2p->pdf_palette == NULL ||
+		(uint32_t)mT2p->pdf_palettesize < component_count)
+		return;
+
 	// Cap to keep expand-in-place writes within tiff_datasize, and clamp
 	// the index against the colormap (which holds 2^bps entries — fewer
 	// than 256 when bps<8 and the input byte aliases a wider value).
-	if(component_count != 0)
-	{
-		max_samples = (uint32_t)(mT2p->tiff_datasize / component_count);
-		if(sample_count > max_samples)
-			sample_count = max_samples;
-		palette_entries = (uint32_t)(mT2p->pdf_palettesize / component_count);
-	}
+	max_samples = (uint32_t)(mT2p->tiff_datasize / component_count);
+	if(sample_count > max_samples)
+		sample_count = max_samples;
+	palette_entries = (uint32_t)(mT2p->pdf_palettesize / component_count);
 
 	for(i=sample_count;i>0;i--)
 	{

--- a/PDFWriter/TIFFImageHandler.cpp
+++ b/PDFWriter/TIFFImageHandler.cpp
@@ -3204,7 +3204,7 @@ void TIFFImageHandler::SampleRealizePalette(unsigned char* inBuffer)
 	uint32_t palette_offset=0;
 	uint32_t sample_offset=0;
 	uint32_t palette_entries=0;
-	uint32_t max_samples=0;
+	uint64_t max_samples=0;
 	uint32_t idx=0;
 	uint32_t i=0;
 	uint32_t j=0;
@@ -3219,9 +3219,9 @@ void TIFFImageHandler::SampleRealizePalette(unsigned char* inBuffer)
 	// Cap to keep expand-in-place writes within tiff_datasize, and clamp
 	// the index against the colormap (which holds 2^bps entries — fewer
 	// than 256 when bps<8 and the input byte aliases a wider value).
-	max_samples = (uint32_t)(mT2p->tiff_datasize / component_count);
-	if(sample_count > max_samples)
-		sample_count = max_samples;
+	max_samples = (uint64_t)mT2p->tiff_datasize / component_count;
+	if((uint64_t)sample_count > max_samples)
+		sample_count = (uint32_t)max_samples;
 	palette_entries = (uint32_t)(mT2p->pdf_palettesize / component_count);
 
 	for(i=sample_count;i>0;i--)


### PR DESCRIPTION
## Summary

Three LOW-sev fixes in `TIFFImageHandler`, closing out Phase 3.2's TIFF audit. Branched from main; should rebase cleanly against PR #390 (V-102..V-105) — different blocks of the same file.

**V-106 — overlapping memcpy.** `SampleRGBAAToRGB`'s in-place expand `memcpy(inData + i*3, inData + i*4, 3)` overlaps for i in [0,2] (dest end at `i*3+3` vs src start at `i*4` — gap is `i-3`). memcpy is UB on overlap per the C spec even when libc happens to handle forward-direction correctly. Switched to `memmove`.

**V-107 — signed `tsize_t` underflow.** Two strip-read loops in `WriteImageData` (lines ~2911 and ~3026) clamp `stripsize` to remaining buffer via `stripsize = (stripsize > tiff_datasize - bufferoffset) ? (tiff_datasize - bufferoffset) : stripsize`. If libtiff reports more bytes than the original allocation accounted for and `bufferoffset > tiff_datasize`, the subtraction is negative; reinterpreted as huge unsigned by the next `TIFFReadEncodedStrip` call → OOB. Guarded both sites: `if (bufferoffset >= tiff_datasize) stripsize = 0;` else the original clamp runs safely.

**V-108 — palette-realize bounds.** `SampleRealizePalette` has two memory-safety bugs:
- The in-place expand assumes one input byte per output pixel, but the upstream realloc only multiplies `tiff_datasize × samplesperpixel`. For palettized images with bps<8 the input buffer is packed (fewer bytes than pixels), so the resulting buffer is smaller than `sample_count × component_count` and the descending-i expand writes OOB.
- The palette index reuses the raw input byte (0–255) even though the colormap only holds 2^bps entries (16 for bps=4, 2 for bps=1) → OOB read of `pdf_palette`.

Capped `sample_count` to `tiff_datasize / component_count` and clamped the palette index to `pdf_palettesize / component_count` before the multiply. **Note:** bps<8 palettized output still won't be visually correct — the code never unpacked nibbles/bits in the first place. Properly handling bps<8 palettes is a feature change outside the memory-safety hardening scope. The bounds fix prevents heap corruption; the existing wrong-output behavior is unchanged.

## Why no new regression tests

- **V-106:** triggers UB only on platforms whose libc memcpy doesn't happen to forward-copy. Observable on most systems is "works fine," which is the same observable after the switch to memmove. Nothing for a test to detect.
- **V-107:** requires libtiff to return more bytes than declared in the strip metadata — libtiff itself would generally reject this before the call returns to us.
- **V-108:** requires a bps<8 palettized TIFF, which is a path the code never produced correct output for and we don't have fixtures for. ASan would catch the heap OOB; absent that, a regression test would need a hand-crafted bps=4 palette TIFF (doable but heavy for a LOW-sev defensive fix).

Existing `TIFFImageTest` covers RGBAA / palette-realize / multi-strip happy paths and still passes — confirms no happy-path regression.

## Test plan

- [x] `cmake --build .` clean (only pre-existing sprintf-deprecation warnings)
- [x] `ctest -C Release` — all 101 tests pass
- [x] `ctest -R "TIFF|Tiff"` — TIFFImageTest + TiffSpecialsTest pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)