### PR TITLE
fix: clear mMorePageEndTasks in Cleanup + propagate WriteResourcesDictionary status

### DIFF
--- a/PDFWriter/DocumentContext.cpp
+++ b/PDFWriter/DocumentContext.cpp
@@ -1135,7 +1135,9 @@ EStatusCode DocumentContext::EndFormXObjectNoRelease(PDFFormXObject* inFormXObje
 	status = mObjectsContext->StartNewIndirectObject(inFormXObject->GetResourcesDictionaryObjectID());
 	if(status != eSuccess)
 		return status;
-	WriteResourcesDictionary(inFormXObject->GetResourcesDictionary());
+	status = WriteResourcesDictionary(inFormXObject->GetResourcesDictionary());
+	if(status != eSuccess)
+		return status;
 	mObjectsContext->EndIndirectObject();
 
     // now write writing tasks
@@ -1193,7 +1195,10 @@ EStatusCode DocumentContext::EndTiledPattern(PDFTiledPattern* inTiledPattern)
 	if(status != eSuccess) {
 		return status;
 	}
-	WriteResourcesDictionary(inTiledPattern->GetResourcesDictionary());
+	status = WriteResourcesDictionary(inTiledPattern->GetResourcesDictionary());
+	if(status != eSuccess) {
+		return status;
+	}
 	mObjectsContext->EndIndirectObject();
 
 
@@ -1312,6 +1317,8 @@ EStatusCode DocumentContext::WriteResourcesDictionary(ResourcesDictionary& inRes
 
 		// Color space
         status = WriteResourceDictionary(&inResourcesDictionary,resourcesContext,scColorSpaces,inResourcesDictionary.GetColorSpacesIterator());
+        if(status!=eSuccess)
+            break;
 
 		// Patterns
         status = WriteResourceDictionary(&inResourcesDictionary,resourcesContext,scPatterns,inResourcesDictionary.GetPatternsIterator());
@@ -1387,7 +1394,6 @@ EStatusCode DocumentContext::WriteResourceDictionary(ResourcesDictionary* inReso
             }
 
             IDocumentContextExtenderSet::iterator it = mExtenders.begin();
-            EStatusCode status = PDFHummus::eSuccess;
             for(; it != mExtenders.end() && eSuccess == status; ++it)
             {
                 status = (*it)->OnResourceDictionaryWrite(resourceContext,inResourceDictionaryLabel,mObjectsContext,this);
@@ -1826,8 +1832,8 @@ EStatusCode DocumentContext::WritePageTreeState(ObjectsContext* inStateWriter,Ob
 	{
 		ObjectIDTypeList::iterator it = kidsObjectIDs.begin();
 		int i = 0;
-		for(;i < inPageTree->GetNodesCount();++i,++it)
-			WritePageTreeState(inStateWriter,*it,inPageTree->GetPageTreeChild(i));
+		for(;i < inPageTree->GetNodesCount() && eSuccess == status;++i,++it)
+			status = WritePageTreeState(inStateWriter,*it,inPageTree->GetPageTreeChild(i));
 	}
 
 	if(inPageTree == mCatalogInformation.GetCurrentPageTreeNode())
@@ -2322,7 +2328,7 @@ void DocumentContext::Cleanup()
 				delete *itEndWritingTasks;
 
 		}
-		mMoreFormEndTasks.clear();		
+		mMorePageEndTasks.clear();
 	}
 
 


### PR DESCRIPTION
## Summary

Phase 4.2 writer-side memory-management audit (`CatalogInformation.cpp`, `PageContentContext.cpp`, non-copy methods in `DocumentContext.cpp`).

**Memory-safety fix:**
- `DocumentContext::Cleanup` iterated `mMorePageEndTasks` and `delete`'d its task pointers but called `mMoreFormEndTasks.clear()` (copy-paste typo) instead of clearing the map it had just drained. Subsequent `Cleanup` invocations — which always happen via `~PDFWriter` → `PDFWriter::Cleanup` → `DocumentContext::Cleanup`, then `~DocumentContext` → `Cleanup` — re-iterated the still-populated map and double-freed any `IObjectEndWritingTask` registered via the `IObjectEndWritingTask` overload of `RegisterPageEndWritingTask` for a page never delivered through `WritePage`.

**Correctness cleanups folded in (spotted while auditing the file):**
- `WriteResourcesDictionary` was missing `if(status != eSuccess) break;` after the Color spaces step, so a failure there was silently overwritten by the Patterns step.
- `WriteResourceDictionary` declared a fresh `EStatusCode status = eSuccess;` inside the loop body that shadowed the outer `status`, so extender failures never reached the caller.
- `EndFormXObjectNoRelease` and `EndTiledPattern` ignored the return value of `WriteResourcesDictionary` entirely.
- `WritePageTreeState` ignored its own recursive return.

## Test plan
- [x] `cmake --build build --config Release` — clean.
- [x] `ctest -C Release` — 102/102 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)