### PR TITLE
fix: bound Trace::TraceToLog output via vsnprintf

### DIFF
--- a/PDFWriter/Trace.cpp
+++ b/PDFWriter/Trace.cpp
@@ -20,7 +20,6 @@
 */
 #include "Trace.h"
 #include "Log.h"
-#include "SafeBufferMacrosDefs.h"
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -87,7 +86,7 @@ void Trace::TraceToLog(const char* inFormat,...)
 		va_list argptr;
 		va_start(argptr, inFormat);
 
-		SAFE_VSPRINTF(mBuffer, MAX_TRACE_SIZE,inFormat,argptr);
+		vsnprintf(mBuffer, MAX_TRACE_SIZE, inFormat, argptr);
 		va_end(argptr);
 
 		mLog->LogEntry(std::string(mBuffer));
@@ -106,7 +105,7 @@ void Trace::TraceToLog(const char* inFormat,va_list inList)
 				mLog = new Log(mLogFilePath,mPlaceUTF8Bom);
 		}
 
-		SAFE_VSPRINTF(mBuffer, MAX_TRACE_SIZE,inFormat,inList);
+		vsnprintf(mBuffer, MAX_TRACE_SIZE, inFormat, inList);
 
 		mLog->LogEntry(std::string(mBuffer));
 	}


### PR DESCRIPTION
## Summary

Phase 4.3 I/O-path audit found that on non-Windows non-MinGW (i.e. macOS/Linux), `SAFE_VSPRINTF` in `SafeBufferMacrosDefs.h:92` expands to plain `vsprintf(BUFFER, FORMAT, ARGLIST)` — `BUFFER_SIZE` is silently dropped. The `SAFE_*` macros were a portability shim around Windows' `sprintf_s` API; the size parameter existed for the Windows branch, not as a bounds-checking guarantee on POSIX. That contract is fine for the ~14 size-bounded-by-construction call sites, but `Trace::TraceToLog` is variadic, fills a 50 KB BSS buffer, and gets fed parser-derived tokens via `%s` (e.g. `Type1Input.cpp:247-688`'s `"bad numeric value '%s'"` messages). A malformed input producing a sufficiently long token writes past the buffer.

Fix: call `vsnprintf` inline from `Trace.cpp` so the size is actually enforced. The macro indirection stays as documented; the bug fix lives at the call site that promises bounded output.

## Test plan
- [x] `cmake --build build --config Release` — clean.
- [x] `ctest -C Release` — 102/102 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)