### PR TITLE
cleanup: dedup PNG handler init + drop keep_unknown_chunks

### DIFF
--- a/PDFWriter/PNGImageHandler.cpp
+++ b/PDFWriter/PNGImageHandler.cpp
@@ -74,7 +74,6 @@ static const std::string scDeviceRGB = "DeviceRGB";
 static const std::string scBitsPerComponent = "BitsPerComponent";
 static const std::string scSMask = "SMask";
 PDFImageXObject* CreateImageXObjectForData(png_structp png_ptr, png_infop info_ptr, png_bytep row, ObjectsContext* inObjectsContext) {
-	PDFImageXObjectList listOfImages;
 	PDFImageXObject* imageXObject = NULL;
 	PDFStream* imageStream = NULL;
 	EStatusCode status = eSuccess;
@@ -307,6 +306,46 @@ void HandlePngWarning(png_structp png_ptr, png_const_charp warning_message) {
 		TRACE_LOG1("LibPNG Warning: %s",warning_message);
 }
 
+png_structp CreatePngReadStruct() {
+	return png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, HandlePngError, HandlePngWarning);
+}
+
+png_infop SetupReadAndCreateInfoStruct(png_structp png_ptr, IByteReaderWithPosition* inPNGStream) {
+	// pair png with custom IO (dont bother with writing)
+	png_set_read_fn(png_ptr, (png_voidp)inPNGStream, ReadDataFromStream);
+
+	// create info struct
+	png_infop info_ptr = png_create_info_struct(png_ptr);
+	if (info_ptr == NULL) {
+		png_error(png_ptr, "OOM allocating info structure");
+	}
+	return info_ptr;
+}
+
+void ReadInfoAndApplyStandardTransformations(png_structp png_ptr, png_infop info_ptr) {
+	// read info from png
+	png_read_info(png_ptr, info_ptr);
+
+	png_byte color_type = png_get_color_type(png_ptr, info_ptr);
+	png_byte bit_depth = png_get_bit_depth(png_ptr, info_ptr);
+
+	// all them set_expand option, to bring us to a common 8 bits per component as a minimum
+	if (color_type == PNG_COLOR_TYPE_PALETTE)
+		png_set_palette_to_rgb(png_ptr);
+	if (color_type == PNG_COLOR_TYPE_GRAY &&
+		bit_depth < 8) png_set_expand_gray_1_2_4_to_8(png_ptr);
+	if (png_get_valid(png_ptr, info_ptr,
+		PNG_INFO_tRNS)) png_set_tRNS_to_alpha(png_ptr);
+
+	// now let's also avoid 16 bits for now, to stay always at 8 bits per component
+	if (bit_depth == 16)
+		png_set_strip_16(png_ptr);
+
+	// and let's deal with random < 8 packing, so we're surely in 8 bits now
+	if (bit_depth < 8)
+		png_set_packing(png_ptr);
+}
+
 
 PDFFormXObject* CreateFormXObjectForPNGStream(IByteReaderWithPosition* inPNGStream, DocumentContext* inDocumentContext, ObjectsContext* inObjectsContext, ObjectIDType inFormXObjectID) {
 	// Start reading image to get dimension. we'll then create the form, and then the image
@@ -319,8 +358,7 @@ PDFFormXObject* CreateFormXObjectForPNGStream(IByteReaderWithPosition* inPNGStre
 	png_bytep row = NULL;
 
 	do {
-		// init structs and prep 
-		png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, HandlePngError, HandlePngWarning);
+		png_ptr = CreatePngReadStruct();
 		if (png_ptr == NULL) {
 			break;
 		}
@@ -331,42 +369,8 @@ PDFFormXObject* CreateFormXObjectForPNGStream(IByteReaderWithPosition* inPNGStre
 			break;
 		}
 
-		// pair png with custom IO (dont bother with writing)
-		png_set_read_fn(png_ptr, (png_voidp)inPNGStream, ReadDataFromStream);
-
-		// create info struct
-		info_ptr = png_create_info_struct(png_ptr);
-		if (info_ptr == NULL) {
-			png_error(png_ptr, "OOM allocating info structure");
-		}
-
-		// Gal: is this important?
-		png_set_keep_unknown_chunks(png_ptr, PNG_HANDLE_CHUNK_ALWAYS, NULL, 0);
-
-		// read info from png
-		png_read_info(png_ptr, info_ptr);
-
-		png_byte color_type = png_get_color_type(png_ptr, info_ptr);
-		png_byte bit_depth = png_get_bit_depth(png_ptr, info_ptr);
-
-		// Let's setup some default transformations, and then reprint the png info that will
-		// now adapt to post-translation
-
-		// all them set_expand option, to bring us to a common 8 bits per component as a minimum
-		if (color_type == PNG_COLOR_TYPE_PALETTE)
-			png_set_palette_to_rgb(png_ptr);
-		if (color_type == PNG_COLOR_TYPE_GRAY &&
-			bit_depth < 8) png_set_expand_gray_1_2_4_to_8(png_ptr);
-		if (png_get_valid(png_ptr, info_ptr,
-			PNG_INFO_tRNS)) png_set_tRNS_to_alpha(png_ptr);
-
-		// now let's also avoid 16 bits for now, to stay always at 8 bits per component
-		if (bit_depth == 16)
-			png_set_strip_16(png_ptr);
-
-		// and let's deal with random < 8 packing, so we're surely in 8 bits now
-		if (bit_depth < 8)
-			png_set_packing(png_ptr);
+		info_ptr = SetupReadAndCreateInfoStruct(png_ptr, inPNGStream);
+		ReadInfoAndApplyStandardTransformations(png_ptr, info_ptr);
 
 		// setup for potential interlace
 		int passes = png_set_interlace_handling(png_ptr);
@@ -472,8 +476,7 @@ PNGImageHandler::PNGImageInfo PNGImageHandler::ReadImageInfo(IByteReaderWithPosi
 	PNGImageHandler::PNGImageInfo data;
 
 	do {
-		// init structs and prep 
-		png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, HandlePngError, HandlePngWarning);
+		png_ptr = CreatePngReadStruct();
 		if (png_ptr == NULL) {
 			break;
 		}
@@ -484,42 +487,8 @@ PNGImageHandler::PNGImageInfo PNGImageHandler::ReadImageInfo(IByteReaderWithPosi
 			break;
 		}
 
-		// pair png with custom IO (dont bother with writing)
-		png_set_read_fn(png_ptr, (png_voidp)inPNGStream, ReadDataFromStream);
-
-		// create info struct
-		info_ptr = png_create_info_struct(png_ptr);
-		if (info_ptr == NULL) {
-			png_error(png_ptr, "OOM allocating info structure");
-		}
-
-		// Gal: is this important?
-		png_set_keep_unknown_chunks(png_ptr, PNG_HANDLE_CHUNK_ALWAYS, NULL, 0);
-
-		// read info from png
-		png_read_info(png_ptr, info_ptr);
-
-		png_byte color_type = png_get_color_type(png_ptr, info_ptr);
-		png_byte bit_depth = png_get_bit_depth(png_ptr, info_ptr);
-
-		// Let's setup some default transformations, and then reprint the png info that will
-		// now adapt to post-translation
-
-		// all them set_expand option, to bring us to a common 8 bits per component as a minimum
-		if (color_type == PNG_COLOR_TYPE_PALETTE)
-			png_set_palette_to_rgb(png_ptr);
-		if (color_type == PNG_COLOR_TYPE_GRAY &&
-			bit_depth < 8) png_set_expand_gray_1_2_4_to_8(png_ptr);
-		if (png_get_valid(png_ptr, info_ptr,
-			PNG_INFO_tRNS)) png_set_tRNS_to_alpha(png_ptr);
-
-		// now let's also avoid 16 bits for now, to stay always at 8 bits per component
-		if (bit_depth == 16)
-			png_set_strip_16(png_ptr);
-
-		// and let's deal with random < 8 packing, so we're surely in 8 bits now
-		if (bit_depth < 8)
-			png_set_packing(png_ptr);
+		info_ptr = SetupReadAndCreateInfoStruct(png_ptr, inPNGStream);
+		ReadInfoAndApplyStandardTransformations(png_ptr, info_ptr);
 
 		// let's update info so now it fits the post transform data
 		png_read_update_info(png_ptr, info_ptr);


### PR DESCRIPTION
## Summary

Three small cleanups in `PNGImageHandler.cpp`, all flagged during the Phase 3.3 audit pass. No behaviour change.

1. **Dead local removed** — `PDFImageXObjectList listOfImages` at the top of `CreateImageXObjectForData` was declared but never used. Outer caller (`CreateFormXObjectForPNGStream`) has its own list; this was a copy-paste leftover.

2. **`png_set_keep_unknown_chunks(PNG_HANDLE_CHUNK_ALWAYS, NULL, 0)` removed** at both call sites (one was annotated `// Gal: is this important?`). Grep confirms no `png_get_unknown_chunks` call site anywhere in the codebase — libpng was retaining unknown chunks for the duration of the read but we never read them back, so the directive only added memory overhead. Default libpng behaviour without the call is to skip unknown chunks during read, which is what we want. Closes one of the two DoS-cap items flagged in the audit.

3. **Duplicated libpng init/transform sequence factored** out of `CreateFormXObjectForPNGStream` and `ReadImageInfo` into three free helpers:
   - `CreatePngReadStruct` — wraps `png_create_read_struct` with our error/warning handlers. Returns NULL on allocation failure; can't longjmp.
   - `SetupReadAndCreateInfoStruct` — pairs the read struct with our `IByteReaderWithPosition` I/O, allocates the info struct. May longjmp via `png_error` on OOM, so the caller must have `setjmp` installed first.
   - `ReadInfoAndApplyStandardTransformations` — runs `png_read_info` and applies our standard normalisations (palette → RGB, gray < 8 → 8, tRNS → alpha, strip 16, set_packing < 8). May longjmp.

   `setjmp(png_jmpbuf(png_ptr))` stays inline in each caller. The `jmp_buf` is owned by `png_ptr`, but the longjmp target frame must outlive the jump — so `setjmp` can't be wrapped in a helper. Helpers that *may* longjmp run after the caller installs `setjmp`, which is fine: control restores to the caller's frame on longjmp, and the helper's frame is unwound normally as part of the stack restore.

## Test plan

- [x] `cmake --build .` clean (only pre-existing sprintf/unused-include warnings)
- [x] `ctest -C Release` — all 101 tests pass
- [x] `ctest -R "PNG|Png"` — PNGImageTest + FuzzTest_InvalidPNGColumns pass

Net -31 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)