### PR TITLE
fix: delete streamReader on dictionary-write failure in WriteStreamObject

### DIFF
--- a/PDFWriter/PDFDocumentHandler.cpp
+++ b/PDFWriter/PDFDocumentHandler.cpp
@@ -2092,6 +2092,7 @@ EStatusCode PDFDocumentHandler::WriteStreamObject(PDFStreamInput* inStream, IObj
 	if (status != PDFHummus::eSuccess)
 	{
 		TRACE_LOG("PDFDocumentHandler::WriteStreamObject, failed to write stream dictionary");
+		delete streamReader;
 		return PDFHummus::eFailure;
 	}
 


### PR DESCRIPTION
## Summary

`WriteStreamObject` allocates a `streamReader` (`IByteReader*`) early via `StartReadingFromStream` / `StartReadingFromStreamForPlainCopying`, then writes the stream's dictionary, then copies the stream body. The later error branches (`CopyToOutputStream` failure at line ~2104) correctly `delete streamReader` before returning. The earlier branch (dictionary-write failure at line ~2092) didn't — leaking the reader.

One-line fix: add `delete streamReader;` to the dictionary-write failure branch.

## Leak conditions

- One of the source-side stream open paths succeeded (`streamReader != NULL`).
- AND a `WriteKey` or `WriteObjectByType` call in the dictionary loop subsequently failed (e.g. nested stream-write error, output-stream error).

The `streamReader == NULL` → `status = eFailure` → enter-same-branch path is leak-free already because `delete` on `NULL` is a no-op, so the unconditional `delete streamReader` is safe regardless of which failure led here. It also mirrors the existing cleanup in the `CopyToOutputStream` branch.

Resource hygiene fix surfaced during the Phase 4.1 copy/merge audit. Not memory-safety, not security severity.

## Test plan

- [x] All 101 existing tests pass on Release.
- [x] No new regression test — triggering needs both the source stream to be openable AND the dictionary write to fail mid-copy, an unusual combination not covered by the happy-path suite. The success path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)