### PR TITLE
add ability to add font by buffer (buffer is copied)

### DIFF
--- a/PDFWriter/CFFEmbeddedFontWriter.cpp
+++ b/PDFWriter/CFFEmbeddedFontWriter.cpp
@@ -139,14 +139,23 @@ EStatusCode CFFEmbeddedFontWriter::CreateCFFSubset(
 	do
 	{
 
-		status = mOpenTypeFile.OpenFile(inFontInfo.GetFontFilePath());
-		if(status != PDFHummus::eSuccess)
+		if(inFontInfo.IsMemoryFont())
 		{
-			TRACE_LOG1("CFFEmbeddedFontWriter::CreateCFFSubset, cannot open type font file at %s",inFontInfo.GetFontFilePath().c_str());
-			break;
+			mMemoryFontStream.Assign(inFontInfo.GetFontBuffer(), inFontInfo.GetFontBufferLength());
+			mFontStream = &mMemoryFontStream;
+		}
+		else
+		{
+			status = mOpenTypeFile.OpenFile(inFontInfo.GetFontFilePath());
+			if(status != PDFHummus::eSuccess)
+			{
+				TRACE_LOG1("CFFEmbeddedFontWriter::CreateCFFSubset, cannot open type font file at %s",inFontInfo.GetFontFilePath().c_str());
+				break;
+			}
+			mFontStream = mOpenTypeFile.GetInputStream();
 		}
 
-		status = mOpenTypeInput.ReadOpenTypeFile(mOpenTypeFile.GetInputStream(),(unsigned short)inFontInfo.GetFontIndex());
+		status = mOpenTypeInput.ReadOpenTypeFile(mFontStream,(unsigned short)inFontInfo.GetFontIndex());
 		if(status != PDFHummus::eSuccess)
 		{
 			TRACE_LOG("CFFEmbeddedFontWriter::CreateCFFSubset, failed to read true type file");
@@ -293,8 +302,8 @@ EStatusCode CFFEmbeddedFontWriter::WriteCFFHeader()
 	 // i'll probably just set it to something.
 	
 	OutputStreamTraits streamCopier(&mFontFileStream);
-	mOpenTypeFile.GetInputStream()->SetPosition(mOpenTypeInput.mCFF.mCFFOffset);
-	return streamCopier.CopyToOutputStream(mOpenTypeFile.GetInputStream(),mOpenTypeInput.mCFF.mHeader.hdrSize);
+	mFontStream->SetPosition(mOpenTypeInput.mCFF.mCFFOffset);
+	return streamCopier.CopyToOutputStream(mFontStream,mOpenTypeInput.mCFF.mHeader.hdrSize);
 }
 
 EStatusCode CFFEmbeddedFontWriter::WriteName(const std::string& inSubsetFontName)
@@ -492,8 +501,8 @@ EStatusCode CFFEmbeddedFontWriter::WriteStringIndex()
 		// starting position is equal to the strings end position. hence length is...
 
 		OutputStreamTraits streamCopier(&mFontFileStream);
-		mOpenTypeFile.GetInputStream()->SetPosition(mOpenTypeInput.mCFF.mCFFOffset + mOpenTypeInput.mCFF.mStringIndexPosition);
-		return streamCopier.CopyToOutputStream(mOpenTypeFile.GetInputStream(),
+		mFontStream->SetPosition(mOpenTypeInput.mCFF.mCFFOffset + mOpenTypeInput.mCFF.mStringIndexPosition);
+		return streamCopier.CopyToOutputStream(mFontStream,
 												(LongBufferSizeType)(mOpenTypeInput.mCFF.mGlobalSubrsPosition -
 												mOpenTypeInput.mCFF.mStringIndexPosition));
 	}

--- a/PDFWriter/CFFEmbeddedFontWriter.h
+++ b/PDFWriter/CFFEmbeddedFontWriter.h
@@ -28,6 +28,7 @@
 #include "CFFPrimitiveWriter.h"
 #include "OutputStringBufferStream.h"
 #include "IOBasicTypes.h"
+#include "InputByteArrayStream.h"
 
 #include <vector>
 #include <string>
@@ -91,6 +92,8 @@ public:
 private:
 	OpenTypeFileInput mOpenTypeInput;
 	InputFile mOpenTypeFile;
+	InputByteArrayStream mMemoryFontStream;
+	IByteReaderWithPosition* mFontStream;
 	CFFPrimitiveWriter mPrimitivesWriter;
 	OutputStringBufferStream mFontFileStream;
 	bool mIsCID;

--- a/PDFWriter/DocumentContext.cpp
+++ b/PDFWriter/DocumentContext.cpp
@@ -1504,6 +1504,11 @@ PDFUsedFont* DocumentContext::GetFontForFile(const std::string& inFontFilePath,l
 	return mUsedFontsRepository.GetFontForFile(inFontFilePath,inFontIndex);
 }
 
+PDFUsedFont* DocumentContext::GetFontForFile(const std::vector<IOBasicTypes::Byte>& inFontBuffer,long inFontIndex)
+{
+	return mUsedFontsRepository.GetFontForFile(inFontBuffer,inFontIndex);
+}
+
 EStatusCode DocumentContext::WriteUsedFontsDefinitions()
 {
 	return mUsedFontsRepository.WriteUsedFontsDefinitions();

--- a/PDFWriter/DocumentContext.h
+++ b/PDFWriter/DocumentContext.h
@@ -298,6 +298,7 @@ namespace PDFHummus
 
 		// Font [Text] (font index is for multi-font files. for single file fonts, pass 0)
 		PDFUsedFont* GetFontForFile(const std::string& inFontFilePath,long inFontIndex);
+		PDFUsedFont* GetFontForFile(const std::vector<IOBasicTypes::Byte>& inFontBuffer,long inFontIndex);
 		// second overload is for type 1, when an additional metrics file is available
 		PDFUsedFont* GetFontForFile(const std::string& inFontFilePath,const std::string& inAdditionalMeticsFilePath,long inFontIndex);
 

--- a/PDFWriter/FreeTypeFaceWrapper.h
+++ b/PDFWriter/FreeTypeFaceWrapper.h
@@ -22,6 +22,7 @@
 
 #include "EFontStretch.h"
 #include "EStatusCode.h"
+#include "IOBasicTypes.h"
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -102,6 +103,11 @@ public:
 
 	const std::string& GetFontFilePath();
     long GetFontIndex();
+
+	// memory streams have read==NULL; file streams always have a read function
+	bool IsMemoryFont() const { return mFace && mFace->stream && mFace->stream->read == NULL; }
+	IOBasicTypes::Byte* GetFontBuffer() const { return (mFace && mFace->stream) ? (IOBasicTypes::Byte*)mFace->stream->base : NULL; }
+	IOBasicTypes::LongFilePositionType GetFontBufferLength() const { return (mFace && mFace->stream) ? (IOBasicTypes::LongFilePositionType)mFace->stream->size : 0; }
 
 
 	// use this method to align measurements from (remember the dreaded point per EM!!!).

--- a/PDFWriter/FreeTypeWrapper.cpp
+++ b/PDFWriter/FreeTypeWrapper.cpp
@@ -23,6 +23,8 @@
 #include "InputFile.h"
 #include "IByteReaderWithPosition.h"
 
+#include <memory.h>
+
 
 using namespace PDFHummus;
 
@@ -48,6 +50,11 @@ FreeTypeWrapper::~FreeTypeWrapper(void)
 		}
 	}
 	mOpenStreams.clear();
+	for(std::map<FT_Face,FT_Byte*>::iterator itMemory = mOpenMemoryFaces.begin(); itMemory != mOpenMemoryFaces.end(); ++itMemory)
+	{
+		delete[] itMemory->second;
+	}
+	mOpenMemoryFaces.clear();
 	if (mFreeType)
 		FT_Done_FreeType(mFreeType);
 
@@ -84,6 +91,38 @@ FT_Face FreeTypeWrapper::NewFace(const std::string& inFilePath,FT_Long inFontInd
 		CloseOpenFaceArgumentsStream(openFaceArguments);
 	else
 		RegisterStreamForFace(face,openFaceArguments.stream);
+	return face;
+}
+FT_Face FreeTypeWrapper::NewFace(const std::vector<IOBasicTypes::Byte>& inFontBuffer,FT_Long inFontIndex)
+{
+	if(inFontBuffer.size() == 0)
+	{
+		TRACE_LOG("FreeTypeWrapper::NewFace, memory font buffer is NULL or empty");
+		return NULL;
+	}
+
+	if(inFontBuffer.size() > (IOBasicTypes::LongBufferSizeType)0x7fffffff)
+	{
+		TRACE_LOG("FreeTypeWrapper::NewFace, memory font buffer is too large for FreeType FT_Long size");
+		return NULL;
+	}
+
+	FT_Byte* internalBuffer = new FT_Byte[inFontBuffer.size()];
+	memcpy(internalBuffer,inFontBuffer.data(),inFontBuffer.size());
+
+	FT_Face face = NULL;
+	FT_Error ftStatus = FT_New_Memory_Face(mFreeType,internalBuffer,(FT_Long)inFontBuffer.size(),inFontIndex,&face);
+	if(ftStatus)
+	{
+		const char* errMsg = FT_Error_String(ftStatus);
+		TRACE_LOG1("FreeTypeWrapper::NewFace, unable to load memory font with index %ld",inFontIndex);
+		TRACE_LOG2("FreeTypeWrapper::NewFace, Free Type Error, Code = %d, Message = %s",ftStatus,errMsg ? errMsg : "");
+		delete[] internalBuffer;
+		return NULL;
+	}
+
+	mOpenMemoryFaces.insert(std::map<FT_Face,FT_Byte*>::value_type(face,internalBuffer));
+
 	return face;
 }
 
@@ -169,6 +208,7 @@ FT_Error FreeTypeWrapper::DoneFace(FT_Face ioFace)
 {
 	FT_Error status = FT_Done_Face(ioFace);
 	CleanStreamsForFace(ioFace);
+	CleanMemoryFace(ioFace);
 	return status;
 }
 
@@ -186,6 +226,15 @@ void FreeTypeWrapper::CleanStreamsForFace(FT_Face inFace)
 	}
 }
 
+void FreeTypeWrapper::CleanMemoryFace(FT_Face inFace)
+{
+	std::map<FT_Face,FT_Byte*>::iterator it = mOpenMemoryFaces.find(inFace);
+	if(it != mOpenMemoryFaces.end())
+	{
+		delete[] it->second;
+		mOpenMemoryFaces.erase(it);
+	}
+}
 
 FT_Library FreeTypeWrapper::operator->()
 {

--- a/PDFWriter/FreeTypeWrapper.h
+++ b/PDFWriter/FreeTypeWrapper.h
@@ -21,8 +21,10 @@
 #pragma once
 
 #include "EStatusCode.h"
+#include "IOBasicTypes.h"
 
 #include <string>
+#include <vector>
 #include <map>
 #include <list>
 
@@ -41,6 +43,7 @@ public:
 	~FreeTypeWrapper(void);
 
 	FT_Face NewFace(const std::string& inFilePath,FT_Long inFontIndex);
+	FT_Face NewFace(const std::vector<IOBasicTypes::Byte>& inFontBuffer,FT_Long inFontIndex);
 	FT_Face NewFace(const std::string& inFilePath,const std::string& inSecondaryFilePath,FT_Long inFontIndex);
 	FT_Error DoneFace(FT_Face ioFace);
 
@@ -51,12 +54,14 @@ private:
 
 	FT_Library mFreeType;
 	FTFaceToFTStreamListMap mOpenStreams;
+	std::map<FT_Face,FT_Byte*> mOpenMemoryFaces;
 
 	FT_Stream CreateFTStreamForPath(const std::string& inFilePath);
 	PDFHummus::EStatusCode FillOpenFaceArgumentsForUTF8String(const std::string& inFilePath, FT_Open_Args& ioArgs);
 	void CloseOpenFaceArgumentsStream(FT_Open_Args& ioArgs);
 	void RegisterStreamForFace(FT_Face inFace,FT_Stream inStream);
 	void CleanStreamsForFace(FT_Face inFace);
+    void CleanMemoryFace(FT_Face inFace);
 
 
 };

--- a/PDFWriter/PDFWriter.cpp
+++ b/PDFWriter/PDFWriter.cpp
@@ -311,6 +311,11 @@ PDFUsedFont* PDFWriter::GetFontForFile(const std::string& inFontFilePath,long in
 	return mDocumentContext.GetFontForFile(inFontFilePath,inFontIndex);
 }
 
+PDFUsedFont* PDFWriter::GetFontForFile(const std::vector<IOBasicTypes::Byte>& inFontBuffer,long inFontIndex)
+{
+	return mDocumentContext.GetFontForFile(inFontBuffer,inFontIndex);
+}
+
 PDFUsedFont* PDFWriter::GetFontForFile(const std::string& inFontFilePath,const std::string& inAdditionalMeticsFilePath,long inFontIndex)
 {
 	return mDocumentContext.GetFontForFile(inFontFilePath,inAdditionalMeticsFilePath,inFontIndex);

--- a/PDFWriter/PDFWriter.h
+++ b/PDFWriter/PDFWriter.h
@@ -36,6 +36,7 @@
 #include "EncryptionOptions.h"
 
 #include <string>
+#include <vector>
 #include <utility>
 
 typedef std::pair<double,double> DoubleAndDoublePair;
@@ -277,6 +278,7 @@ public:
 	// fonts [text], font index is provided for multi-font file packages (such as dfont and ttc), 0 the default is
     // what should be passed for single-font files
 	PDFUsedFont* GetFontForFile(const std::string& inFontFilePath,long inFontIndex = 0);
+	PDFUsedFont* GetFontForFile(const std::vector<IOBasicTypes::Byte>& inFontBuffer,long inFontIndex = 0);
 	// second overload is for type 1, when an additional metrics file is available
 	PDFUsedFont* GetFontForFile(const std::string& inFontFilePath,const std::string& inAdditionalMeticsFilePath,long inFontIndex = 0);
 

--- a/PDFWriter/TrueTypeEmbeddedFontWriter.cpp
+++ b/PDFWriter/TrueTypeEmbeddedFontWriter.cpp
@@ -121,14 +121,23 @@ EStatusCode TrueTypeEmbeddedFontWriter::CreateTrueTypeSubset(	FreeTypeFaceWrappe
 	{
 		UIntVector subsetGlyphIDs = inSubsetGlyphIDs;
 
-		status = mTrueTypeFile.OpenFile(inFontInfo.GetFontFilePath());
-		if(status != PDFHummus::eSuccess)
+		if(inFontInfo.IsMemoryFont())
 		{
-			TRACE_LOG1("TrueTypeEmbeddedFontWriter::CreateTrueTypeSubset, cannot open true type font file at %s",inFontInfo.GetFontFilePath().c_str());
-			break;
+			mMemoryFontStream.Assign(inFontInfo.GetFontBuffer(), inFontInfo.GetFontBufferLength());
+			mFontStream = &mMemoryFontStream;
+		}
+		else
+		{
+			status = mTrueTypeFile.OpenFile(inFontInfo.GetFontFilePath());
+			if(status != PDFHummus::eSuccess)
+			{
+				TRACE_LOG1("TrueTypeEmbeddedFontWriter::CreateTrueTypeSubset, cannot open true type font file at %s",inFontInfo.GetFontFilePath().c_str());
+				break;
+			}
+			mFontStream = mTrueTypeFile.GetInputStream();
 		}
 
-		status = mTrueTypeInput.ReadOpenTypeFile(mTrueTypeFile.GetInputStream(),(unsigned short)inFontInfo.GetFontIndex());
+		status = mTrueTypeInput.ReadOpenTypeFile(mFontStream,(unsigned short)inFontInfo.GetFontIndex());
 		if(status != PDFHummus::eSuccess)
 		{
 			TRACE_LOG("TrueTypeEmbeddedFontWriter::CreateTrueTypeSubset, failed to read true type file");
@@ -415,8 +424,8 @@ EStatusCode TrueTypeEmbeddedFontWriter::WriteHead()
 	startTableOffset = mFontFileStream.GetCurrentPosition();
 
 	// copy and save the current position
-	mTrueTypeFile.GetInputStream()->SetPosition(tableEntry->Offset);
-	streamCopier.CopyToOutputStream(mTrueTypeFile.GetInputStream(),tableEntry->Length);
+	mFontStream->SetPosition(tableEntry->Offset);
+	streamCopier.CopyToOutputStream(mFontStream,tableEntry->Length);
 	mPrimitivesWriter.PadTo4();
 	endOfStream = mFontFileStream.GetCurrentPosition();
 
@@ -487,8 +496,8 @@ EStatusCode TrueTypeEmbeddedFontWriter::WriteHHea()
 	startTableOffset = mFontFileStream.GetCurrentPosition();
 
 	// copy and save the current position
-	mTrueTypeFile.GetInputStream()->SetPosition(tableEntry->Offset);
-	streamCopier.CopyToOutputStream(mTrueTypeFile.GetInputStream(),tableEntry->Length);
+	mFontStream->SetPosition(tableEntry->Offset);
+	streamCopier.CopyToOutputStream(mFontStream,tableEntry->Length);
 	mPrimitivesWriter.PadTo4();
 	endOfStream = mFontFileStream.GetCurrentPosition();
 
@@ -561,8 +570,8 @@ EStatusCode TrueTypeEmbeddedFontWriter::WriteMaxp()
 	startTableOffset = mFontFileStream.GetCurrentPosition();
 
 	// copy and save the current position
-	mTrueTypeFile.GetInputStream()->SetPosition(tableEntry->Offset);
-	streamCopier.CopyToOutputStream(mTrueTypeFile.GetInputStream(),tableEntry->Length);
+	mFontStream->SetPosition(tableEntry->Offset);
+	streamCopier.CopyToOutputStream(mFontStream,tableEntry->Length);
 	mPrimitivesWriter.PadTo4();
 	endOfStream = mFontFileStream.GetCurrentPosition();
 
@@ -624,9 +633,9 @@ EStatusCode TrueTypeEmbeddedFontWriter::WriteGlyf(const UIntVector& inSubsetGlyp
 			inLocaTable[i] = inLocaTable[previousGlyphIndexEnd];
 		if(mTrueTypeInput.mGlyf[glyphIndex] != NULL)
 		{
-			mTrueTypeFile.GetInputStream()->SetPosition(tableEntry->Offset + 
+			mFontStream->SetPosition(tableEntry->Offset + 
 															mTrueTypeInput.mLoca[glyphIndex]);
-			streamCopier.CopyToOutputStream(mTrueTypeFile.GetInputStream(),
+			streamCopier.CopyToOutputStream(mFontStream,
 				mTrueTypeInput.mLoca[(glyphIndex) + 1] - mTrueTypeInput.mLoca[glyphIndex]);
 		}
 		inLocaTable[glyphIndex + 1] = (unsigned long)(mFontFileStream.GetCurrentPosition() - startTableOffset);
@@ -717,8 +726,8 @@ EStatusCode TrueTypeEmbeddedFontWriter::CreateTableCopy(const char* inTableName,
 	startTableOffset = mFontFileStream.GetCurrentPosition();
 
 	// copy and save the current position
-	mTrueTypeFile.GetInputStream()->SetPosition(tableEntry->Offset);
-	streamCopier.CopyToOutputStream(mTrueTypeFile.GetInputStream(),tableEntry->Length);
+	mFontStream->SetPosition(tableEntry->Offset);
+	streamCopier.CopyToOutputStream(mFontStream,tableEntry->Length);
 	mPrimitivesWriter.PadTo4();
 	endOfStream = mFontFileStream.GetCurrentPosition();
 

--- a/PDFWriter/TrueTypeEmbeddedFontWriter.h
+++ b/PDFWriter/TrueTypeEmbeddedFontWriter.h
@@ -29,6 +29,7 @@
 #include "InputStringBufferStream.h"
 #include "OpenTypePrimitiveReader.h"
 #include "MyStringBuf.h"
+#include "InputByteArrayStream.h"
 
 #include <vector>
 #include <set>
@@ -60,6 +61,8 @@ public:
 private:
 	OpenTypeFileInput mTrueTypeInput;
 	InputFile mTrueTypeFile;
+	InputByteArrayStream mMemoryFontStream;
+	IByteReaderWithPosition* mFontStream;
 	OutputStringBufferStream mFontFileStream;
 	TrueTypePrimitiveWriter mPrimitivesWriter;
 	InputStringBufferStream mFontFileReaderStream; // now this might be confusing - i'm using a reader

--- a/PDFWriter/Type1ToCFFEmbeddedFontWriter.cpp
+++ b/PDFWriter/Type1ToCFFEmbeddedFontWriter.cpp
@@ -219,14 +219,24 @@ EStatusCode Type1ToCFFEmbeddedFontWriter::CreateCFFSubset(
 		if(subsetGlyphIDs.front() != 0) // make sure 0 glyph is in
 			subsetGlyphIDs.insert(subsetGlyphIDs.begin(),0);
 
-		status = mType1File.OpenFile(inFontInfo.GetFontFilePath());
-		if(status != PDFHummus::eSuccess)
+		IByteReaderWithPosition* fontStream;
+		if(inFontInfo.IsMemoryFont())
 		{
-			TRACE_LOG1("Type1ToCFFEmbeddedFontWriter::CreateCFFSubset, cannot open Type 1 font file at %s",inFontInfo.GetFontFilePath().c_str());
-			break;
+			mMemoryFontStream.Assign(inFontInfo.GetFontBuffer(), inFontInfo.GetFontBufferLength());
+			fontStream = &mMemoryFontStream;
+		}
+		else
+		{
+			status = mType1File.OpenFile(inFontInfo.GetFontFilePath());
+			if(status != PDFHummus::eSuccess)
+			{
+				TRACE_LOG1("Type1ToCFFEmbeddedFontWriter::CreateCFFSubset, cannot open Type 1 font file at %s",inFontInfo.GetFontFilePath().c_str());
+				break;
+			}
+			fontStream = mType1File.GetInputStream();
 		}
 
-		status = mType1Input.ReadType1File(mType1File.GetInputStream());
+		status = mType1Input.ReadType1File(fontStream);
 		if(status != PDFHummus::eSuccess)
 		{
 			TRACE_LOG("Type1ToCFFEmbeddedFontWriter::CreateCFFSubset, failed to read Type 1 file");

--- a/PDFWriter/Type1ToCFFEmbeddedFontWriter.h
+++ b/PDFWriter/Type1ToCFFEmbeddedFontWriter.h
@@ -26,6 +26,7 @@
 #include "CFFPrimitiveWriter.h"
 #include "OutputStringBufferStream.h"
 #include "MyStringBuf.h"
+#include "InputByteArrayStream.h"
 
 
 #include <vector>
@@ -63,6 +64,7 @@ public:
 private:
 	Type1Input mType1Input;
 	InputFile mType1File;
+	InputByteArrayStream mMemoryFontStream;
 	CFFPrimitiveWriter mPrimitivesWriter;
 	OutputStringBufferStream mFontFileStream;
 	StringVector mStrings;

--- a/PDFWriter/UsedFontsRepository.cpp
+++ b/PDFWriter/UsedFontsRepository.cpp
@@ -98,7 +98,7 @@ PDFUsedFont* UsedFontsRepository::GetFontForFile(const std::string& inFontFilePa
 			PDFUsedFont* usedFont = new PDFUsedFont(face,inFontFilePath,inOptionalMetricsFile,inFontIndex,mObjectsContext,mEmbedFonts);
 			if(!usedFont->IsValid())
 			{
-				TRACE_LOG1("UsedFontsRepository::GetFontForFile, Unreckognized font format for font in %s",inFontFilePath.c_str());
+				TRACE_LOG1("UsedFontsRepository::GetFontForFile, Unrecognized font format for font in %s",inFontFilePath.c_str());
 				delete usedFont;
 				usedFont = NULL;
 			}
@@ -125,6 +125,54 @@ EStatusCode UsedFontsRepository::WriteUsedFontsDefinitions()
 PDFUsedFont* UsedFontsRepository::GetFontForFile(const std::string& inFontFilePath,long inFontIndex)
 {
 	return GetFontForFile(inFontFilePath,"",inFontIndex);
+}
+
+PDFUsedFont* UsedFontsRepository::GetFontForFile(const std::vector<IOBasicTypes::Byte>& inFontBuffer,long inFontIndex)
+{
+	if(!mObjectsContext)
+	{
+		TRACE_LOG("UsedFontsRepository::GetFontForFile, exception, not objects context available");
+		return NULL;
+	}
+
+	if(inFontBuffer.size() == 0)
+	{
+		TRACE_LOG("UsedFontsRepository::GetFontForFile, exception, input memory font buffer is NULL or empty");
+		return NULL;
+	}
+
+	if(!mInputFontsInformation)
+		mInputFontsInformation = new FreeTypeWrapper();
+
+	// load face first to derive a stable cache key from the PostScript name
+	FT_Face face = mInputFontsInformation->NewFace(inFontBuffer,inFontIndex);
+	if(!face)
+	{
+		TRACE_LOG("UsedFontsRepository::GetFontForFile, Failed to load memory font");
+		return NULL;
+	}
+
+	const char* psName = FT_Get_Postscript_Name(face);
+	std::string key = std::string("memory-font-") + (psName ? psName : "unknown") + "-" + std::to_string(inFontBuffer.size());
+
+	StringAndLongToPDFUsedFontMap::iterator it = mUsedFonts.find(StringAndLong(key,inFontIndex));
+	if(it != mUsedFonts.end())
+	{
+		mInputFontsInformation->DoneFace(face);
+		return it->second;
+	}
+
+	PDFUsedFont* usedFont = new PDFUsedFont(face,key,"",inFontIndex,mObjectsContext,mEmbedFonts);
+	if(!usedFont->IsValid())
+	{
+		TRACE_LOG1("UsedFontsRepository::GetFontForFile, Unrecognized memory font format for key %s",key.c_str());
+		delete usedFont;
+		usedFont = NULL;
+	}
+	
+	it = mUsedFonts.insert(StringAndLongToPDFUsedFontMap::value_type(StringAndLong(key,inFontIndex),usedFont)).first;
+
+	return it->second;
 }
 
 typedef std::list<ObjectIDType> ObjectIDTypeList;

--- a/PDFWriter/UsedFontsRepository.h
+++ b/PDFWriter/UsedFontsRepository.h
@@ -22,8 +22,10 @@
 
 #include "EStatusCode.h"
 #include "ObjectsBasicTypes.h"
+#include "IOBasicTypes.h"
 
 #include <string>
+#include <vector>
 #include <map>
 #include <utility>
 
@@ -49,6 +51,7 @@ public:
 
 
 	PDFUsedFont* GetFontForFile(const std::string& inFontFilePath,long inFontIndex);
+	PDFUsedFont* GetFontForFile(const std::vector<IOBasicTypes::Byte>& inFontBuffer,long inFontIndex);
 	// second overload is for type 1, when an additional metrics file is available
 	PDFUsedFont* GetFontForFile(const std::string& inFontFilePath,const std::string& inOptionalMetricsFile,long inFontIndex);
 

--- a/PDFWriterTesting/TextUsageBugs.cpp
+++ b/PDFWriterTesting/TextUsageBugs.cpp
@@ -25,6 +25,8 @@
 #include "PageContentContext.h"
 
 #include <iostream>
+#include <fstream>
+#include <iterator>
 
 #include "testing/TestIO.h"
 
@@ -147,6 +149,90 @@ static EStatusCode RunCNRSTest(char* argv[])
 		for (int i = 2900; i < 2950; i++)
 			glyphs4.push_back(GlyphUnicodeMapping(i, i));
 		contentContext->Tj(glyphs4);
+
+		contentContext->ET();
+
+		status = pdfWriter.EndPageContentContext(contentContext);
+		if (status != PDFHummus::eSuccess) {
+			cout << "failed to end page content context\n";
+			break;
+		}
+
+		status = pdfWriter.WritePageAndRelease(page);
+		if (status != PDFHummus::eSuccess) {
+			cout << "failed to write page\n";
+			break;
+		}
+
+		status = pdfWriter.EndPDF();
+		if (status != PDFHummus::eSuccess) {
+			cout << "failed in end PDF\n";
+			break;
+		}
+	} while (false);
+	return status;
+}
+
+static EStatusCode RunCNRSMemoryFontTest(char* argv[])
+{
+	PDFWriter pdfWriter;
+	EStatusCode status;
+
+	do {
+		std::string fontPath = BuildRelativeInputPath(argv, "fonts/texgyrepagella-math.otf");
+		std::ifstream fontFile(fontPath, std::ios::binary);
+		if (!fontFile) {
+			status = PDFHummus::eFailure;
+			cout << "failed to open font file for memory test\n";
+			break;
+		}
+		std::vector<IOBasicTypes::Byte> fontBuffer(
+			(std::istreambuf_iterator<char>(fontFile)),
+			std::istreambuf_iterator<char>());
+
+		status = pdfWriter.StartPDF(BuildRelativeOutputPath(argv, "TextUsageBugsCNRSMemoryFont.pdf"), ePDFVersion14, LogConfiguration::DefaultLogConfiguration(), PDFCreationSettings(true, true));
+		if (status != PDFHummus::eSuccess) {
+			cout << "failed to start PDF\n";
+			break;
+		}
+		PDFPage* page = new PDFPage();
+		page->SetMediaBox(PDFRectangle(0, 0, 595, 842));
+
+		PageContentContext* contentContext = pdfWriter.StartPageContentContext(page);
+		if (NULL == contentContext) {
+			status = PDFHummus::eFailure;
+			cout << "failed to create content context for page\n";
+			break;
+		}
+
+		PDFUsedFont* font = pdfWriter.GetFontForFile(fontBuffer);
+		if (!font) {
+			status = PDFHummus::eFailure;
+			cout << "failed to create font object from memory buffer\n";
+			break;
+		}
+
+		contentContext->BT();
+		contentContext->k(0, 0, 0, 1);
+		contentContext->Tf(font, 10);
+
+		contentContext->Tm(1, 0, 0, 1, 78, 660);
+		GlyphUnicodeMappingList glyphs1;
+		for (int i = 65; i < 150; i++)
+			glyphs1.push_back(GlyphUnicodeMapping(i, i));
+		contentContext->Tj(glyphs1);
+
+		contentContext->Tm(1, 0, 0, 1, 78, 640);
+		GlyphUnicodeMappingList glyphs2;
+		for (int i = 150; i < 210; i++)
+			glyphs2.push_back(GlyphUnicodeMapping(i, i));
+		contentContext->Tj(glyphs2);
+
+		contentContext->Tm(1, 0, 0, 1, 78, 620);
+		GlyphUnicodeMappingList glyphs3;
+		for (int i = 2900; i < 2950; i++)
+			glyphs3.push_back(GlyphUnicodeMapping(i, i));
+		contentContext->Tj(glyphs3);
 
 		contentContext->ET();
 


### PR DESCRIPTION
Here is an implementation of a new PDFWriter::GetFontForFile overload which takes a font buffer instead of a filepath