### PR TITLE
fix: return actual status from WriteDictionaryObject on copy failure

### DIFF
--- a/PDFWriter/PDFDocumentHandler.cpp
+++ b/PDFWriter/PDFDocumentHandler.cpp
@@ -2047,7 +2047,7 @@ EStatusCode PDFDocumentHandler::WriteDictionaryObject(PDFDictionary* inDictionar
 		return mObjectsContext->EndDictionary(dictionary);
 	}
 	else
-		return PDFHummus::eSuccess;
+		return status;
 }
 
 EStatusCode PDFDocumentHandler::WriteStreamObject(PDFStreamInput* inStream, IObjectWritePolicy* inWritePolicy)


### PR DESCRIPTION
## Summary

`PDFDocumentHandler::WriteDictionaryObject` correctly tracks failure status through its per-entry loop, but then discards that status on the error branch and tells the caller everything succeeded:

```cpp
if(PDFHummus::eSuccess == status)
{
    return mObjectsContext->EndDictionary(dictionary);
}
else
    return PDFHummus::eSuccess;  // <- reports success on failure
```

One-line change: `return status` instead of `return PDFHummus::eSuccess`.

## Impact

When copying a dictionary fails mid-way (e.g. a nested stream value can't be read by the source parser, or the output stream fails), the caller is told the copy succeeded. Combined with the fact that `EndDictionary` is not called on the error branch, this silently leaves `ObjectsContext` in a half-written-dictionary state and produces a malformed output PDF that looks healthy from the writer's return code.

Found during Phase 4.1 copy/merge audit; framed as a correctness fix, not a security-class memory-safety bug.

## Test plan

- [x] All 101 existing tests pass on Release.
- [x] No new regression test — triggering the failure path requires unusual write- or stream-read failures (specific filter-chain mishandling, output-stream errors) that aren't exercised by the current happy-path suite. The success branch (the `EndDictionary` call) is unchanged, so all currently-passing PDFs continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)