### PR TITLE
build: add PDFHUMMUS_SANITIZER opt-in build option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #all the binaries
-BUILD
+build/
+build-sanitizer/
 # Compiled source #
 ###################
 *.com

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,18 @@ option(PDFHUMMUS_NO_TIFF "Whether to drop TIFF Images support (will not use LibT
 option(PDFHUMMUS_NO_PNG "Whether to drop PNG Images support (will not use LibPng)" )
 option(PDFHUMMUS_NO_OPENSSL "Whether to drop OpenSSL Usage, and therefore PDF2.0 encryption support (will not allow encryption or decryption of PDF2.0 files)" )
 
+# Optional sanitizer build (requires clang). Accepts comma-separated -fsanitize= values:
+# address, undefined, address,undefined, thread, memory. Empty (default) = no sanitizer.
+# Flags are applied globally so they also instrument bundled dependencies (zlib, freetype, libpng, libjpeg, libtiff, libaesgm).
+# See wiki: Sanitizer-Builds-Of-PDFWriter
+set(PDFHUMMUS_SANITIZER "" CACHE STRING "Build with the given clang sanitizer (e.g. address, undefined, address,undefined). Empty = off.")
+
+if(PDFHUMMUS_SANITIZER)
+    message(STATUS "Building with sanitizer: ${PDFHUMMUS_SANITIZER}")
+    add_compile_options(-fsanitize=${PDFHUMMUS_SANITIZER} -fno-omit-frame-pointer -g)
+    add_link_options(-fsanitize=${PDFHUMMUS_SANITIZER})
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # OpenSSL detection and AES implementation choice - done early to inform all subsequent logic


### PR DESCRIPTION
## Summary
- Adds `PDFHUMMUS_SANITIZER` CMake cache string for opt-in clang-sanitizer builds. Accepts `address`, `undefined`, `address,undefined`, `thread`, `memory`. Default empty (off). Flags applied globally so bundled deps (zlib/freetype/libpng/libjpeg/libtiff/libaesgm) are instrumented too.
- Mirrors the `BUILD_FUZZING_HARNESS` shape — opt-in build target for occasional auditing, not gating CI.
- Fixes `.gitignore`: `BUILD` was only matching `build/` on case-insensitive filesystems. Replaced with explicit `build/` and `build-sanitizer/` entries so Linux contributors get correct behavior too.

## Why
First step of Phase 5 tooling (the broader vulnerability-finding project). Subsequent phases will add a targeted audit skill and additional fuzz harnesses. This piece is the foundation — a knob maintainers can flip to re-run the test suite under ASan/UBSan and surface anything the manual audit missed.

## Verification
- Configure: `cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DPDFHUMMUS_SANITIZER=address,undefined ..`
- Build: clean, only pre-existing `sprintf` deprecation warning in `PDFDateTest.cpp`
- Test: **103/103 ctest tests pass** on macOS arm64 / AppleClang 21 under ASan+UBSan, including the 9 `FuzzTest_*` regression tests that feed historically-crashing PDFs
- Sanitizer instrumentation confirmed real: 17420 `__asan`/`__ubsan` symbol references in the test binary + `libclang_rt.asan_osx_dynamic.dylib` linked

## Wiki
A draft of a wiki page documenting the option (matching the style of [Fuzz-Testing-Of-PDFParser](https://github.com/galkahana/PDF-Writer/wiki/Fuzz-Testing-Of-PDFParser)) is ready to be copied onto the wiki as `Sanitizer-Builds-Of-PDFWriter`. The CMakeLists comment references that page name.

## Test plan
- [ ] Reviewer can configure with `-DPDFHUMMUS_SANITIZER=address,undefined` (clang required) and `ctest` passes
- [ ] Reviewer confirms default build (no `PDFHUMMUS_SANITIZER` flag) is unaffected
- [ ] `.gitignore` change doesn't break existing contributors' workflows — anyone using `build/` as the build dir is unaffected