### PR TITLE
build: instrument PDFWriter + bundled deps when fuzzing is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,20 @@ if(PDFHUMMUS_SANITIZER)
     add_link_options(-fsanitize=${PDFHUMMUS_SANITIZER})
 endif()
 
+# Fuzzing harness build (requires LLVM clang + lld + libFuzzer runtime).
+# Declared up here (before the dependency subdirectories) so the instrumentation
+# flag flows into PDFWriter and every bundled dep (zlib, freetype, libpng,
+# libjpeg, libtiff, libaesgm). Without this, libFuzzer only sees ~5 edges
+# (the harness body) and coverage-guided exploration is effectively off.
+# See wiki: Fuzz-Testing
+option(BUILD_FUZZING_HARNESS "Build the fuzzing harnesses, requires LLVM's clang + lld")
+
+if(BUILD_FUZZING_HARNESS)
+    message(STATUS "Building with fuzzing instrumentation: -fsanitize=fuzzer-no-link,address")
+    add_compile_options(-fsanitize=fuzzer-no-link,address -fno-omit-frame-pointer -g -O2)
+    add_link_options(-fsanitize=address)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # OpenSSL detection and AES implementation choice - done early to inform all subsequent logic
@@ -195,9 +209,8 @@ if(PROJECT_IS_TOP_LEVEL AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/PDFWriterTesting)
     # avoid installing the testing lib altogether when included in another project.
     # it's annoying when in parent all, and more annoying to then get the tests added
     # to the parent project ctest.
-
-    # option specific for testing
-    option(BUILD_FUZZING_HARNESS "Build the fuzzing harness, requires LLVM's clang")
+    # BUILD_FUZZING_HARNESS is declared near the top of this file so its
+    # instrumentation flag reaches the bundled-dep subdirectory builds.
 
     enable_testing()
     ADD_SUBDIRECTORY(PDFWriterTesting)

--- a/PDFWriterTesting/CMakeLists.txt
+++ b/PDFWriterTesting/CMakeLists.txt
@@ -146,6 +146,10 @@ endforeach ()
 # fuzz testing with fuzzing harness
 # Each harness is a separate libFuzzer entry point targeting one parser/decoder surface.
 # Source files are named <Subject>FuzzingHarness.cpp and live next to this CMakeLists.
+# Instrumentation (-fsanitize=fuzzer-no-link,address) is applied globally in the
+# top-level CMakeLists.txt so PDFWriter and bundled deps are instrumented too;
+# here we only add the runtime-link flag (-fsanitize=fuzzer) to the harness
+# binaries themselves so they pull in libFuzzer's main + dispatch.
 if(BUILD_FUZZING_HARNESS)
     set(FUZZING_HARNESSES
         PDFParserFuzzingHarness
@@ -156,8 +160,8 @@ if(BUILD_FUZZING_HARNESS)
     endif()
     foreach(harness ${FUZZING_HARNESSES})
         add_executable(${harness} ${harness}.cpp)
-        target_compile_options(${harness} PRIVATE -fsanitize=fuzzer,address -g -O2)
-        target_link_libraries(${harness} PDFWriter -O2 -fsanitize=fuzzer,address -fuse-ld=lld)
+        target_link_libraries(${harness} PDFWriter)
+        target_link_options(${harness} PRIVATE -fsanitize=fuzzer -fuse-ld=lld)
     endforeach()
 endif()
 


### PR DESCRIPTION
## Summary
Fixes the latent issue called out in #405's PR description: `BUILD_FUZZING_HARNESS=ON` instrumented only the harness's own translation unit, not the library or bundled deps. libFuzzer reported only ~5 inline 8-bit counters per harness (the harness body), so coverage-guided exploration was effectively off across all existing harnesses.

## Root cause
In the top-level `CMakeLists.txt`, `option(BUILD_FUZZING_HARNESS ...)` was declared **inside** the `if(PROJECT_IS_TOP_LEVEL AND EXISTS PDFWriterTesting)` block near the end of the file — well after every `ADD_SUBDIRECTORY` for `PDFWriter` and the bundled deps had already configured. By the time CMake processed the harness target's compile flags, the library and deps were locked in with their default (uninstrumented) configuration.

Compare with `PDFHUMMUS_SANITIZER` at line 20: declared *before* the subdirectory adds, which is precisely why that flag does instrument bundled deps.

## Fix
1. Move `option(BUILD_FUZZING_HARNESS ...)` to the top of the top-level `CMakeLists.txt`, alongside `PDFHUMMUS_SANITIZER`
2. Add a global flag block that fires before the subdirectory adds:
   ```cmake
   if(BUILD_FUZZING_HARNESS)
       add_compile_options(-fsanitize=fuzzer-no-link,address -fno-omit-frame-pointer -g -O2)
       add_link_options(-fsanitize=address)
   endif()
   ```
   `-fsanitize=fuzzer-no-link` enables SanitizerCoverage instrumentation without linking the libFuzzer runtime (which expects an `LLVMFuzzerTestOneInput` entry point that only the harness binaries have).
3. In `PDFWriterTesting/CMakeLists.txt`, drop the now-redundant target-level compile options (they're inherited from the global add_compile_options) and use `target_link_options` to add `-fsanitize=fuzzer` (with runtime) + `-fuse-ld=lld` on the harness binaries themselves.

## Verification (macOS, brew llvm + lld)
Local fuzz-smoke results, before vs after:

| Harness | Edges (before → after) | Initial seed coverage (before → after) |
|---|---|---|
| `PDFParserFuzzingHarness` | 5 → **11,489** | 23 → **2,791** |
| `JPEGImageParserFuzzingHarness` | 5 → **562** | 3 → **72** |
| `TIFFImageHandlerFuzzingHarness` | 5 → **81,815** | — |

The TIFF count is highest because it goes through the full stack: PDFWriter → bundled libtiff → libjpeg → zlib, all now instrumented.

JPEG with the `jpeg.dict` from #405 now produces real results: **2,100 new corpus units added in 15 seconds** (was 17 in 60s previously). Coverage-guided exploration is finally on.

Default build (`BUILD_FUZZING_HARNESS=OFF`): fresh-dir configure + build clean. No effect on the standard build path.

## Composes with PDFHUMMUS_SANITIZER
Both touch global flags. Setting both — e.g. `-DBUILD_FUZZING_HARNESS=ON -DPDFHUMMUS_SANITIZER=undefined` — composes cleanly: clang accepts the union and the harness gets fuzzer + ASan + UBSan all stacked.

## Test plan
- [ ] Reviewer can `-DBUILD_FUZZING_HARNESS=ON` build with LLVM clang + lld, and the libFuzzer startup line for any harness shows a counter count in the thousands (not 5)
- [ ] `./PDFParserFuzzingHarness Materials/fuzzing/MinimalFuzzingCorpus` shows libFuzzer expanding the corpus over time (the `NEW` lines)
- [ ] Default build (`BUILD_FUZZING_HARNESS=OFF`) builds cleanly and `ctest` still passes
- [ ] Composed build `-DBUILD_FUZZING_HARNESS=ON -DPDFHUMMUS_SANITIZER=undefined` builds and runs (compose smoke)