### PR TITLE
cleanup: NULL-check catalogDict before GetIterator in modified-doc catalog write

### DIFF
--- a/PDFWriter/DocumentContext.cpp
+++ b/PDFWriter/DocumentContext.cpp
@@ -2456,12 +2456,13 @@ public:
 		// now write all info that's not overriden by this implementation
 		PDFParser* modifiedDocumentParser = mModifiedDocumentCopyingContext->GetSourceDocumentParser();
 		PDFObjectCastPtr<PDFDictionary> catalogDict(modifiedDocumentParser->QueryDictionaryObject(modifiedDocumentParser->GetTrailer(),"Root"));
-		MapIterator<PDFNameToPDFObjectMap>  catalogDictIt = catalogDict->GetIterator();
 
 		if (!catalogDict) {
 			// no catalog. not cool but possible. call quits
 			return eSuccess;
 		}
+
+		MapIterator<PDFNameToPDFObjectMap>  catalogDictIt = catalogDict->GetIterator();
 
 		// copy all elements that were not already written. in other words - overriden
 		while (catalogDictIt.MoveNext())


### PR DESCRIPTION
## Summary

Move a dead defensive NULL check ahead of the deref it was supposed to guard, in `ModifiedDocCatalogWriterExtension::OnCatalogWrite` (`DocumentContext.cpp`).

Original code:

```cpp
PDFObjectCastPtr<PDFDictionary> catalogDict(...QueryDictionaryObject(...,"Root"));
MapIterator<PDFNameToPDFObjectMap>  catalogDictIt = catalogDict->GetIterator();  // <- deref

if (!catalogDict) {
    // no catalog. not cool but possible. call quits
    return eSuccess;                                                              // <- dead guard
}
```

`PDFObjectCast<PDFDictionary>` can structurally return NULL when the source PDF's `/Root` doesn't resolve to a dictionary. The guard on line 2461 was clearly there for that case, but the `GetIterator()` call on line 2459 derefs `catalogDict` before the guard runs — so any NULL would crash before being checked.

The fix is a three-line reorder: NULL-check first, then `GetIterator()`.

## Why this is a cleanup, not a vuln fix

In current code the cast cannot return NULL. `PDFParser::ParsePagesObjectIDs:904-910` (called unconditionally inside `StartPDFParsing`) already rejects any source PDF whose `/Root` resolves to a non-dictionary, so a modified-document workflow never reaches `OnCatalogWrite` with a non-dict catalog. The defensive branch is unreachable today.

But it's worth fixing because:
- The "NULL check after deref" pattern is a real code smell — static analyzers flag it, and reviewers reading the code (as I was during the Phase 4.1 audit) reasonably expect a defensive check to actually defend.
- The check matches the code's stated intent (`// no catalog. not cool but possible. call quits`).
- Keeps the code robust if parser strictness ever loosens — e.g. an undecryptable-encrypted source path where `ParsePagesObjectIDs` is skipped (`PDFParser.cpp:130-138`) could in principle reach this code with an unvalidated catalog.

Three-line diff, no behavior change.

## Test plan

- [x] All 101 existing tests pass locally on Release.
- [x] No regression test added — the fix is unreachable through any synthesizable PDF (parser blocks every input that would exercise the NULL path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)