### PR TITLE
fix: reject TIFFs whose declared decoded size dwarfs strip bytecount

### DIFF
--- a/PDFWriter/TIFFImageHandler.cpp
+++ b/PDFWriter/TIFFImageHandler.cpp
@@ -100,6 +100,13 @@ using namespace PDFHummus;
 
 #define PS_UNIT_SIZE	72.0F
 
+/* Upper bound on declared decoded-size to declared compressed-size ratio.
+   Defends against malicious TIFFs that declare huge dimensions but ship a tiny
+   strip payload, which would otherwise inflate buffer allocations to gigabytes
+   on a kilobyte input. Generous headroom over worst-case real codecs
+   (G4 fax ~1000-2000:1) so no legitimate TIFF trips it. */
+#define TIFF_MAX_COMPRESSION_RATIO 10000
+
 /* This type is of PDF color spaces. */
 typedef enum {
 	T2P_CS_BILEVEL = 0x01,	/* Bilevel, black and white */
@@ -2328,6 +2335,36 @@ void TIFFImageHandler::CalculateTiffTileSize(int inTileIndex)
 			else
 				totalSize *= mT2p->tiff_samplesperpixel;
 		}
+		// Cross-check declared decoded tile size against the on-disk bytecount.
+		// Reject sparse-payload tiles whose ratio exceeds any real codec.
+		if(totalSize > 0)
+		{
+			tsize_t_compat* tbc = NULL;
+			if(TIFFGetField(mT2p->input, TIFFTAG_TILEBYTECOUNTS, &tbc) != 0 && tbc != NULL)
+			{
+				uint64_t compressed = static_cast<uint64_t>(tbc[inTileIndex]);
+				if(compressed == 0 ||
+					totalSize / compressed > TIFF_MAX_COMPRESSION_RATIO)
+				{
+					TRACE_LOG4("TIFFImageHandler::CalculateTiffTileSize, "
+						"tile %d declared decoded size %llu vs bytecount %llu exceeds "
+						"the maximum allowed compression ratio %d; rejecting input",
+						inTileIndex,
+						(unsigned long long)totalSize,
+						(unsigned long long)compressed,
+						TIFF_MAX_COMPRESSION_RATIO);
+					totalSize = 0;
+				}
+			}
+			else
+			{
+				TRACE_LOG1("TIFFImageHandler::CalculateTiffTileSize, "
+					"tile %d missing TIFFTAG_TILEBYTECOUNTS; cannot sanity-check "
+					"declared decoded size, rejecting input",
+					inTileIndex);
+				totalSize = 0;
+			}
+		}
 		mT2p->tiff_datasize = static_cast<tsize_t>(totalSize);
 	}
 }
@@ -2850,6 +2887,37 @@ void TIFFImageHandler::CalculateTiffSizeNoTiles()
 				totalSize = 0;
 			else
 				totalSize *= mT2p->tiff_samplesperpixel;
+		}
+		// Cross-check declared decoded size against the sum of per-strip on-disk
+		// bytecounts. Reject sparse-payload TIFFs whose ratio exceeds any real codec.
+		if(totalSize > 0)
+		{
+			tsize_t_compat* sbc = NULL;
+			if(TIFFGetField(mT2p->input, TIFFTAG_STRIPBYTECOUNTS, &sbc) != 0 && sbc != NULL)
+			{
+				uint64_t stripcount = TIFFNumberOfStrips(mT2p->input);
+				uint64_t totalCompressed = 0;
+				for(uint64_t i = 0; i < stripcount; ++i)
+					totalCompressed += static_cast<uint64_t>(sbc[i]);
+				if(totalCompressed == 0 ||
+					totalSize / totalCompressed > TIFF_MAX_COMPRESSION_RATIO)
+				{
+					TRACE_LOG3("TIFFImageHandler::CalculateTiffSizeNoTiles, "
+						"declared decoded size %llu vs strip bytecount sum %llu exceeds "
+						"the maximum allowed compression ratio %d; rejecting input",
+						(unsigned long long)totalSize,
+						(unsigned long long)totalCompressed,
+						TIFF_MAX_COMPRESSION_RATIO);
+					totalSize = 0;
+				}
+			}
+			else
+			{
+				TRACE_LOG("TIFFImageHandler::CalculateTiffSizeNoTiles, "
+					"missing TIFFTAG_STRIPBYTECOUNTS; cannot sanity-check declared "
+					"decoded size, rejecting input");
+				totalSize = 0;
+			}
 		}
 		mT2p->tiff_datasize = static_cast<tsize_t>(totalSize);
 	}

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -82,6 +82,7 @@ create_test_sourcelist (Tests
   SimpleTextUsage.cpp
   TestMeasurementsTest.cpp
   TextUsageBugs.cpp
+  TIFFImageHandlerTest.cpp
   TIFFImageTest.cpp
   TiffSpecialsTest.cpp
   TimerTest.cpp
@@ -112,6 +113,7 @@ add_executable (PDFWriterTesting
     # and test specific additionals
     CFFSyntheticBuilder.cpp
     Type1SyntheticBuilder.cpp
+    TIFFSyntheticBuilder.cpp
     PDFComment.cpp
     PDFCommentWriter.cpp
     AnnotationsWriter.cpp

--- a/PDFWriterTesting/TIFFImageHandlerTest.cpp
+++ b/PDFWriterTesting/TIFFImageHandlerTest.cpp
@@ -1,0 +1,118 @@
+/*
+   Source File : TIFFImageHandlerTest.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+   Unit-style regression tests for TIFFImageHandler against synthetic byte
+   streams. Broader integration coverage with real TIFFs lives in
+   TIFFImageTest.cpp.
+
+*/
+
+#ifndef PDFHUMMUS_NO_TIFF
+
+#include "PDFWriter.h"
+#include "PDFFormXObject.h"
+#include "InputByteArrayStream.h"
+#include "OutputStringBufferStream.h"
+#include "EStatusCode.h"
+
+#include "TIFFSyntheticBuilder.h"
+
+#include <iostream>
+#include <string>
+#include <stdint.h>
+
+using namespace std;
+using namespace PDFHummus;
+
+// ---- CalculateTiffSizeNoTiles cases -----------------------------------------
+
+struct CalculateTiffSizeNoTilesCase {
+    const char* label;
+    uint32_t width;
+    uint32_t length;
+    uint32_t declaredStripByteCount;
+    bool expectRejection;
+};
+
+// Cases for the declared-decoded vs strip-bytecount ratio guard.
+static const CalculateTiffSizeNoTilesCase scCalculateTiffSizeNoTilesCases[] = {
+    // 50000 x 50000 RGB = 7.5 GB decoded vs 5 KB strip → 1.5M:1 ratio, above K=10000.
+    {"SparsePayloadRatioExceedsCap_Rejects", 50000, 50000, 5000, true},
+    // 10 x 10 RGB uncompressed = 300 bytes decoded == 300 bytes strip → 1:1 ratio.
+    {"BalancedRatio_Accepts",                10,    10,    300,  false},
+};
+
+static bool RunCalculateTiffSizeNoTilesCases()
+{
+    const size_t count =
+        sizeof(scCalculateTiffSizeNoTilesCases) /
+        sizeof(scCalculateTiffSizeNoTilesCases[0]);
+
+    for(size_t i = 0; i < count; ++i) {
+        const CalculateTiffSizeNoTilesCase& c = scCalculateTiffSizeNoTilesCases[i];
+
+        // Arrange — synthesize a minimal TIFF with caller-chosen declared
+        // dimensions and declared strip bytecount. Output sinks to a memory
+        // buffer so the test produces no on-disk artifact.
+        PDFWriter writer;
+        OutputStringBufferStream outputSink;
+        if(writer.StartPDFForStream(&outputSink, ePDFVersion13) != eSuccess) {
+            cout << "TIFFImageHandlerTest [CalculateTiffSizeNoTiles::"
+                 << c.label << "]: StartPDFForStream failed" << endl;
+            return false;
+        }
+        string tiff = TIFFSyntheticBuilder::SingleStripRGB(
+            c.width, c.length, c.declaredStripByteCount);
+        InputByteArrayStream stream(
+            reinterpret_cast<IOBasicTypes::Byte*>(&tiff[0]),
+            static_cast<LongFilePositionType>(tiff.size()));
+
+        // Act
+        PDFFormXObject* formXObject =
+            writer.CreateFormXObjectFromTIFFStream(&stream);
+        writer.EndPDFForStream(); // best-effort cleanup; assertion is on the handler
+
+        // Assert — handler returns NULL exactly when the ratio guard fires.
+        bool rejected = (formXObject == NULL);
+        delete formXObject;
+        if(rejected != c.expectRejection) {
+            cout << "TIFFImageHandlerTest [CalculateTiffSizeNoTiles::"
+                 << c.label << "]: expected rejection=" << c.expectRejection
+                 << " but got rejected=" << rejected << endl;
+            return false;
+        }
+    }
+    return true;
+}
+
+// ---- Entry point ------------------------------------------------------------
+
+int TIFFImageHandlerTest(int argc, char* argv[])
+{
+    (void)argc;
+    (void)argv;
+    if(!RunCalculateTiffSizeNoTilesCases()) return 1;
+    return 0;
+}
+
+#else
+
+int TIFFImageHandlerTest(int argc, char* argv[]) { return 0; }
+
+#endif

--- a/PDFWriterTesting/TIFFSyntheticBuilder.cpp
+++ b/PDFWriterTesting/TIFFSyntheticBuilder.cpp
@@ -1,0 +1,136 @@
+/*
+   Source File : TIFFSyntheticBuilder.cpp
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+*/
+#include "TIFFSyntheticBuilder.h"
+
+#include <string>
+#include <stdint.h>
+
+using std::string;
+
+static void AppendU16LE(string& ioOut, uint16_t inValue)
+{
+    ioOut.push_back(static_cast<char>(inValue & 0xFF));
+    ioOut.push_back(static_cast<char>((inValue >> 8) & 0xFF));
+}
+
+static void AppendU32LE(string& ioOut, uint32_t inValue)
+{
+    ioOut.push_back(static_cast<char>(inValue & 0xFF));
+    ioOut.push_back(static_cast<char>((inValue >> 8) & 0xFF));
+    ioOut.push_back(static_cast<char>((inValue >> 16) & 0xFF));
+    ioOut.push_back(static_cast<char>((inValue >> 24) & 0xFF));
+}
+
+// TIFF type codes (TIFF 6.0 §2)
+static const uint16_t kTypeShort    = 3;
+static const uint16_t kTypeLong     = 4;
+static const uint16_t kTypeRational = 5;
+
+// TIFF tag codes
+static const uint16_t kTagImageWidth                = 256;
+static const uint16_t kTagImageLength               = 257;
+static const uint16_t kTagBitsPerSample             = 258;
+static const uint16_t kTagCompression               = 259;
+static const uint16_t kTagPhotometricInterpretation = 262;
+static const uint16_t kTagStripOffsets              = 273;
+static const uint16_t kTagSamplesPerPixel           = 277;
+static const uint16_t kTagRowsPerStrip              = 278;
+static const uint16_t kTagStripByteCounts           = 279;
+static const uint16_t kTagXResolution               = 282;
+static const uint16_t kTagYResolution               = 283;
+static const uint16_t kTagResolutionUnit            = 296;
+
+static void AppendIFDEntry(string& ioOut,
+                           uint16_t inTag,
+                           uint16_t inType,
+                           uint32_t inCount,
+                           uint32_t inValueOrOffset)
+{
+    AppendU16LE(ioOut, inTag);
+    AppendU16LE(ioOut, inType);
+    AppendU32LE(ioOut, inCount);
+    AppendU32LE(ioOut, inValueOrOffset);
+}
+
+string TIFFSyntheticBuilder::SingleStripRGB(uint32_t inWidth,
+                                            uint32_t inLength,
+                                            uint32_t inDeclaredStripByteCount)
+{
+    // Layout (little-endian, 12-entry IFD):
+    //   [0..7]       header
+    //   [8..157]     IFD (2 + 12*12 + 4 = 150 bytes)
+    //   [158..163]   BitsPerSample external data (3 SHORTs)
+    //   [164..171]   XResolution external data (RATIONAL = 2 LONGs)
+    //   [172..179]   YResolution external data (RATIONAL = 2 LONGs)
+    //   [180..]      strip payload
+    const uint32_t kIFDOffset             = 8;
+    const uint32_t kBitsPerSampleDataOff  = 158;
+    const uint32_t kXResolutionDataOff    = 164;
+    const uint32_t kYResolutionDataOff    = 172;
+    const uint32_t kStripDataOff          = 180;
+
+    string out;
+    out.reserve(kStripDataOff + inDeclaredStripByteCount);
+
+    // Header
+    out.push_back('I');
+    out.push_back('I');
+    AppendU16LE(out, 42);
+    AppendU32LE(out, kIFDOffset);
+
+    // IFD entry count
+    AppendU16LE(out, 12);
+
+    // Entries (must be sorted ascending by tag)
+    AppendIFDEntry(out, kTagImageWidth,                kTypeLong,     1, inWidth);
+    AppendIFDEntry(out, kTagImageLength,               kTypeLong,     1, inLength);
+    AppendIFDEntry(out, kTagBitsPerSample,             kTypeShort,    3, kBitsPerSampleDataOff);
+    AppendIFDEntry(out, kTagCompression,               kTypeShort,    1, 1);   // none
+    AppendIFDEntry(out, kTagPhotometricInterpretation, kTypeShort,    1, 2);   // RGB
+    AppendIFDEntry(out, kTagStripOffsets,              kTypeLong,     1, kStripDataOff);
+    AppendIFDEntry(out, kTagSamplesPerPixel,           kTypeShort,    1, 3);
+    AppendIFDEntry(out, kTagRowsPerStrip,              kTypeLong,     1, inLength);
+    AppendIFDEntry(out, kTagStripByteCounts,           kTypeLong,     1, inDeclaredStripByteCount);
+    AppendIFDEntry(out, kTagXResolution,               kTypeRational, 1, kXResolutionDataOff);
+    AppendIFDEntry(out, kTagYResolution,               kTypeRational, 1, kYResolutionDataOff);
+    AppendIFDEntry(out, kTagResolutionUnit,            kTypeShort,    1, 2);   // inch
+
+    // Next IFD offset (none)
+    AppendU32LE(out, 0);
+
+    // External data: BitsPerSample {8, 8, 8}
+    AppendU16LE(out, 8);
+    AppendU16LE(out, 8);
+    AppendU16LE(out, 8);
+
+    // External data: XResolution = 72/1
+    AppendU32LE(out, 72);
+    AppendU32LE(out, 1);
+
+    // External data: YResolution = 72/1
+    AppendU32LE(out, 72);
+    AppendU32LE(out, 1);
+
+    // Strip payload: exactly inDeclaredStripByteCount zeros
+    out.append(inDeclaredStripByteCount, '\0');
+
+    return out;
+}

--- a/PDFWriterTesting/TIFFSyntheticBuilder.h
+++ b/PDFWriterTesting/TIFFSyntheticBuilder.h
@@ -1,0 +1,38 @@
+/*
+   Source File : TIFFSyntheticBuilder.h
+
+
+   Copyright 2026 Gal Kahana PDFWriter
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+*/
+#pragma once
+
+#include <string>
+#include <stdint.h>
+
+// Test-only helper for synthesizing minimal TIFF byte streams in-process so
+// regression tests for TIFFImageHandler can run without binary fixtures.
+class TIFFSyntheticBuilder
+{
+public:
+    // Single-strip uncompressed RGB TIFF with caller-chosen declared dimensions
+    // and a caller-chosen declared StripByteCount. Strip payload on disk is
+    // exactly inDeclaredStripByteCount bytes of zero. Use to construct sparse
+    // attack shapes: huge declared decoded size vs tiny strip bytecount.
+    static std::string SingleStripRGB(uint32_t inWidth,
+                                      uint32_t inLength,
+                                      uint32_t inDeclaredStripByteCount);
+};


### PR DESCRIPTION
## Summary

Cross-format memory-budget item #1 (TIFF sparse-payload). A malicious TIFF can declare 50000×50000 RGB (7.5 GB decoded) while shipping a 5 KB strip — `_TIFFmalloc` then allocates gigabytes on a kilobyte input. App-side file-size caps don't help because the attack file fits under any reasonable cap.

Add a consistency check in `CalculateTiffSizeNoTiles` and `CalculateTiffTileSize`: compare declared decoded size against the sum of on-disk strip/tile bytecounts. Reject if the implied ratio exceeds `TIFF_MAX_COMPRESSION_RATIO=10000` — well above worst-case real codecs (G4 fax ~1000–2000:1) so no legitimate TIFF trips it. TRACE_LOG explains the rejection. Failure path reuses the existing `tiff_datasize<=0` guard downstream.

Framing: not a memory cap (which would rot as hardware grows) but a consistency check between two IFD header fields. Compression-ratio physics doesn't change over time.

## Test plan
- [x] `cmake --build` clean.
- [x] `ctest -C Release` — 103/103 pass.
- [x] New `TIFFImageHandlerTest` covers both rejection (sparse) and acceptance (balanced) paths via synthetic input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)